### PR TITLE
fix: surface calibrated decisions in dashboard audit log

### DIFF
--- a/crates/permit0-cli/src/cmd/serve.rs
+++ b/crates/permit0-cli/src/cmd/serve.rs
@@ -127,10 +127,13 @@ async fn check_handler(
         .chars()
         .take(200)
         .collect();
+    let surface_tool = tool_call.tool_name.clone();
     record_and_respond(
         &state,
         &result,
-        tool_call.tool_name.clone(),
+        &tool_call,
+        &ctx,
+        surface_tool,
         surface_command,
         meta,
     )
@@ -329,7 +332,7 @@ async fn check_action_handler(
     let norm = NormAction {
         action_type,
         channel: req.channel,
-        entities: req.entities,
+        entities: req.entities.clone(),
         execution: ExecutionMeta {
             surface_tool: surface_tool.clone(),
             surface_command: String::new(),
@@ -338,6 +341,14 @@ async fn check_action_handler(
 
     let ctx = PermissionCtx::new(NormalizeCtx::new().with_org_domain(&state.org_domain))
         .with_skip_audit(state.calibrate);
+
+    // Synthesize a raw tool call mirroring what `check_norm_action` does
+    // internally, so the audit chain has something to record on calibration.
+    let synthetic_tool_call = RawToolCall {
+        tool_name: surface_tool.clone(),
+        parameters: serde_json::Value::Object(req.entities),
+        metadata: Default::default(),
+    };
 
     let result = state.engine.check_norm_action(norm, &ctx).map_err(|e| {
         (
@@ -348,7 +359,15 @@ async fn check_action_handler(
 
     let (result, meta) = apply_calibration(&state, result).await?;
 
-    record_and_respond(&state, &result, surface_tool, String::new(), meta)
+    record_and_respond(
+        &state,
+        &result,
+        &synthetic_tool_call,
+        &ctx,
+        surface_tool,
+        String::new(),
+        meta,
+    )
 }
 
 /// In calibration mode, escalate every fresh decision (engine-produced —
@@ -466,6 +485,8 @@ struct CalibrationMeta {
 fn record_and_respond(
     state: &ServerState,
     result: &permit0_engine::PermissionResult,
+    tool_call: &RawToolCall,
+    ctx: &PermissionCtx,
     surface_tool: String,
     surface_command: String,
     calibration: CalibrationMeta,
@@ -489,10 +510,33 @@ fn record_and_respond(
             surface_tool,
             surface_command,
             engine_permission: calibration.engine_permission,
-            reviewer: calibration.reviewer,
-            reason: calibration.reason,
+            reviewer: calibration.reviewer.clone(),
+            reason: calibration.reason.clone(),
         };
         let _ = store.save_decision(record);
+    }
+
+    // When a human calibrated this decision, the engine's normal audit
+    // write was suppressed via `ctx.skip_audit`. Append the composite
+    // entry now so the dashboard's audit log and recent-decisions list
+    // see it. `engine_permission` is the pre-calibration verdict — the
+    // chain stores it in `engine_decision` so the dashboard can show
+    // override information ("permit0 said vs human said vs match?").
+    if let (Some(engine_permission), Some(reviewer), Some(reason)) = (
+        calibration.engine_permission,
+        calibration.reviewer,
+        calibration.reason,
+    ) {
+        if let Err(e) = state.engine.log_calibrated_audit(
+            result,
+            tool_call,
+            ctx,
+            engine_permission,
+            reviewer,
+            reason,
+        ) {
+            tracing::warn!("failed to append calibrated audit entry: {e}");
+        }
     }
 
     Ok(Json(CheckResponse {

--- a/crates/permit0-engine/src/engine.rs
+++ b/crates/permit0-engine/src/engine.rs
@@ -12,7 +12,7 @@ use permit0_normalize::{Normalizer, NormalizerRegistry};
 use permit0_scoring::{ScoringConfig, compute_hybrid};
 use permit0_session::{SessionContext, evaluate_session_block_rules, session_amplifier_score};
 use permit0_store::audit::{
-    AuditEntry, AuditPolicy, AuditSigner, AuditSink, FailedOpenContext, Redactor,
+    AuditEntry, AuditPolicy, AuditSigner, AuditSink, FailedOpenContext, HumanReview, Redactor,
     chain::{GENESIS_HASH, compute_entry_hash},
 };
 use permit0_store::{InMemoryStore, Store};
@@ -383,6 +383,7 @@ impl Engine {
                 pack_version: String::new(),
                 dsl_version: "1.0".into(),
                 human_review: None,
+                engine_decision: None,
                 token_id: None,
                 prev_hash,
                 entry_hash: String::new(),
@@ -417,6 +418,108 @@ impl Engine {
         }
 
         Ok(())
+    }
+
+    /// Append a calibrated audit entry to the audit chain.
+    ///
+    /// Used by the calibration daemon after a human submits a decision via
+    /// the dashboard. The normal `log_decision` path is suppressed during
+    /// calibration via `ctx.skip_audit` (so the chain never sees the
+    /// engine's pre-calibration recommendation); this writes the composite
+    /// record with the human's verdict in `human_review`, `decision` set
+    /// to the post-calibration permission, and `engine_decision` set to
+    /// what the engine would have decided (for override visibility in the
+    /// dashboard).
+    ///
+    /// No-op if no audit sink is configured.
+    pub fn log_calibrated_audit(
+        &self,
+        result: &PermissionResult,
+        tool_call: &RawToolCall,
+        ctx: &PermissionCtx,
+        engine_permission: Permission,
+        reviewer: String,
+        reason: String,
+    ) -> Result<(), EngineError> {
+        let (sink, signer) = match (&self.audit_sink, &self.audit_signer) {
+            (Some(sink), Some(signer)) => (sink, signer),
+            _ => return Ok(()),
+        };
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let entry_id = ulid::Ulid::new().to_string();
+
+        let raw_tool_call = if let Some(ref redactor) = self.audit_redactor {
+            redactor.redact(&serde_json::to_value(tool_call).unwrap_or_default())
+        } else {
+            serde_json::to_value(tool_call).unwrap_or_default()
+        };
+
+        let sequence = self
+            .audit_sequence
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            + 1;
+        let prev_hash = {
+            let guard = self.audit_prev_hash.lock().unwrap();
+            guard.clone()
+        };
+
+        let mut entry = AuditEntry {
+            entry_id,
+            timestamp: now.clone(),
+            sequence,
+            decision: result.permission,
+            decision_source: result.source.as_str().into(),
+            norm_action: result.norm_action.clone(),
+            norm_hash: result.norm_action.norm_hash(),
+            raw_tool_call,
+            risk_score: result.risk_score.clone(),
+            scoring_detail: None,
+            agent_id: String::new(),
+            session_id: ctx.session.as_ref().map(|s| s.session_id.clone()),
+            task_goal: ctx.task_goal.clone(),
+            org_id: ctx.normalize_ctx.org_domain.clone().unwrap_or_default(),
+            environment: String::new(),
+            engine_version: env!("CARGO_PKG_VERSION").into(),
+            pack_id: String::new(),
+            pack_version: String::new(),
+            dsl_version: "1.0".into(),
+            human_review: Some(HumanReview {
+                reviewer,
+                decision: result.permission,
+                reason,
+                reviewed_at: now,
+            }),
+            engine_decision: Some(engine_permission),
+            token_id: None,
+            prev_hash,
+            entry_hash: String::new(),
+            signature: String::new(),
+            correction_of: None,
+            failed_open_context: None,
+            retroactive_decision: None,
+        };
+
+        entry.entry_hash = compute_entry_hash(&entry);
+        entry.signature = signer.sign(&entry.entry_hash);
+
+        {
+            let mut guard = self.audit_prev_hash.lock().unwrap();
+            *guard = entry.entry_hash.clone();
+        }
+
+        match sink.append(&entry) {
+            Ok(()) => Ok(()),
+            Err(e) => match self.audit_policy {
+                AuditPolicy::Strict => Err(EngineError::AuditFailure(format!(
+                    "audit sink failed (strict policy): {e}"
+                ))),
+                AuditPolicy::BestEffort => {
+                    tracing::warn!("audit sink failed (best_effort): {e}");
+                    Ok(())
+                }
+            },
+        }
     }
 
     /// Reconstruct an audit entry from a client-side `FailOpenBuffer` event.
@@ -485,6 +588,7 @@ impl Engine {
                 pack_version: String::new(),
                 dsl_version: "1.0".into(),
                 human_review: None,
+                engine_decision: None,
                 token_id: None,
                 prev_hash,
                 entry_hash: String::new(),
@@ -1130,5 +1234,114 @@ mod tests {
             .log_failed_open_replay(&tool_call, &ctx, &retro, sample_failed_open_context())
             .unwrap();
         assert!(!entry_id.is_empty()); // ULID returned even without sink
+    }
+
+    // ── Calibration audit path ────────────────────────────────────────
+
+    #[test]
+    fn calibrated_audit_writes_entry_with_human_review() {
+        // Mirrors the daemon's calibration flow: get_permission with
+        // skip_audit=true (suppressed engine write) → human approves →
+        // log_calibrated_audit(...) appends the composite entry. The
+        // dashboard's audit log reads from this sink, so without the
+        // composite write nothing surfaces.
+        let (engine, sink) = build_test_engine_with_audit();
+        let ctx = default_ctx().with_skip_audit(true);
+        let tool_call = gmail_send("Hello", "body");
+
+        // Engine pass — its own log_decision early-returns due to
+        // skip_audit, so the sink stays empty here.
+        let result = engine.get_permission(&tool_call, &ctx).unwrap();
+        assert!(sink.all_entries().is_empty());
+
+        // Now the human's verdict comes back; record it. Pretend the
+        // engine had said HumanInTheLoop and the human overrode to Allow
+        // (the actual `result.permission` is what the engine returned,
+        // since calibration daemon would mutate it post-hoc — for this
+        // test we just thread distinct values through).
+        engine
+            .log_calibrated_audit(
+                &result,
+                &tool_call,
+                &ctx,
+                Permission::HumanInTheLoop,
+                "su@example.com".into(),
+                "looks fine".into(),
+            )
+            .unwrap();
+
+        let entries = sink.all_entries();
+        assert_eq!(entries.len(), 1);
+        let e = &entries[0];
+        assert_eq!(e.decision, result.permission);
+        let hr = e.human_review.as_ref().expect("human_review populated");
+        assert_eq!(hr.reviewer, "su@example.com");
+        assert_eq!(hr.reason, "looks fine");
+        assert_eq!(hr.decision, result.permission);
+        assert!(!hr.reviewed_at.is_empty());
+        assert_eq!(e.engine_decision, Some(Permission::HumanInTheLoop));
+    }
+
+    #[test]
+    fn calibrated_audit_chain_links_with_normal_entries() {
+        // A calibrated entry must thread through the chain like any other —
+        // sequence monotonic, prev_hash linking back to the previous entry.
+        let (engine, sink) = build_test_engine_with_audit();
+
+        // One normal entry first.
+        let tc1 = gmail_send("first", "body");
+        engine.get_permission(&tc1, &default_ctx()).unwrap();
+
+        // Then a calibrated one.
+        let tc2 = gmail_send("second", "body");
+        let cal_ctx = default_ctx().with_skip_audit(true);
+        let result2 = engine.get_permission(&tc2, &cal_ctx).unwrap();
+        engine
+            .log_calibrated_audit(
+                &result2,
+                &tc2,
+                &cal_ctx,
+                Permission::HumanInTheLoop,
+                "su".into(),
+                "approve".into(),
+            )
+            .unwrap();
+
+        // Then another normal one.
+        let tc3 = gmail_send("third", "body");
+        engine.get_permission(&tc3, &default_ctx()).unwrap();
+
+        let entries = sink.all_entries();
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].sequence, 1);
+        assert_eq!(entries[1].sequence, 2);
+        assert_eq!(entries[2].sequence, 3);
+        assert_eq!(entries[1].prev_hash, entries[0].entry_hash);
+        assert_eq!(entries[2].prev_hash, entries[1].entry_hash);
+
+        assert!(entries[0].human_review.is_none());
+        assert!(entries[1].human_review.is_some());
+        assert!(entries[2].human_review.is_none());
+    }
+
+    #[test]
+    fn calibrated_audit_no_op_without_sink() {
+        // If audit isn't wired up, the call is a no-op and returns Ok —
+        // callers don't have to branch on sink presence.
+        let engine = build_test_engine();
+        let ctx = default_ctx().with_skip_audit(true);
+        let tool_call = gmail_send("Hello", "body");
+        let result = engine.get_permission(&tool_call, &ctx).unwrap();
+
+        engine
+            .log_calibrated_audit(
+                &result,
+                &tool_call,
+                &ctx,
+                Permission::HumanInTheLoop,
+                "su".into(),
+                "ok".into(),
+            )
+            .unwrap();
     }
 }

--- a/crates/permit0-store/src/audit/chain.rs
+++ b/crates/permit0-store/src/audit/chain.rs
@@ -60,6 +60,9 @@ pub fn compute_entry_hash(entry: &AuditEntry) -> String {
         let hr_json = serde_json::to_string(hr).unwrap_or_default();
         hasher.update(hr_json.as_bytes());
     }
+    if let Some(ref ed) = entry.engine_decision {
+        hasher.update(format!("{ed:?}").as_bytes());
+    }
 
     // Token
     if let Some(ref tid) = entry.token_id {
@@ -137,6 +140,7 @@ mod tests {
             pack_version: "1.0".into(),
             dsl_version: "1.0".into(),
             human_review: None,
+            engine_decision: None,
             token_id: None,
             prev_hash: prev_hash.into(),
             entry_hash: String::new(),

--- a/crates/permit0-store/src/audit/export.rs
+++ b/crates/permit0-store/src/audit/export.rs
@@ -105,6 +105,7 @@ mod tests {
             pack_version: "1.0".into(),
             dsl_version: "1.0".into(),
             human_review: None,
+            engine_decision: None,
             token_id: None,
             prev_hash: GENESIS_HASH.into(),
             entry_hash: String::new(),

--- a/crates/permit0-store/src/audit/memory_sink.rs
+++ b/crates/permit0-store/src/audit/memory_sink.rs
@@ -188,6 +188,7 @@ mod tests {
             pack_version: "1.0".into(),
             dsl_version: "1.0".into(),
             human_review: None,
+            engine_decision: None,
             token_id: None,
             prev_hash: prev_hash.into(),
             entry_hash: String::new(),

--- a/crates/permit0-store/src/audit/types.rs
+++ b/crates/permit0-store/src/audit/types.rs
@@ -62,6 +62,13 @@ pub struct AuditEntry {
     // ── Human review chain ───────────────────────────────
     /// Human review data, if applicable.
     pub human_review: Option<HumanReview>,
+    /// What the engine would have decided before any human review,
+    /// captured at decision time. `Some` only on calibrated entries
+    /// where the human's verdict may differ from the engine's; `None`
+    /// for ordinary entries (engine's verdict equals `decision`) and
+    /// for failed-open replays.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine_decision: Option<Permission>,
 
     // ── Token ────────────────────────────────────────────
     /// Token ID if a scoped token was issued.

--- a/crates/permit0-ui/src/dashboard_routes.rs
+++ b/crates/permit0-ui/src/dashboard_routes.rs
@@ -780,6 +780,7 @@ mod tests {
             pack_version: String::new(),
             dsl_version: "1.0".into(),
             human_review: None,
+            engine_decision: None,
             token_id: None,
             prev_hash: String::new(),
             entry_hash: String::new(),

--- a/crates/permit0-ui/src/routes.rs
+++ b/crates/permit0-ui/src/routes.rs
@@ -76,10 +76,8 @@ pub async fn list_audit(
                 // nested shape (norm_action.action_type, decision,
                 // risk_score.tier). Project to the flat shape so both views
                 // render correctly without reaching into nested objects.
-                let json_entries: Vec<serde_json::Value> = entries
-                    .iter()
-                    .map(flatten_audit_entry)
-                    .collect();
+                let json_entries: Vec<serde_json::Value> =
+                    entries.iter().map(flatten_audit_entry).collect();
                 Ok(ok_response(json_entries))
             }
             Err(e) => Err(err_response(

--- a/crates/permit0-ui/src/routes.rs
+++ b/crates/permit0-ui/src/routes.rs
@@ -6,6 +6,7 @@ use axum::response::Json;
 use serde::{Deserialize, Serialize};
 
 use permit0_store::AuditFilter;
+use permit0_store::audit::AuditEntry;
 use permit0_types::{DecisionFilter, Permission};
 
 use crate::approval::HumanDecision;
@@ -69,9 +70,15 @@ pub async fn list_audit(
         };
         match sink.query(&filter) {
             Ok(entries) => {
+                // The frontend's audit table and dashboard "Recent Decisions"
+                // both read flat fields (action_type, permission, tier,
+                // risk_raw, ...) shaped like DecisionRecord. AuditEntry has a
+                // nested shape (norm_action.action_type, decision,
+                // risk_score.tier). Project to the flat shape so both views
+                // render correctly without reaching into nested objects.
                 let json_entries: Vec<serde_json::Value> = entries
                     .iter()
-                    .filter_map(|e| serde_json::to_value(e).ok())
+                    .map(flatten_audit_entry)
                     .collect();
                 Ok(ok_response(json_entries))
             }
@@ -227,6 +234,55 @@ fn parse_permission(s: &str) -> Option<Permission> {
         "human" | "humanintheloop" => Some(Permission::HumanInTheLoop),
         _ => None,
     }
+}
+
+/// Project an `AuditEntry` to the flat JSON shape the frontend reads.
+///
+/// Mirrors `DecisionRecord` field names so the audit-log table and
+/// dashboard "Recent Decisions" can render without nested-field
+/// destructuring. Audit-only fields (entry_id, sequence, prev_hash,
+/// human_review, failed_open_context) are preserved alongside, so detail
+/// expansion still has the chain metadata to show.
+fn flatten_audit_entry(e: &AuditEntry) -> serde_json::Value {
+    let risk_raw = e.risk_score.as_ref().map(|s| s.raw);
+    let risk_score = e.risk_score.as_ref().map(|s| s.score);
+    let tier = e.risk_score.as_ref().map(|s| s.tier.to_string());
+    let blocked = e.risk_score.as_ref().map(|s| s.blocked);
+    let flags: Vec<String> = e
+        .risk_score
+        .as_ref()
+        .map(|s| s.flags.clone())
+        .unwrap_or_default();
+    let reviewer = e.human_review.as_ref().map(|hr| hr.reviewer.clone());
+    let reason = e.human_review.as_ref().map(|hr| hr.reason.clone());
+
+    serde_json::json!({
+        "id": e.entry_id,
+        "timestamp": e.timestamp,
+        "action_type": e.norm_action.action_type.as_action_str(),
+        "channel": e.norm_action.channel,
+        "permission": e.decision,
+        "source": e.decision_source,
+        "tier": tier,
+        "risk_raw": risk_raw,
+        "score": risk_score,
+        "blocked": blocked,
+        "flags": flags,
+        "surface_tool": e.norm_action.execution.surface_tool,
+        "surface_command": e.norm_action.execution.surface_command,
+        "reviewer": reviewer,
+        "reason": reason,
+        "engine_permission": e.engine_decision,
+        "norm_hash": hex::encode(e.norm_hash),
+        "session_id": e.session_id,
+        "task_goal": e.task_goal,
+        "sequence": e.sequence,
+        "entry_id": e.entry_id,
+        "prev_hash": e.prev_hash,
+        "human_review": e.human_review,
+        "failed_open_context": e.failed_open_context,
+        "retroactive_decision": e.retroactive_decision,
+    })
 }
 
 fn hex_to_norm_hash(hex_str: &str) -> Option<permit0_types::NormHash> {


### PR DESCRIPTION
## Summary

In \`--calibrate\` mode, human approvals were visible in the **Calibration** tab but missing from the **Audit Log** and Dashboard "Recent Decisions". Total Decisions counter showed activity, but the lists were empty.

**Root cause**: The engine's normal \`log_decision\` is suppressed via \`ctx.skip_audit\` during calibration so the chain doesn't record the pre-calibration verdict. But the deferred post-calibration write was never wired up — only the SQLite \`DecisionRecord\` was written, leaving the audit sink empty. A second issue: the audit endpoint serialized \`AuditEntry\` directly (nested shape) while the frontend reads flat \`DecisionRecord\`-shaped fields.

## Type

- [x] Bug fix
- [x] Core feature (new \`engine_decision\` audit field)

## What changed

- **\`Engine::log_calibrated_audit()\`** — new method appending a chained \`AuditEntry\` with \`human_review\` populated and \`engine_decision\` carrying the pre-calibration verdict. Mirrors the failed-open-replay shape; respects audit policy (Strict/BestEffort); no-op when no sink is configured.
- **\`record_and_respond\`** in \`serve.rs\` now threads \`&RawToolCall\` and \`&PermissionCtx\` through both \`check_handler\` and \`check_action_handler\`, calling the new engine method after writing the SQLite record. \`check_action_handler\` synthesizes a tool call to mirror the engine's internal pattern in \`check_norm_action\`.
- **\`engine_decision: Option<Permission>\`** added to \`AuditEntry\` and included in \`compute_entry_hash\` so the dashboard can render "permit0 said vs human said vs match?" columns for calibrated rows. Field is \`#[serde(skip_serializing_if = "Option::is_none")]\` so existing entries aren't affected.
- **\`flatten_audit_entry\`** in \`routes.rs\` projects \`AuditEntry\` to the flat JSON shape the frontend reads (audit-log table and Recent Decisions both use \`DecisionRecord\` field names).

## Reviewer notes

- Existing entries written before this change won't have \`engine_decision\` set — they'll show "—" for the override columns. New approvals fill in correctly.
- The audit chain hash now includes \`engine_decision\` (when \`Some\`), following the same opt-in pattern used for \`token_id\`, \`correction_of\`, etc. Existing entries with \`None\` skip it, preserving prior hashes.
- This does not introduce a new failure mode in non-calibrate mode — \`log_calibrated_audit\` is only called when \`reviewer\`/\`reason\`/\`engine_permission\` are all set, which only happens via the calibration path.

## Test Plan

- [x] \`cargo test --workspace\` — all passing (3 new engine tests + 77 store/ui tests touched)
- [x] Manual: \`./target/release/permit0 serve --ui --calibrate --port 9090\`, approve actions via dashboard, verify they appear in Audit Log and Recent Decisions with full fields
- [x] New unit tests:
  - \`calibrated_audit_writes_entry_with_human_review\` — composite write
  - \`calibrated_audit_chain_links_with_normal_entries\` — chain continuity across mixed normal+calibrated entries
  - \`calibrated_audit_no_op_without_sink\` — no-op when audit not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)