### PR TITLE
fix(build): add .cargo/config.toml so cargo build --workspace works on macOS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+# PyO3 extension modules on macOS need the linker to defer Python symbol
+# resolution to runtime — the Python interpreter loads the .dylib and
+# provides the symbols. Without these flags, plain `cargo build` of the
+# workspace fails on macOS with "Undefined symbols ... _PyBaseObject_Type"
+# when linking permit0-py's cdylib. maturin sets these automatically; this
+# config makes direct cargo invocations work too.
+#
+# See: https://pyo3.rs/v0.24.0/building-and-distribution.html#macos
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]


### PR DESCRIPTION
## Summary
- Adds `.cargo/config.toml` setting `-undefined dynamic_lookup` rustflags for `aarch64-apple-darwin` and `x86_64-apple-darwin`.
- Without this, plain `cargo build --workspace` on macOS fails at the link step for `permit0-py` (a PyO3 cdylib) with hundreds of `Undefined symbols for architecture arm64: _PyBaseObject_Type, _PyBytes_AsString, ...` errors. The Python symbols are resolved by the interpreter at load time, not at link time — `maturin develop` sets these flags automatically, but direct cargo builds didn't, even though the README documents `cargo build --release --workspace` as a supported path.

## Verification (on macOS Apple Silicon, aarch64-apple-darwin)
- ✅ **`cargo build --workspace`** — all 14 crates compile, including `permit0-py` (`Finished dev profile [unoptimized + debuginfo] target(s) in 13.23s`).
- ✅ **`cargo build --workspace --release`** — same, release profile (`Finished release profile [optimized] target(s) in 25.92s`).
- ✅ **Linux unaffected** — installed `x86_64-unknown-linux-gnu` target and tried `cargo build --target x86_64-unknown-linux-gnu -p permit0-cli`. Build failed at `cc-rs: failed to find tool "x86_64-linux-gnu-gcc"` (missing cross C toolchain on macOS — expected). Crucially, **no** complaints about `-undefined` / `dynamic_lookup` from any linker or rustc warning, confirming the `[target.<apple-darwin>]` sections do not apply when targeting Linux. This matches cargo's documented behavior for target-specific config sections. Pure-Rust crate `permit0-types` cross-compiled cleanly for Linux.
- ⏸️ **Intel Mac (x86_64-apple-darwin)** — no machine available to spot-check. The `[target.x86_64-apple-darwin]` section mirrors the Apple Silicon one verbatim, so the fix should apply identically; flagging for any reviewer with Intel hardware to confirm.

## Trade-off / open question
- These rustflags apply to **every** crate compiled for macOS, not just `permit0-py`. The flag is benign for normal binaries (they already have all symbols at link time), but it does mean the linker won't catch missing symbols at link time for any crate.
- A more scoped alternative is a `build.rs` in `permit0-py` emitting `cargo::rustc-link-arg-cdylib=-undefined` and `cargo::rustc-link-arg-cdylib=dynamic_lookup`, which would limit the flag to that one cdylib. Happy to switch if you prefer; both make `cargo build --workspace` work.

## Test plan
- [x] `cargo build --workspace` succeeds on macOS Apple Silicon.
- [x] `cargo build --workspace --release` succeeds on macOS Apple Silicon.
- [x] CI (Linux) unaffected — verified via cross-build of `permit0-cli` for `x86_64-unknown-linux-gnu`; no rustflag-related complaints, only the expected missing cross C toolchain.
- [ ] Spot-check on macOS Intel (x86_64-apple-darwin) — unable to verify locally; needs a reviewer with Intel hardware.