### PR TITLE
feat(email): alias resolver + OpenClaw client + email.list_drafts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,6 +1265,7 @@ dependencies = [
  "permit0-types",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror 2.0.18",
 ]
 

--- a/crates/permit0-cli/src/cmd/hook.rs
+++ b/crates/permit0-cli/src/cmd/hook.rs
@@ -56,6 +56,11 @@ pub enum ClientKind {
     /// Claude Desktop (macOS/Windows GUI app). Passes MCP tool names
     /// as-is, no prefix.
     ClaudeDesktop,
+    /// OpenClaw. MCP tools resolved by `mcporter` arrive as
+    /// `<server>.<tool>` (single dot separator) at the gateway dispatch
+    /// boundary. Strip the leading `<server>.` so normalizers can match
+    /// the bare tool name.
+    OpenClaw,
     /// No prefix stripping at all. Use this when you're calling the hook
     /// directly (e.g. from tests or a custom integration that already
     /// hands you the bare tool name).
@@ -73,6 +78,14 @@ impl ClientKind {
                 .strip_prefix("mcp__")
                 .and_then(|rest| rest.split_once("__").map(|(_, tool)| tool))
                 .unwrap_or(tool_name),
+            // OpenClaw via mcporter: "<server>.<tool>". Strip everything
+            // up to and including the first dot. Names without a dot pass
+            // through (built-in tools like "exec" or plugin tools that
+            // register bare names).
+            Self::OpenClaw => tool_name
+                .split_once('.')
+                .map(|(_, tool)| tool)
+                .unwrap_or(tool_name),
             // Claude Desktop and Raw: passthrough.
             Self::ClaudeDesktop | Self::Raw => tool_name,
         }
@@ -85,9 +98,10 @@ impl FromStr for ClientKind {
         match s {
             "claude-code" | "claude_code" => Ok(Self::ClaudeCode),
             "claude-desktop" | "claude_desktop" => Ok(Self::ClaudeDesktop),
+            "openclaw" | "open-claw" | "open_claw" => Ok(Self::OpenClaw),
             "raw" | "none" => Ok(Self::Raw),
             other => Err(format!(
-                "unknown client '{other}' (supported: claude-code, claude-desktop, raw)"
+                "unknown client '{other}' (supported: claude-code, claude-desktop, openclaw, raw)"
             )),
         }
     }
@@ -465,6 +479,23 @@ mod tests {
     }
 
     #[test]
+    fn openclaw_strips_dot_prefix() {
+        let c = ClientKind::OpenClaw;
+        // mcporter shape: "<server>.<tool>"
+        assert_eq!(c.strip_prefix("gmail.create_label"), "create_label");
+        assert_eq!(c.strip_prefix("gmail.search_threads"), "search_threads");
+        assert_eq!(c.strip_prefix("linear.list_issues"), "list_issues");
+        // Bare names (built-in tools, plugin tools) pass through.
+        assert_eq!(c.strip_prefix("exec"), "exec");
+        assert_eq!(c.strip_prefix("Bash"), "Bash");
+        // Only the FIRST dot is consumed. Tool names containing dots
+        // after the server segment survive.
+        assert_eq!(c.strip_prefix("server.tool.with.dots"), "tool.with.dots");
+        // Edge: starts with "." → empty server, tool is the rest.
+        assert_eq!(c.strip_prefix(".tool"), "tool");
+    }
+
+    #[test]
     fn client_kind_parses_from_string() {
         assert_eq!(
             "claude-code".parse::<ClientKind>().unwrap(),
@@ -477,6 +508,18 @@ mod tests {
         assert_eq!(
             "claude-desktop".parse::<ClientKind>().unwrap(),
             ClientKind::ClaudeDesktop
+        );
+        assert_eq!(
+            "openclaw".parse::<ClientKind>().unwrap(),
+            ClientKind::OpenClaw
+        );
+        assert_eq!(
+            "open-claw".parse::<ClientKind>().unwrap(),
+            ClientKind::OpenClaw
+        );
+        assert_eq!(
+            "open_claw".parse::<ClientKind>().unwrap(),
+            ClientKind::OpenClaw
         );
         assert_eq!("raw".parse::<ClientKind>().unwrap(), ClientKind::Raw);
         assert_eq!("none".parse::<ClientKind>().unwrap(), ClientKind::Raw);

--- a/crates/permit0-cli/src/cmd/serve.rs
+++ b/crates/permit0-cli/src/cmd/serve.rs
@@ -32,7 +32,9 @@ use permit0_types::{
 use permit0_ui::{AppState, ApprovalManager, TokenStore};
 use tower_http::services::ServeDir;
 
+use crate::cmd::hook::ClientKind;
 use crate::engine_factory;
+use std::str::FromStr;
 
 /// Shared state for the server.
 #[derive(Clone)]
@@ -56,6 +58,13 @@ struct ServerState {
 /// `AuditEntry.task_goal`. Unknown keys round-trip into the engine as
 /// part of `RawToolCall.metadata` and are available to normalizers/risk
 /// rules that opt in to consuming them.
+///
+/// `client_kind` selects host-specific tool-name prefix stripping. See
+/// [`ClientKind`] for the supported values. When omitted (or invalid),
+/// the handler falls back to no stripping (`Raw`) — clients that already
+/// pass bare tool names work without setting it. As a backwards-compat
+/// fallback, the handler also reads `metadata.client_kind` (where older
+/// clients stamped it) before defaulting to `Raw`.
 #[derive(Debug, Deserialize, Default)]
 struct CheckRequest {
     #[serde(alias = "tool")]
@@ -64,6 +73,8 @@ struct CheckRequest {
     parameters: serde_json::Value,
     #[serde(default)]
     metadata: serde_json::Map<String, serde_json::Value>,
+    #[serde(default)]
+    client_kind: Option<String>,
 }
 
 /// Response for POST /api/v1/check.
@@ -95,8 +106,23 @@ async fn check_handler(
     let session_id = extract_string_field(&req.metadata, "session_id");
     let task_goal = extract_string_field(&req.metadata, "task_goal");
 
+    // Resolve client_kind. Default is Raw (passthrough) — clients that
+    // already pass bare tool names work without sending the field.
+    // Unknown values silently fall back to Raw rather than 400-ing, since
+    // a strict deserializer on a host hint creates a deployment coupling
+    // we'd rather not enforce at the wire boundary.
+    let client_kind = req
+        .client_kind
+        .as_deref()
+        .and_then(|s| ClientKind::from_str(s).ok())
+        .unwrap_or(ClientKind::Raw);
+
+    // Strip host-specific tool-name prefix so YAML normalizers can match
+    // the bare name. Mirrors the stdin-hook adapter (see hook.rs).
+    let stripped_tool_name = client_kind.strip_prefix(&req.tool_name).to_string();
+
     let tool_call = RawToolCall {
-        tool_name: req.tool_name,
+        tool_name: stripped_tool_name,
         parameters: req.parameters,
         metadata: req.metadata,
     };
@@ -682,6 +708,24 @@ mod tests {
         assert_eq!(req.metadata.get("session_id").unwrap(), "conv-42");
         assert_eq!(req.metadata.get("task_goal").unwrap(), "list files");
         assert_eq!(req.metadata.get("trace_id").unwrap(), "abc-123");
+    }
+
+    #[test]
+    fn check_request_accepts_client_kind() {
+        let json = r#"{
+            "tool_name": "gmail.create_label",
+            "parameters": {},
+            "client_kind": "openclaw"
+        }"#;
+        let req: CheckRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.client_kind.as_deref(), Some("openclaw"));
+    }
+
+    #[test]
+    fn check_request_client_kind_defaults_to_none() {
+        let json = r#"{"tool_name": "Bash", "parameters": {}}"#;
+        let req: CheckRequest = serde_json::from_str(json).unwrap();
+        assert!(req.client_kind.is_none());
     }
 
     #[test]

--- a/crates/permit0-cli/src/engine_factory.rs
+++ b/crates/permit0-cli/src/engine_factory.rs
@@ -124,6 +124,19 @@ fn install_pack(mut builder: EngineBuilder, pack_dir: &Path) -> Result<EngineBui
         }
     }
 
+    // Optional aliases file at the pack root. Lets foreign tool names
+    // (e.g. Google's official Gmail MCP) be rewritten to the canonical
+    // names the pack's normalizers match. Single file rather than a
+    // directory because aliases naturally form one table per pack.
+    let aliases_path = pack_dir.join("aliases.yaml");
+    if aliases_path.exists() {
+        let yaml = std::fs::read_to_string(&aliases_path)
+            .with_context(|| format!("reading {}", aliases_path.display()))?;
+        builder = builder
+            .install_aliases_yaml(&yaml)
+            .with_context(|| format!("installing aliases {}", aliases_path.display()))?;
+    }
+
     Ok(builder)
 }
 

--- a/crates/permit0-engine/src/engine.rs
+++ b/crates/permit0-engine/src/engine.rs
@@ -736,6 +736,18 @@ impl EngineBuilder {
         self.install_risk_rule(rule_def)
     }
 
+    /// Install a tool-name alias YAML document. Aliases let foreign tool
+    /// names (e.g. Google's official Gmail MCP `create_label`) be
+    /// rewritten to the canonical names normalizers match
+    /// (`gmail_create_mailbox`). See [`permit0_normalize::AliasResolver`]
+    /// for the YAML schema.
+    pub fn install_aliases_yaml(mut self, yaml: &str) -> Result<Self, EngineError> {
+        self.registry
+            .install_aliases_yaml(yaml)
+            .map_err(|e| EngineError::Build(e.to_string()))?;
+        Ok(self)
+    }
+
     /// Build the engine. Uses `InMemoryStore` if no store was provided.
     pub fn build(self) -> Result<Engine, EngineError> {
         let store = self.store.unwrap_or_else(|| Arc::new(InMemoryStore::new()));

--- a/crates/permit0-normalize/Cargo.toml
+++ b/crates/permit0-normalize/Cargo.toml
@@ -11,4 +11,5 @@ rust-version.workspace = true
 permit0-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/permit0-normalize/src/alias.rs
+++ b/crates/permit0-normalize/src/alias.rs
@@ -1,0 +1,537 @@
+#![forbid(unsafe_code)]
+
+//! Tool-name alias resolver.
+//!
+//! When an agent calls a tool whose name doesn't match any registered
+//! normalizer (e.g. Google's official Gmail MCP exposes `create_label`
+//! while permit0's pack normalizers key on `gmail_create_mailbox`), the
+//! `AliasResolver` rewrites the bare tool name to a canonical one so the
+//! normalizer registry can match.
+//!
+//! Two flavors of alias are supported:
+//!
+//! - **Flat**: `{ tool: "create_label", rewrite_as: "gmail_create_mailbox" }`
+//! - **Conditional**: a `when:` block with `if`/`default` branches that
+//!   choose the rewrite target based on a parameter value.
+//!
+//! Conditional aliases exist because some foreign tools overload one
+//! name across multiple semantic actions. Gmail's `label_thread` adds
+//! a label to a thread, but the *kind* of label changes the action
+//! taxonomy: `STARRED` is `email.flag`, `SPAM` is `email.mark_spam`,
+//! `TRASH` is `email.delete`, and arbitrary user labels are
+//! `email.move`. A flat alias would mis-route the high-stakes cases
+//! through whatever policy applies to the catch-all.
+//!
+//! ## YAML schema
+//!
+//! ```yaml
+//! permit0_pack: "permit0/email"
+//! aliases:
+//!   - tool: create_label
+//!     rewrite_as: gmail_create_mailbox
+//!   - tool: label_thread
+//!     when:
+//!       - if: { param: labelIds, contains: SPAM }
+//!         rewrite_as: gmail_mark_spam
+//!       - if: { param: labelIds, contains: STARRED }
+//!         rewrite_as: gmail_flag
+//!       - default: gmail_move
+//! ```
+//!
+//! Conditions are evaluated top-to-bottom; the first matching branch
+//! wins. The optional `default` branch is the catch-all for
+//! conditional entries.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::error::RegistryError;
+
+/// Resolved alias action: either a flat rewrite or a conditional one.
+#[derive(Debug)]
+enum AliasAction {
+    Flat(String),
+    Conditional(Vec<WhenBranch>),
+}
+
+#[derive(Debug)]
+struct WhenBranch {
+    /// `None` for the catch-all `default` branch.
+    condition: Option<Condition>,
+    rewrite_as: String,
+}
+
+#[derive(Debug)]
+struct Condition {
+    param: String,
+    matcher: Matcher,
+}
+
+#[derive(Debug)]
+enum Matcher {
+    /// Match if the param value is an array containing this scalar, or a
+    /// string containing this substring.
+    Contains(serde_json::Value),
+}
+
+impl Matcher {
+    fn matches(&self, value: &serde_json::Value) -> bool {
+        match self {
+            Self::Contains(needle) => match value {
+                serde_json::Value::Array(items) => items.iter().any(|v| v == needle),
+                serde_json::Value::String(s) => match needle {
+                    serde_json::Value::String(n) => s.contains(n.as_str()),
+                    _ => false,
+                },
+                _ => false,
+            },
+        }
+    }
+}
+
+/// Maps foreign tool names onto canonical ones the normalizer registry
+/// knows about. The resolver runs *before* normalizer dispatch.
+#[derive(Debug)]
+pub struct AliasResolver {
+    map: HashMap<String, AliasAction>,
+}
+
+impl AliasResolver {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    /// Build a resolver from a YAML document. See module docs for the
+    /// expected schema.
+    pub fn from_yaml(yaml: &str) -> Result<Self, RegistryError> {
+        let doc: AliasFile = serde_yaml::from_str(yaml)
+            .map_err(|e| RegistryError::AliasParse(format!("yaml parse: {e}")))?;
+        let mut resolver = Self::new();
+        for entry in doc.aliases {
+            let action = entry.compile()?;
+            resolver.insert(entry.tool, action)?;
+        }
+        Ok(resolver)
+    }
+
+    /// Merge another resolver into this one. Errors on tool conflicts.
+    pub fn merge(&mut self, other: AliasResolver) -> Result<(), RegistryError> {
+        for (tool, action) in other.map {
+            self.insert(tool, action)?;
+        }
+        Ok(())
+    }
+
+    fn insert(&mut self, tool: String, action: AliasAction) -> Result<(), RegistryError> {
+        if self.map.contains_key(&tool) {
+            let existing = match self.map.get(&tool).unwrap() {
+                AliasAction::Flat(s) => s.clone(),
+                AliasAction::Conditional(_) => "<conditional>".into(),
+            };
+            let new = match &action {
+                AliasAction::Flat(s) => s.clone(),
+                AliasAction::Conditional(_) => "<conditional>".into(),
+            };
+            return Err(RegistryError::AliasConflict {
+                tool,
+                existing,
+                new,
+            });
+        }
+        self.map.insert(tool, action);
+        Ok(())
+    }
+
+    /// Resolve a tool name. Returns the rewrite target if the tool is
+    /// aliased and any condition matches, else `None` (caller keeps the
+    /// original name).
+    ///
+    /// `params` is the tool call's parameter object (`raw.parameters`),
+    /// used to evaluate conditional `when:` clauses.
+    pub fn resolve<'a>(
+        &'a self,
+        tool_name: &str,
+        params: &serde_json::Value,
+    ) -> Option<&'a str> {
+        match self.map.get(tool_name)? {
+            AliasAction::Flat(target) => Some(target.as_str()),
+            AliasAction::Conditional(branches) => {
+                for branch in branches {
+                    match &branch.condition {
+                        None => return Some(branch.rewrite_as.as_str()),
+                        Some(cond) => {
+                            if let Some(value) = params.get(&cond.param) {
+                                if cond.matcher.matches(value) {
+                                    return Some(branch.rewrite_as.as_str());
+                                }
+                            }
+                        }
+                    }
+                }
+                None
+            }
+        }
+    }
+
+    /// Number of distinct tool names with aliases registered.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+}
+
+impl Default for AliasResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── YAML schema (private deserialization types) ───────────────────────
+
+#[derive(Debug, Deserialize)]
+struct AliasFile {
+    #[serde(default)]
+    #[allow(dead_code)] // pack identifier; informational only
+    permit0_pack: Option<String>,
+    aliases: Vec<AliasEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AliasEntry {
+    tool: String,
+    #[serde(default)]
+    rewrite_as: Option<String>,
+    #[serde(default)]
+    when: Option<Vec<WhenClauseYaml>>,
+}
+
+impl AliasEntry {
+    fn compile(&self) -> Result<AliasAction, RegistryError> {
+        match (&self.rewrite_as, &self.when) {
+            (Some(target), None) => Ok(AliasAction::Flat(target.clone())),
+            (None, Some(branches)) => {
+                if branches.is_empty() {
+                    return Err(RegistryError::AliasParse(format!(
+                        "alias '{}' has empty 'when' list",
+                        self.tool
+                    )));
+                }
+                let compiled: Result<Vec<_>, _> = branches
+                    .iter()
+                    .map(|b| b.compile(&self.tool))
+                    .collect();
+                Ok(AliasAction::Conditional(compiled?))
+            }
+            (Some(_), Some(_)) => Err(RegistryError::AliasParse(format!(
+                "alias '{}' has both 'rewrite_as' and 'when' — pick one",
+                self.tool
+            ))),
+            (None, None) => Err(RegistryError::AliasParse(format!(
+                "alias '{}' has neither 'rewrite_as' nor 'when'",
+                self.tool
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct WhenClauseYaml {
+    #[serde(default, rename = "if")]
+    condition: Option<ConditionYaml>,
+    #[serde(default)]
+    rewrite_as: Option<String>,
+    #[serde(default)]
+    default: Option<String>,
+}
+
+impl WhenClauseYaml {
+    fn compile(&self, tool: &str) -> Result<WhenBranch, RegistryError> {
+        match (&self.condition, &self.rewrite_as, &self.default) {
+            (Some(cond), Some(target), None) => Ok(WhenBranch {
+                condition: Some(cond.compile(tool)?),
+                rewrite_as: target.clone(),
+            }),
+            (None, None, Some(target)) => Ok(WhenBranch {
+                condition: None,
+                rewrite_as: target.clone(),
+            }),
+            _ => Err(RegistryError::AliasParse(format!(
+                "alias '{tool}' has malformed when clause — use either ('if' + 'rewrite_as') or 'default'"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ConditionYaml {
+    param: String,
+    #[serde(default)]
+    contains: Option<serde_yaml::Value>,
+}
+
+impl ConditionYaml {
+    fn compile(&self, tool: &str) -> Result<Condition, RegistryError> {
+        let matcher = match &self.contains {
+            Some(v) => Matcher::Contains(yaml_to_json(v.clone())),
+            None => {
+                return Err(RegistryError::AliasParse(format!(
+                    "alias '{tool}' condition for param '{}' has no matcher (expected 'contains')",
+                    self.param
+                )));
+            }
+        };
+        Ok(Condition {
+            param: self.param.clone(),
+            matcher,
+        })
+    }
+}
+
+/// Convert a `serde_yaml::Value` into a `serde_json::Value` for matcher
+/// storage. Yaml's tagged scalars are dropped — we only care about
+/// strings, numbers, booleans, null, sequences and mappings.
+fn yaml_to_json(v: serde_yaml::Value) -> serde_json::Value {
+    match v {
+        serde_yaml::Value::Null => serde_json::Value::Null,
+        serde_yaml::Value::Bool(b) => serde_json::Value::Bool(b),
+        serde_yaml::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_json::Value::Number(i.into())
+            } else if let Some(u) = n.as_u64() {
+                serde_json::Value::Number(u.into())
+            } else if let Some(f) = n.as_f64() {
+                serde_json::Number::from_f64(f)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or(serde_json::Value::Null)
+            } else {
+                serde_json::Value::Null
+            }
+        }
+        serde_yaml::Value::String(s) => serde_json::Value::String(s),
+        serde_yaml::Value::Sequence(items) => {
+            serde_json::Value::Array(items.into_iter().map(yaml_to_json).collect())
+        }
+        serde_yaml::Value::Mapping(m) => {
+            let map = m
+                .into_iter()
+                .filter_map(|(k, v)| {
+                    let key = match k {
+                        serde_yaml::Value::String(s) => s,
+                        _ => return None,
+                    };
+                    Some((key, yaml_to_json(v)))
+                })
+                .collect();
+            serde_json::Value::Object(map)
+        }
+        serde_yaml::Value::Tagged(_) => serde_json::Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn flat_alias_resolves() {
+        let yaml = r#"
+permit0_pack: "permit0/email"
+aliases:
+  - tool: create_label
+    rewrite_as: gmail_create_mailbox
+"#;
+        let r = AliasResolver::from_yaml(yaml).unwrap();
+        assert_eq!(
+            r.resolve("create_label", &json!({})),
+            Some("gmail_create_mailbox")
+        );
+        assert_eq!(r.resolve("nonexistent", &json!({})), None);
+    }
+
+    #[test]
+    fn conditional_alias_picks_first_match() {
+        let yaml = r#"
+aliases:
+  - tool: label_thread
+    when:
+      - if: { param: labelIds, contains: SPAM }
+        rewrite_as: gmail_mark_spam
+      - if: { param: labelIds, contains: STARRED }
+        rewrite_as: gmail_flag
+      - default: gmail_move
+"#;
+        let r = AliasResolver::from_yaml(yaml).unwrap();
+
+        // Array contains SPAM → mark_spam.
+        let spam = json!({ "labelIds": ["SPAM", "INBOX"] });
+        assert_eq!(r.resolve("label_thread", &spam), Some("gmail_mark_spam"));
+
+        // Array contains STARRED → flag.
+        let star = json!({ "labelIds": ["STARRED"] });
+        assert_eq!(r.resolve("label_thread", &star), Some("gmail_flag"));
+
+        // Neither → falls through to default.
+        let other = json!({ "labelIds": ["MyCustomLabel"] });
+        assert_eq!(r.resolve("label_thread", &other), Some("gmail_move"));
+
+        // Missing param → falls through to default (since default has no condition).
+        assert_eq!(r.resolve("label_thread", &json!({})), Some("gmail_move"));
+    }
+
+    #[test]
+    fn conditional_with_no_default_returns_none_on_miss() {
+        let yaml = r#"
+aliases:
+  - tool: thing
+    when:
+      - if: { param: kind, contains: foo }
+        rewrite_as: foo_canonical
+"#;
+        let r = AliasResolver::from_yaml(yaml).unwrap();
+        // No condition matches, no default → no rewrite.
+        assert_eq!(r.resolve("thing", &json!({"kind": "bar"})), None);
+    }
+
+    #[test]
+    fn duplicate_tool_in_one_file_errors() {
+        let yaml = r#"
+aliases:
+  - tool: create_label
+    rewrite_as: gmail_create_mailbox
+  - tool: create_label
+    rewrite_as: outlook_create_mailbox
+"#;
+        let err = AliasResolver::from_yaml(yaml).unwrap_err();
+        assert!(matches!(err, RegistryError::AliasConflict { .. }));
+    }
+
+    #[test]
+    fn entry_must_have_either_rewrite_or_when() {
+        let yaml = r#"
+aliases:
+  - tool: half_baked
+"#;
+        assert!(matches!(
+            AliasResolver::from_yaml(yaml).unwrap_err(),
+            RegistryError::AliasParse(_)
+        ));
+    }
+
+    #[test]
+    fn entry_cannot_have_both_rewrite_and_when() {
+        let yaml = r#"
+aliases:
+  - tool: confused
+    rewrite_as: a
+    when:
+      - default: b
+"#;
+        assert!(matches!(
+            AliasResolver::from_yaml(yaml).unwrap_err(),
+            RegistryError::AliasParse(_)
+        ));
+    }
+
+    #[test]
+    fn empty_when_list_errors() {
+        let yaml = r#"
+aliases:
+  - tool: empty
+    when: []
+"#;
+        assert!(matches!(
+            AliasResolver::from_yaml(yaml).unwrap_err(),
+            RegistryError::AliasParse(_)
+        ));
+    }
+
+    #[test]
+    fn malformed_when_clause_errors() {
+        // 'if' without 'rewrite_as'
+        let yaml = r#"
+aliases:
+  - tool: bad
+    when:
+      - if: { param: x, contains: y }
+"#;
+        assert!(matches!(
+            AliasResolver::from_yaml(yaml).unwrap_err(),
+            RegistryError::AliasParse(_)
+        ));
+    }
+
+    #[test]
+    fn merge_two_resolvers() {
+        let mut r = AliasResolver::from_yaml(
+            r#"
+aliases:
+  - tool: a
+    rewrite_as: aa
+"#,
+        )
+        .unwrap();
+        let other = AliasResolver::from_yaml(
+            r#"
+aliases:
+  - tool: b
+    rewrite_as: bb
+"#,
+        )
+        .unwrap();
+        r.merge(other).unwrap();
+        assert_eq!(r.resolve("a", &json!({})), Some("aa"));
+        assert_eq!(r.resolve("b", &json!({})), Some("bb"));
+    }
+
+    #[test]
+    fn merge_conflict_errors() {
+        let mut r = AliasResolver::from_yaml(
+            r#"
+aliases:
+  - tool: a
+    rewrite_as: aa
+"#,
+        )
+        .unwrap();
+        let other = AliasResolver::from_yaml(
+            r#"
+aliases:
+  - tool: a
+    rewrite_as: bb
+"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            r.merge(other).unwrap_err(),
+            RegistryError::AliasConflict { .. }
+        ));
+    }
+
+    #[test]
+    fn matcher_string_substring_works() {
+        let yaml = r#"
+aliases:
+  - tool: maybe_send
+    when:
+      - if: { param: command, contains: "swaks" }
+        rewrite_as: swaks_send
+      - default: bash_unknown
+"#;
+        let r = AliasResolver::from_yaml(yaml).unwrap();
+        assert_eq!(
+            r.resolve("maybe_send", &json!({"command": "swaks --to alice"})),
+            Some("swaks_send")
+        );
+        assert_eq!(
+            r.resolve("maybe_send", &json!({"command": "ls -la"})),
+            Some("bash_unknown")
+        );
+    }
+}

--- a/crates/permit0-normalize/src/alias.rs
+++ b/crates/permit0-normalize/src/alias.rs
@@ -151,11 +151,7 @@ impl AliasResolver {
     ///
     /// `params` is the tool call's parameter object (`raw.parameters`),
     /// used to evaluate conditional `when:` clauses.
-    pub fn resolve<'a>(
-        &'a self,
-        tool_name: &str,
-        params: &serde_json::Value,
-    ) -> Option<&'a str> {
+    pub fn resolve<'a>(&'a self, tool_name: &str, params: &serde_json::Value) -> Option<&'a str> {
         match self.map.get(tool_name)? {
             AliasAction::Flat(target) => Some(target.as_str()),
             AliasAction::Conditional(branches) => {
@@ -222,10 +218,8 @@ impl AliasEntry {
                         self.tool
                     )));
                 }
-                let compiled: Result<Vec<_>, _> = branches
-                    .iter()
-                    .map(|b| b.compile(&self.tool))
-                    .collect();
+                let compiled: Result<Vec<_>, _> =
+                    branches.iter().map(|b| b.compile(&self.tool)).collect();
                 Ok(AliasAction::Conditional(compiled?))
             }
             (Some(_), Some(_)) => Err(RegistryError::AliasParse(format!(

--- a/crates/permit0-normalize/src/error.rs
+++ b/crates/permit0-normalize/src/error.rs
@@ -27,4 +27,14 @@ pub enum NormalizeError {
 pub enum RegistryError {
     #[error("priority conflict: normalizers '{a}' and '{b}' both have priority {priority}")]
     PriorityConflict { a: String, b: String, priority: i32 },
+
+    #[error("alias conflict: tool '{tool}' is aliased twice (existing: '{existing}', new: '{new}')")]
+    AliasConflict {
+        tool: String,
+        existing: String,
+        new: String,
+    },
+
+    #[error("alias parse error: {0}")]
+    AliasParse(String),
 }

--- a/crates/permit0-normalize/src/error.rs
+++ b/crates/permit0-normalize/src/error.rs
@@ -28,7 +28,9 @@ pub enum RegistryError {
     #[error("priority conflict: normalizers '{a}' and '{b}' both have priority {priority}")]
     PriorityConflict { a: String, b: String, priority: i32 },
 
-    #[error("alias conflict: tool '{tool}' is aliased twice (existing: '{existing}', new: '{new}')")]
+    #[error(
+        "alias conflict: tool '{tool}' is aliased twice (existing: '{existing}', new: '{new}')"
+    )]
     AliasConflict {
         tool: String,
         existing: String,

--- a/crates/permit0-normalize/src/lib.rs
+++ b/crates/permit0-normalize/src/lib.rs
@@ -1,12 +1,14 @@
 #![forbid(unsafe_code)]
 #![doc = "Normalizer trait and registry for the permit0 agent permission framework."]
 
+mod alias;
 mod context;
 mod error;
 mod fallback;
 mod registry;
 mod traits;
 
+pub use alias::AliasResolver;
 pub use context::NormalizeCtx;
 pub use error::{NormalizeError, RegistryError};
 pub use fallback::FallbackNormalizer;

--- a/crates/permit0-normalize/src/registry.rs
+++ b/crates/permit0-normalize/src/registry.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use permit0_types::{NormAction, RawToolCall};
 
+use crate::alias::AliasResolver;
 use crate::context::NormalizeCtx;
 use crate::error::{NormalizeError, RegistryError};
 use crate::fallback::FallbackNormalizer;
@@ -14,11 +15,16 @@ use crate::traits::Normalizer;
 /// Invariants:
 /// - No two normalizers share the same priority (conflict detection at registration).
 /// - A fallback normalizer (priority 0) always exists as the last resort.
+/// - An alias resolver runs *before* normalizer dispatch and rewrites
+///   `tool_name` for foreign tools that wrap permit0's canonical actions
+///   under a different name (e.g. Google's official Gmail MCP).
 pub struct NormalizerRegistry {
     /// Sorted by priority descending (highest first).
     by_priority: Vec<Arc<dyn Normalizer>>,
     /// Fallback normalizer for unknown tools (priority 0).
     fallback: Arc<dyn Normalizer>,
+    /// Aliases applied before normalizer dispatch.
+    aliases: AliasResolver,
 }
 
 impl NormalizerRegistry {
@@ -27,6 +33,7 @@ impl NormalizerRegistry {
         Self {
             by_priority: Vec::new(),
             fallback: Arc::new(FallbackNormalizer),
+            aliases: AliasResolver::new(),
         }
     }
 
@@ -35,6 +42,7 @@ impl NormalizerRegistry {
         Self {
             by_priority: Vec::new(),
             fallback,
+            aliases: AliasResolver::new(),
         }
     }
 
@@ -63,20 +71,58 @@ impl NormalizerRegistry {
         Ok(())
     }
 
+    /// Install a YAML alias document (`packs/<pack>/aliases.yaml`).
+    ///
+    /// Aliases let foreign tool names (e.g. Google's official Gmail MCP
+    /// `create_label`) be rewritten to canonical names the registry's
+    /// normalizers already match (`gmail_create_mailbox`). See
+    /// [`AliasResolver`] for the YAML schema.
+    pub fn install_aliases_yaml(&mut self, yaml: &str) -> Result<(), RegistryError> {
+        let resolver = AliasResolver::from_yaml(yaml)?;
+        self.aliases.merge(resolver)
+    }
+
     /// Normalize a raw tool call by dispatching to the first matching normalizer.
     /// Falls back to the fallback normalizer if no registered normalizer matches.
+    ///
+    /// Alias resolution runs first: if the bare `tool_name` matches a
+    /// registered alias and (for conditional aliases) the `when:` clause
+    /// evaluates to a rewrite, the rewritten name is used for normalizer
+    /// dispatch. The original tool name is preserved on the surface for
+    /// audit (it ends up in `ExecutionMeta.surface_tool` via the matched
+    /// normalizer's `surface_tool` slot, since we hand the rewritten
+    /// `RawToolCall` to the normalizer).
     pub fn normalize(
         &self,
         raw: &RawToolCall,
         ctx: &NormalizeCtx,
     ) -> Result<NormAction, NormalizeError> {
+        // Step 0: alias rewrite, if any.
+        let resolved_name = self
+            .aliases
+            .resolve(&raw.tool_name, &raw.parameters)
+            .map(str::to_owned);
+
+        // If an alias rewrote the name, dispatch against a clone with the
+        // canonical name. Otherwise the original raw call is used directly.
+        let dispatch_target: std::borrow::Cow<'_, RawToolCall> = match resolved_name {
+            Some(canonical) => std::borrow::Cow::Owned(RawToolCall {
+                tool_name: canonical,
+                parameters: raw.parameters.clone(),
+                metadata: raw.metadata.clone(),
+            }),
+            None => std::borrow::Cow::Borrowed(raw),
+        };
+
         for normalizer in &self.by_priority {
-            if normalizer.matches(raw) {
-                return normalizer.normalize(raw, ctx);
+            if normalizer.matches(&dispatch_target) {
+                return normalizer.normalize(&dispatch_target, ctx);
             }
         }
 
-        // No registered normalizer matched — use fallback
+        // No registered normalizer matched — use fallback. Fallback uses
+        // the ORIGINAL raw call so the audit log records the actual tool
+        // name the agent invoked, not the (failed) alias guess.
         self.fallback.normalize(raw, ctx)
     }
 
@@ -88,6 +134,11 @@ impl NormalizerRegistry {
     /// Whether the registry has no registered normalizers (excluding fallback).
     pub fn is_empty(&self) -> bool {
         self.by_priority.is_empty()
+    }
+
+    /// Number of registered aliases.
+    pub fn alias_count(&self) -> usize {
+        self.aliases.len()
     }
 }
 
@@ -267,5 +318,149 @@ mod tests {
 
         assert_eq!(reg.len(), 1);
         assert!(!reg.is_empty());
+    }
+
+    #[test]
+    fn alias_rewrites_before_dispatch() {
+        // Register a normalizer keyed on the canonical name, then alias
+        // the foreign name to it. Confirms the rewrite happens before
+        // normalizer matching.
+        let mut reg = NormalizerRegistry::new();
+        let email_create_mailbox = ActionType::parse("email.create_mailbox").unwrap();
+        reg.register(Arc::new(MockNormalizer {
+            id: "gmail_create_mailbox".into(),
+            priority: 100,
+            tool_match: "gmail_create_mailbox".into(),
+            action_type: email_create_mailbox,
+        }))
+        .unwrap();
+
+        reg.install_aliases_yaml(
+            r#"
+aliases:
+  - tool: create_label
+    rewrite_as: gmail_create_mailbox
+"#,
+        )
+        .unwrap();
+        assert_eq!(reg.alias_count(), 1);
+
+        let ctx = NormalizeCtx::new();
+        // Calling the foreign name routes through the alias to the
+        // canonical normalizer.
+        let action = reg.normalize(&make_raw("create_label"), &ctx).unwrap();
+        assert_eq!(action.action_type, email_create_mailbox);
+    }
+
+    #[test]
+    fn alias_unaliased_tool_falls_through_to_fallback() {
+        let mut reg = NormalizerRegistry::new();
+        reg.install_aliases_yaml(
+            r#"
+aliases:
+  - tool: create_label
+    rewrite_as: gmail_create_mailbox
+"#,
+        )
+        .unwrap();
+
+        let ctx = NormalizeCtx::new();
+        let action = reg.normalize(&make_raw("totally_unknown"), &ctx).unwrap();
+        // No alias, no normalizer → fallback fires.
+        assert_eq!(action.action_type, ActionType::UNKNOWN);
+    }
+
+    #[test]
+    fn alias_with_no_canonical_normalizer_falls_through_to_fallback() {
+        // Alias rewrites to a name no normalizer knows. Should still
+        // hit the fallback rather than panic.
+        let mut reg = NormalizerRegistry::new();
+        reg.install_aliases_yaml(
+            r#"
+aliases:
+  - tool: foreign
+    rewrite_as: nonexistent_canonical
+"#,
+        )
+        .unwrap();
+
+        let ctx = NormalizeCtx::new();
+        let action = reg.normalize(&make_raw("foreign"), &ctx).unwrap();
+        assert_eq!(action.action_type, ActionType::UNKNOWN);
+    }
+
+    #[test]
+    fn conditional_alias_routes_by_param_value() {
+        // Mirrors the real Gmail label_thread case: SPAM → mark_spam,
+        // STARRED → flag, anything else → move.
+        let mut reg = NormalizerRegistry::new();
+        let mark_spam = ActionType::parse("email.mark_spam").unwrap();
+        let flag = ActionType::parse("email.flag").unwrap();
+        let move_action = ActionType::parse("email.move").unwrap();
+
+        reg.register(Arc::new(MockNormalizer {
+            id: "gmail_mark_spam".into(),
+            priority: 100,
+            tool_match: "gmail_mark_spam".into(),
+            action_type: mark_spam,
+        }))
+        .unwrap();
+        reg.register(Arc::new(MockNormalizer {
+            id: "gmail_flag".into(),
+            priority: 99,
+            tool_match: "gmail_flag".into(),
+            action_type: flag,
+        }))
+        .unwrap();
+        reg.register(Arc::new(MockNormalizer {
+            id: "gmail_move".into(),
+            priority: 98,
+            tool_match: "gmail_move".into(),
+            action_type: move_action,
+        }))
+        .unwrap();
+
+        reg.install_aliases_yaml(
+            r#"
+aliases:
+  - tool: label_thread
+    when:
+      - if: { param: labelIds, contains: SPAM }
+        rewrite_as: gmail_mark_spam
+      - if: { param: labelIds, contains: STARRED }
+        rewrite_as: gmail_flag
+      - default: gmail_move
+"#,
+        )
+        .unwrap();
+
+        let ctx = NormalizeCtx::new();
+
+        let spam_call = RawToolCall {
+            tool_name: "label_thread".into(),
+            parameters: serde_json::json!({"labelIds": ["SPAM"]}),
+            metadata: serde_json::Map::new(),
+        };
+        assert_eq!(
+            reg.normalize(&spam_call, &ctx).unwrap().action_type,
+            mark_spam
+        );
+
+        let star_call = RawToolCall {
+            tool_name: "label_thread".into(),
+            parameters: serde_json::json!({"labelIds": ["STARRED"]}),
+            metadata: serde_json::Map::new(),
+        };
+        assert_eq!(reg.normalize(&star_call, &ctx).unwrap().action_type, flag);
+
+        let custom_call = RawToolCall {
+            tool_name: "label_thread".into(),
+            parameters: serde_json::json!({"labelIds": ["UserCustomLabel"]}),
+            metadata: serde_json::Map::new(),
+        };
+        assert_eq!(
+            reg.normalize(&custom_call, &ctx).unwrap().action_type,
+            move_action
+        );
     }
 }

--- a/crates/permit0-types/src/catalog.rs
+++ b/crates/permit0-types/src/catalog.rs
@@ -68,6 +68,7 @@ impl Domain {
                 Verb::ReadThread,
                 Verb::ListMailboxes,
                 Verb::Draft,
+                Verb::ListDrafts,
                 Verb::Send,
                 Verb::MarkRead,
                 Verb::Flag,
@@ -323,6 +324,7 @@ pub enum Verb {
     ReadThread,
     ListMailboxes,
     Draft,
+    ListDrafts,
     Send,
     MarkRead,
     Flag,
@@ -463,6 +465,7 @@ impl Verb {
             Self::ReadThread => "read_thread",
             Self::ListMailboxes => "list_mailboxes",
             Self::Draft => "draft",
+            Self::ListDrafts => "list_drafts",
             Self::Send => "send",
             Self::MarkRead => "mark_read",
             Self::Flag => "flag",
@@ -660,6 +663,7 @@ const ALL_VERBS: &[Verb] = &[
     Verb::ReadThread,
     Verb::ListMailboxes,
     Verb::Draft,
+    Verb::ListDrafts,
     Verb::Send,
     Verb::MarkRead,
     Verb::Flag,
@@ -792,11 +796,12 @@ mod tests {
 
     #[test]
     fn email_full_set_intact() {
-        // Detailed email taxonomy preserved (15 verbs).
-        assert_eq!(Domain::Email.verbs().len(), 15);
+        // Detailed email taxonomy preserved (16 verbs).
+        assert_eq!(Domain::Email.verbs().len(), 16);
         assert!(ActionType::parse("email.send").is_ok());
         assert!(ActionType::parse("email.read_thread").is_ok());
         assert!(ActionType::parse("email.set_forwarding").is_ok());
+        assert!(ActionType::parse("email.list_drafts").is_ok());
     }
 
     #[test]

--- a/integrations/permit0-openclaw/__tests__/Permit0Client.test.ts
+++ b/integrations/permit0-openclaw/__tests__/Permit0Client.test.ts
@@ -165,6 +165,22 @@ describe("Permit0Client.check — request shape", () => {
     });
     await client.close();
   });
+
+  it("sets client_kind to openclaw so the daemon strips mcporter's <server>.<tool> shape", async () => {
+    const { dispatcher, pool } = setup();
+    let captured: { client_kind?: string } | undefined;
+    pool
+      .intercept({ path: "/api/v1/check", method: "POST" })
+      .reply(200, (opts) => {
+        captured = JSON.parse(String(opts.body));
+        return makeAllowDecision();
+      });
+
+    const client = new Permit0Client({ baseUrl: BASE_URL, dispatcher });
+    await client.check("gmail.create_label", { name: "TestLabel" });
+    expect(captured?.client_kind).toBe("openclaw");
+    await client.close();
+  });
 });
 
 describe("Permit0Client.check — retry semantics", () => {

--- a/integrations/permit0-openclaw/src/Permit0Client.ts
+++ b/integrations/permit0-openclaw/src/Permit0Client.ts
@@ -156,6 +156,10 @@ export class Permit0Client {
       tool_name: toolName,
       parameters,
       metadata: buildMetadata(ctx),
+      // Tells the daemon to strip mcporter's `<server>.<tool>` prefix
+      // before normalizer dispatch. See ClientKind::OpenClaw in
+      // crates/permit0-cli/src/cmd/hook.rs.
+      client_kind: "openclaw",
     };
 
     let lastError: Permit0Error | undefined;

--- a/integrations/permit0-openclaw/src/types.ts
+++ b/integrations/permit0-openclaw/src/types.ts
@@ -52,11 +52,17 @@ export interface Decision {
  * `metadata` is reserved for caller-supplied context (e.g. `session_id`,
  * `task_goal`). It is currently dropped server-side; Lane A step 1 wires it
  * into the audit entry. Sending it now is forward-compatible.
+ *
+ * `client_kind` selects host-specific tool-name prefix stripping on the
+ * daemon. For OpenClaw, set this to `"openclaw"` so mcporter's
+ * `<server>.<tool>` shape gets stripped to the bare tool name before
+ * normalizer dispatch. Omit to leave the name untouched (passthrough).
  */
 export interface CheckRequest {
   tool_name: string;
   parameters: unknown;
   metadata?: Record<string, unknown>;
+  client_kind?: string;
 }
 
 /**

--- a/packs/email/aliases.yaml
+++ b/packs/email/aliases.yaml
@@ -1,0 +1,137 @@
+permit0_pack: "permit0/email"
+
+# Maps foreign tool names onto canonical permit0 normalizer names so
+# policies and risk rules apply uniformly across:
+#
+#   - Google's official Gmail MCP (gmailmcp.googleapis.com)
+#       https://developers.google.com/workspace/gmail/api/reference/mcp
+#   - Microsoft's Work IQ Mail MCP
+#       https://learn.microsoft.com/en-us/microsoft-agent-365/mcp-server-reference/mail
+#
+# Aliasing happens AFTER ClientKind prefix stripping (e.g. mcporter's
+# `gmail.create_label` becomes `create_label` before this table is
+# consulted) and BEFORE normalizer dispatch. See:
+#   - crates/permit0-cli/src/cmd/hook.rs::ClientKind for prefix stripping
+#   - crates/permit0-normalize/src/alias.rs for the alias engine
+#
+# NOTE on parameter-name fidelity: the alias mechanism rewrites tool
+# names, not parameter names. Where a foreign tool uses a different
+# parameter name than the target permit0 normalizer expects (Google
+# uses `query`, our gmail_search expects `q`; Google uses `id` for
+# threadId, gmail_read_thread expects `thread_id`), the action_type is
+# routed correctly but some entities will be empty in the audit. Risk
+# rules that match on those entities will not see the value. A future
+# improvement is parameter remapping in the alias entry.
+
+aliases:
+  # ── Google official Gmail MCP (10 tools) ───────────────────────────
+
+  # Read / browse — clean alignment.
+  - tool: get_thread
+    rewrite_as: gmail_read_thread
+
+  - tool: search_threads
+    rewrite_as: gmail_search
+
+  - tool: list_labels
+    rewrite_as: gmail_list_mailboxes
+
+  - tool: list_drafts
+    rewrite_as: gmail_list_drafts
+
+  # Create — `create_label`/`create_draft` map cleanly to canonicals.
+  - tool: create_label
+    rewrite_as: gmail_create_mailbox
+
+  - tool: create_draft
+    rewrite_as: gmail_draft
+
+  # Send — Google's official MCP doesn't expose send (only create_draft),
+  # but community Gmail MCP servers (and OpenClaw's gmail webhook helpers)
+  # expose it as a bare `send` tool. Alias to gmail_send.
+  #
+  # NOTE: this is a common-name alias — any tool literally named `send`
+  # routes here. If you also use OpenClaw's native sessions/messaging
+  # send tools (e.g. createSessionsSendTool), expect collisions. Prefer
+  # using the message domain pack for those once it lands; until then,
+  # a fallback policy on email.send still covers what an LLM agent can
+  # do with the call.
+  - tool: send
+    rewrite_as: gmail_send
+
+  - tool: send_email
+    rewrite_as: gmail_send
+
+  - tool: send_message
+    rewrite_as: gmail_send
+
+  # Label/unlabel: Gmail labels are overloaded — STARRED is a flag,
+  # SPAM is junk routing, TRASH is delete, INBOX-removal is archive,
+  # everything else is a generic move. Conditional aliases preserve
+  # the existing risk-rule taxonomy so a policy that allows
+  # email.move can still deny email.mark_spam.
+
+  - tool: label_thread
+    when:
+      - if: { param: labelIds, contains: SPAM }
+        rewrite_as: gmail_mark_spam
+      - if: { param: labelIds, contains: STARRED }
+        rewrite_as: gmail_flag
+      - if: { param: labelIds, contains: TRASH }
+        rewrite_as: gmail_delete
+      - default: gmail_move
+
+  - tool: label_message
+    when:
+      - if: { param: labelIds, contains: SPAM }
+        rewrite_as: gmail_mark_spam
+      - if: { param: labelIds, contains: STARRED }
+        rewrite_as: gmail_flag
+      - if: { param: labelIds, contains: TRASH }
+        rewrite_as: gmail_delete
+      - default: gmail_move
+
+  # Removing INBOX label is the canonical Gmail "archive". Removing
+  # STARRED is unflagging — semantically still email.flag (the policy
+  # cares that flagging happens, not the polarity). For everything
+  # else fall back to email.move.
+  - tool: unlabel_thread
+    when:
+      - if: { param: labelIds, contains: INBOX }
+        rewrite_as: gmail_archive
+      - if: { param: labelIds, contains: STARRED }
+        rewrite_as: gmail_flag
+      - default: gmail_move
+
+  - tool: unlabel_message
+    when:
+      - if: { param: labelIds, contains: INBOX }
+        rewrite_as: gmail_archive
+      - if: { param: labelIds, contains: STARRED }
+        rewrite_as: gmail_flag
+      - default: gmail_move
+
+  # ── Microsoft Work IQ Mail MCP ─────────────────────────────────────
+  # Tool names arrive bare (no mcp_MailTools_graph_mail_ prefix) once
+  # ClientKind stripping has run, OR they may arrive prefixed depending
+  # on the host. Add canonical short names here; if real traffic shows
+  # the full prefixed names, extend the strip rule for that ClientKind
+  # rather than aliasing every prefix variant.
+
+  - tool: searchMessages
+    rewrite_as: outlook_search
+
+  - tool: getMessage
+    rewrite_as: outlook_read
+
+  - tool: createMessage
+    rewrite_as: outlook_draft
+
+  - tool: sendMail
+    rewrite_as: outlook_send
+
+  - tool: sendDraft
+    rewrite_as: outlook_send
+
+  - tool: deleteMessage
+    rewrite_as: outlook_delete

--- a/packs/email/normalizers/gmail_list_drafts.yaml
+++ b/packs/email/normalizers/gmail_list_drafts.yaml
@@ -1,0 +1,19 @@
+permit0_pack: "permit0/email"
+id: "email:gmail_list_drafts"
+priority: 130
+match:
+  tool: gmail_list_drafts
+normalize:
+  action_type: "email.list_drafts"
+  domain: "email"
+  verb: "list_drafts"
+  channel: "gmail"
+  entities:
+    query:
+      from: "q"
+      type: "string"
+      optional: true
+    page_token:
+      from: "page_token"
+      type: "string"
+      optional: true

--- a/packs/email/normalizers/gmail_move.yaml
+++ b/packs/email/normalizers/gmail_move.yaml
@@ -13,7 +13,13 @@ normalize:
       from: "id"
       type: "string"
       required: true
+    # Optional rather than required: the canonical permit0 wrapper
+    # always provides this, but aliased calls (Google's
+    # label_thread/label_message default branch routes here) carry
+    # the destination as a `labelIds` array on the original tool
+    # call. The alias mechanism rewrites the tool name only, not
+    # parameter names, so this entity stays empty for those calls.
     destination:
       from: "label_id"
       type: "string"
-      required: true
+      optional: true

--- a/packs/email/normalizers/gmail_read_thread.yaml
+++ b/packs/email/normalizers/gmail_read_thread.yaml
@@ -9,7 +9,12 @@ normalize:
   verb: "read_thread"
   channel: "gmail"
   entities:
+    # Optional rather than required because aliased calls from
+    # Google's official Gmail MCP arrive as `get_thread(id=...)` —
+    # alias rewrites the tool name only, so `thread_id` is empty in
+    # that flow. The canonical permit0-gmail wrapper still passes
+    # `thread_id` and gets the entity populated.
     thread_id:
       from: "thread_id"
       type: "string"
-      required: true
+      optional: true


### PR DESCRIPTION
## Summary

Closes the gap visible in the calibration UI where every Gmail tool call from OpenClaw landed as `unknown.unclassified`. mcporter passes MCP tools as `<server>.<tool>` (dot separator), and even after stripping that prefix the resulting bare names are foreign — Google's official Gmail MCP exposes `create_label`, `get_thread`, `search_threads`, etc., not the canonical `gmail_*` names this pack's normalizers match on.

Before this PR — every row says `unknown.unclassified`:
| Action | Channel | permit0 said | Human said | Match |
|---|---|---|---|---|
| `unknown.unclassified` | `gmail.create_label` | HumanInTheLoop | Allow | ⚠️ |
| `unknown.unclassified` | `gmail.search_threads` | HumanInTheLoop | Allow | ⚠️ |

After: real action types route through the existing risk rules.

## What changed

Three layers, designed to ship together:

### 1. `ClientKind::OpenClaw` — daemon-side prefix strip

[`crates/permit0-cli/src/cmd/hook.rs`](crates/permit0-cli/src/cmd/hook.rs) gains an `OpenClaw` variant that strips mcporter's dot prefix (`gmail.create_label` → `create_label`). [`serve.rs`](crates/permit0-cli/src/cmd/serve.rs) gains a top-level optional `client_kind` field on `CheckRequest` (default `Raw`, no compat break) and applies the strip before engine dispatch — parity with the stdin-hook adapter.

The TS `Permit0Client` always sends `client_kind: "openclaw"` now ([`Permit0Client.ts:155`](integrations/permit0-openclaw/src/Permit0Client.ts)).

### 2. `AliasResolver` — pre-normalize rewrite layer

New module [`crates/permit0-normalize/src/alias.rs`](crates/permit0-normalize/src/alias.rs). Two flavors:

- **Flat**: `{ tool: "create_label", rewrite_as: "gmail_create_mailbox" }`
- **Conditional**: `when:` block with `if`/`default` branches that pick the rewrite target based on parameter values

Conditional aliases exist because Gmail's `label_thread` / `label_message` / `unlabel_*` overload one name across multiple semantic actions. A label can be `STARRED` (flag), `SPAM` (mark_spam), `TRASH` (delete), `INBOX`-removal (archive), or arbitrary (move). Flat aliasing would mis-route the high-stakes cases through whatever policy applies to the catch-all. Conditional aliasing keeps the existing risk-rule taxonomy intact.

Wired into `NormalizerRegistry` as a step-0 rewrite before normalizer dispatch.

### 3. `email.list_drafts` action type

New [`Verb::ListDrafts`](crates/permit0-types/src/catalog.rs). Email domain now has 16 verbs. Includes a corresponding [`gmail_list_drafts`](packs/email/normalizers/gmail_list_drafts.yaml) normalizer.

### Pack content

[`packs/email/aliases.yaml`](packs/email/aliases.yaml) covers:
- All 10 tools of Google's official Gmail MCP
- 6 of Microsoft's Work IQ Mail MCP
- Common community variants (`send`, `send_email`, `send_message`)

[`gmail_move.yaml`](packs/email/normalizers/gmail_move.yaml) and [`gmail_read_thread.yaml`](packs/email/normalizers/gmail_read_thread.yaml) had `destination` / `thread_id` made optional. The alias mechanism rewrites tool names, not parameter names — when a foreign tool uses a different param name (Google's `id` vs our `thread_id`, `query` vs `q`), the `action_type` routes correctly but those entities are empty. Documented inline.

## Why

`unknown.unclassified` for known-shape tool calls breaks calibration because the ground truth (what the human chooses) can't agree with permit0 (which has no opinion). The first screenshot showed 100% mismatch on every Gmail action. After this PR, those rows flow through the existing `email.*` risk rules and policies — calibration becomes meaningful.

## What reviewers should know

- **Schema is additive.** `client_kind` defaults to `Raw` (passthrough), so any existing deployment keeps working unchanged.
- **The "common name" aliases (`send`, `send_email`, `send_message`) collide with potential non-email tools** — flagged in the YAML comment. If OpenClaw's native session/messaging-send tools also expose bare `send`, they'd get routed to `email.send`. The fix is the future `message` domain pack; until then, `email.send` policy still bounds what an LLM can do with the call.
- **Parameter remapping is out of scope.** A follow-up could let alias entries also rewrite param names (`id` → `thread_id`), which would make entity extraction lossless for foreign tools. For this PR, the `optional` fields in `gmail_move` / `gmail_read_thread` are the trade-off.

## Test plan

- [x] `cargo test --workspace --exclude permit0-py` — green
  - 11 new alias unit tests
  - 4 new registry integration tests (including the conditional Gmail-label routing)
  - 16-verb assertion for the email domain
- [x] `npm test` in `integrations/permit0-openclaw/` — 87 tests green, including new assertion that `client_kind: "openclaw"` lands in every request body
- [x] End-to-end smoke against `permit0 hook --client openclaw --packs-dir ./packs`:

| Tool call | Before | After |
|---|---|---|
| `gmail.create_label` | unknown.unclassified | `email.create_mailbox` |
| `gmail.label_thread` (SPAM) | unknown.unclassified | `email.mark_spam` |
| `gmail.label_thread` (custom) | unknown.unclassified | `email.move` |
| `gmail.get_thread` | unknown.unclassified | `email.read_thread` |
| `gmail.search_threads` | unknown.unclassified | `email.search` |
| `gmail.list_drafts` | unknown.unclassified | `email.list_drafts` |
| `gmail.list_labels` | unknown.unclassified | `email.list_mailboxes` |
| `gmail.unlabel_message` (INBOX) | unknown.unclassified | `email.archive` |

- [x] `curl http://localhost:9090/api/v1/check -d '{"tool_name":"gmail.search_threads",...,"client_kind":"openclaw"}'` returns `action_type: email.search` / `channel: gmail`
- [x] Validated in calibration UI with live OpenClaw traffic — `gmail.list_labels` now resolves correctly (per side-by-side dashboard testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)