### PR TITLE
PR 1: rename catalog → taxonomy + introduce test fixture helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,7 @@ version = "0.1.0"
 dependencies = [
  "permit0-normalize",
  "permit0-scoring",
+ "permit0-test-utils",
  "permit0-types",
  "regex",
  "serde",
@@ -1230,6 +1231,7 @@ dependencies = [
  "permit0-scoring",
  "permit0-session",
  "permit0-store",
+ "permit0-test-utils",
  "permit0-token",
  "permit0-types",
  "serde",
@@ -1337,6 +1339,10 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "permit0-test-utils"
+version = "0.1.0"
 
 [[package]]
 name = "permit0-token"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/permit0-py",
     "crates/permit0-node",
     "crates/permit0-shell-dispatch",
+    "crates/permit0-test-utils",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ permit0-cli = { path = "crates/permit0-cli", version = "0.1.0" }
 permit0-py = { path = "crates/permit0-py", version = "0.1.0" }
 permit0-node = { path = "crates/permit0-node", version = "0.1.0" }
 permit0-shell-dispatch = { path = "crates/permit0-shell-dispatch", version = "0.1.0" }
+permit0-test-utils = { path = "crates/permit0-test-utils", version = "0.1.0" }
 
 # Shell parsing
 shlex = "1"

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Packs are permit0's core extension unit. Each Pack = **normalizer** (standardiza
 |------|----------|-------------|------------|
 | `email` | All 15 email norm actions × Outlook + Gmail backends | 30 | 15 |
 
-The catalog declares **22 domains** total (`email`, `message`, `social`,
+The taxonomy declares **22 domains** total (`email`, `message`, `social`,
 `cms`, `newsletter`, `calendar`, `task`, `file`, `db`, `crm`, `payment`,
 `legal`, `iam`, `secret`, `infra`, `process`, `network`, `dev`, `browser`,
 `device`, `ai`, `unknown`). Only `email` ships with full normalizers and
@@ -594,7 +594,7 @@ session_rules:
       - upgrade: { dim: amount, delta: 6 }
 ```
 
-### Action Type Catalog (Selection)
+### Action Type Taxonomy (Selection)
 
 | Domain | Verbs | Notes |
 |--------|-------|-------|
@@ -769,7 +769,7 @@ permit0-core/
 │   ├── permit0-normalize       # Normalizer registry & matching
 │   ├── permit0-session         # Session context & pattern detection
 │   ├── permit0-store           # Storage layer (InMemory / SQLite)
-│   ├── permit0-types           # Shared types + action catalog
+│   ├── permit0-types           # Shared types + action taxonomy
 │   ├── permit0-token           # Biscuit capability tokens
 │   ├── permit0-agent           # LLM Agent reviewer
 │   ├── permit0-ui              # Web admin dashboard (axum)

--- a/crates/permit0-agent/src/types.rs
+++ b/crates/permit0-agent/src/types.rs
@@ -61,7 +61,7 @@ pub const MEDIUM_SCORE_SKIP_THRESHOLD: u32 = 52;
 /// Action types that always skip the reviewer and go straight to HUMAN.
 ///
 /// Strings here must match the canonical `Domain.Verb` form from
-/// permit0-types/catalog.rs (singular domain). `secret.get` covers the
+/// permit0-types/taxonomy.rs (singular domain). `secret.get` covers the
 /// retrieval path since the Secret domain does not expose a dedicated
 /// "read" verb.
 pub const ALWAYS_HUMAN_TYPES: &[&str] = &[

--- a/crates/permit0-dsl/Cargo.toml
+++ b/crates/permit0-dsl/Cargo.toml
@@ -16,3 +16,6 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 regex = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+permit0-test-utils = { workspace = true }

--- a/crates/permit0-dsl/src/validate.rs
+++ b/crates/permit0-dsl/src/validate.rs
@@ -398,8 +398,8 @@ session_rules: []
 
     #[test]
     fn valid_risk_rule_passes() {
-        let yaml = include_str!("../../../packs/email/risk_rules/send.yaml");
-        let def: RiskRuleDef = serde_yaml::from_str(yaml).unwrap();
+        let yaml = permit0_test_utils::load_test_fixture("packs/email/risk_rules/send.yaml");
+        let def: RiskRuleDef = serde_yaml::from_str(&yaml).unwrap();
         let errors = validate_risk_rule(&def);
         assert!(errors.is_empty(), "unexpected errors: {errors:?}");
     }

--- a/crates/permit0-dsl/tests/pack_integration.rs
+++ b/crates/permit0-dsl/tests/pack_integration.rs
@@ -5,6 +5,7 @@ use permit0_dsl::risk_executor::{execute_risk_rules, execute_session_rules};
 use permit0_dsl::schema::risk_rule::RiskRuleDef;
 use permit0_normalize::NormalizeCtx;
 use permit0_normalize::Normalizer;
+use permit0_test_utils::load_test_fixture;
 use permit0_types::RawToolCall;
 use serde_json::json;
 
@@ -18,13 +19,21 @@ fn load_risk_rule(yaml: &str) -> RiskRuleDef {
 
 // ── Email Pack ──
 
-const GMAIL_NORMALIZER: &str = include_str!("../../../packs/email/normalizers/gmail_send.yaml");
-const OUTLOOK_NORMALIZER: &str = include_str!("../../../packs/email/normalizers/outlook_send.yaml");
-const EMAIL_RISK_RULES: &str = include_str!("../../../packs/email/risk_rules/send.yaml");
+fn gmail_normalizer_yaml() -> String {
+    load_test_fixture("packs/email/normalizers/gmail_send.yaml")
+}
+
+fn outlook_normalizer_yaml() -> String {
+    load_test_fixture("packs/email/normalizers/outlook_send.yaml")
+}
+
+fn email_risk_yaml() -> String {
+    load_test_fixture("packs/email/risk_rules/send.yaml")
+}
 
 #[test]
 fn gmail_normalizes_send() {
-    let n = load_normalizer(GMAIL_NORMALIZER);
+    let n = load_normalizer(&gmail_normalizer_yaml());
     let raw = RawToolCall {
         tool_name: "gmail_send".into(),
         parameters: json!({
@@ -47,7 +56,7 @@ fn gmail_normalizes_send() {
 
 #[test]
 fn outlook_normalizes_send() {
-    let n = load_normalizer(OUTLOOK_NORMALIZER);
+    let n = load_normalizer(&outlook_normalizer_yaml());
     let raw = RawToolCall {
         tool_name: "outlook_send".into(),
         parameters: json!({
@@ -70,7 +79,7 @@ fn outlook_normalizes_send() {
 
 #[test]
 fn gmail_does_not_match_outlook_tool() {
-    let n = load_normalizer(GMAIL_NORMALIZER);
+    let n = load_normalizer(&gmail_normalizer_yaml());
     let raw = RawToolCall {
         tool_name: "outlook_send".into(),
         parameters: json!({"to": "x@y.com"}),
@@ -81,7 +90,7 @@ fn gmail_does_not_match_outlook_tool() {
 
 #[test]
 fn outlook_does_not_match_gmail_tool() {
-    let n = load_normalizer(OUTLOOK_NORMALIZER);
+    let n = load_normalizer(&outlook_normalizer_yaml());
     let raw = RawToolCall {
         tool_name: "gmail_send".into(),
         parameters: json!({"to": "x@y.com"}),
@@ -98,7 +107,7 @@ fn outlook_does_not_match_gmail_tool() {
 #[test]
 #[ignore = "pre-existing: pack scoring weights drifted, see TODO"]
 fn email_risk_confidential_subject() {
-    let rule = load_risk_rule(EMAIL_RISK_RULES);
+    let rule = load_risk_rule(&email_risk_yaml());
     let data = json!({
         "to": "bob@external.com",
         "subject": "confidential report Q4",
@@ -114,7 +123,7 @@ fn email_risk_confidential_subject() {
 #[test]
 #[ignore = "pre-existing: pack scoring weights drifted, see TODO above"]
 fn email_risk_credentials_in_body() {
-    let rule = load_risk_rule(EMAIL_RISK_RULES);
+    let rule = load_risk_rule(&email_risk_yaml());
     let data = json!({
         "to": "bob@external.com",
         "subject": "Hello",
@@ -132,7 +141,7 @@ fn email_risk_credentials_in_body() {
 #[test]
 #[ignore = "pre-existing: pack scoring weights drifted, see TODO above"]
 fn email_session_high_volume() {
-    let rule = load_risk_rule(EMAIL_RISK_RULES);
+    let rule = load_risk_rule(&email_risk_yaml());
     let data = json!({"to": "bob@external.com", "subject": "Hi", "body": "ok"});
     let mut template = execute_risk_rules(&rule, &data, None);
 

--- a/crates/permit0-engine/Cargo.toml
+++ b/crates/permit0-engine/Cargo.toml
@@ -25,3 +25,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
+
+[dev-dependencies]
+permit0-test-utils = { workspace = true }

--- a/crates/permit0-engine/src/engine.rs
+++ b/crates/permit0-engine/src/engine.rs
@@ -894,20 +894,19 @@ impl Default for EngineBuilder {
 mod tests {
     use super::*;
     use permit0_normalize::NormalizeCtx;
+    use permit0_test_utils::load_test_fixture;
     use serde_json::json;
 
-    const GMAIL_NORM_YAML: &str = include_str!("../../../packs/email/normalizers/gmail_send.yaml");
-    const OUTLOOK_NORM_YAML: &str =
-        include_str!("../../../packs/email/normalizers/outlook_send.yaml");
-    const EMAIL_RISK_YAML: &str = include_str!("../../../packs/email/risk_rules/send.yaml");
-
     fn build_test_engine() -> Engine {
+        let gmail_norm = load_test_fixture("packs/email/normalizers/gmail_send.yaml");
+        let outlook_norm = load_test_fixture("packs/email/normalizers/outlook_send.yaml");
+        let email_risk = load_test_fixture("packs/email/risk_rules/send.yaml");
         EngineBuilder::new()
-            .install_normalizer_yaml(GMAIL_NORM_YAML)
+            .install_normalizer_yaml(&gmail_norm)
             .unwrap()
-            .install_normalizer_yaml(OUTLOOK_NORM_YAML)
+            .install_normalizer_yaml(&outlook_norm)
             .unwrap()
-            .install_risk_rule_yaml(EMAIL_RISK_YAML)
+            .install_risk_rule_yaml(&email_risk)
             .unwrap()
             .build()
             .unwrap()
@@ -1134,12 +1133,15 @@ mod tests {
     fn build_test_engine_with_audit() -> (Engine, Arc<permit0_store::audit::InMemoryAuditSink>) {
         let signer = Arc::new(permit0_store::audit::Ed25519Signer::generate());
         let sink = Arc::new(permit0_store::audit::InMemoryAuditSink::new());
+        let gmail_norm = load_test_fixture("packs/email/normalizers/gmail_send.yaml");
+        let outlook_norm = load_test_fixture("packs/email/normalizers/outlook_send.yaml");
+        let email_risk = load_test_fixture("packs/email/risk_rules/send.yaml");
         let engine = EngineBuilder::new()
-            .install_normalizer_yaml(GMAIL_NORM_YAML)
+            .install_normalizer_yaml(&gmail_norm)
             .unwrap()
-            .install_normalizer_yaml(OUTLOOK_NORM_YAML)
+            .install_normalizer_yaml(&outlook_norm)
             .unwrap()
-            .install_risk_rule_yaml(EMAIL_RISK_YAML)
+            .install_risk_rule_yaml(&email_risk)
             .unwrap()
             .with_audit(sink.clone() as Arc<dyn AuditSink>, signer)
             .build()

--- a/crates/permit0-test-utils/Cargo.toml
+++ b/crates/permit0-test-utils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "permit0-test-utils"
+description = "Shared test fixture helpers for the permit0 workspace"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]

--- a/crates/permit0-test-utils/src/lib.rs
+++ b/crates/permit0-test-utils/src/lib.rs
@@ -1,0 +1,75 @@
+#![forbid(unsafe_code)]
+
+//! Shared test fixture loading for crates in the permit0 workspace.
+//!
+//! Replaces ad-hoc `include_str!("../../../packs/...")` paths that break
+//! silently whenever the `packs/` directory is reorganized (see PR 3 of the
+//! pack taxonomy refactor). Resolves paths relative to the workspace root
+//! using `CARGO_MANIFEST_DIR`, so any consuming crate gets the same
+//! behavior regardless of its depth in the workspace.
+
+use std::path::{Path, PathBuf};
+
+/// Absolute path to the workspace root.
+///
+/// Computed from this crate's manifest dir (`crates/permit0-test-utils/`),
+/// climbed two parents up. If the workspace ever stops being two levels
+/// deep, this needs to change.
+pub fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .unwrap_or(&manifest_dir)
+        .to_path_buf()
+}
+
+/// Load a fixture YAML (or any text file) from a workspace-relative path.
+///
+/// Panics with a clear message if the file is missing or unreadable. Tests
+/// should fail loudly when fixtures move.
+///
+/// # Examples
+///
+/// ```ignore
+/// use permit0_test_utils::load_test_fixture;
+/// let yaml = load_test_fixture("packs/email/normalizers/gmail_send.yaml");
+/// ```
+pub fn load_test_fixture(rel_path: &str) -> String {
+    let full = workspace_root().join(rel_path);
+    std::fs::read_to_string(&full).unwrap_or_else(|err| {
+        panic!(
+            "load_test_fixture: failed to read {} (workspace_root={}): {err}",
+            full.display(),
+            workspace_root().display(),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_root_contains_cargo_toml() {
+        let root = workspace_root();
+        assert!(
+            root.join("Cargo.toml").exists(),
+            "workspace_root() = {} should contain a Cargo.toml",
+            root.display()
+        );
+    }
+
+    #[test]
+    fn load_test_fixture_reads_existing_file() {
+        // Cargo.toml at workspace root is always present.
+        let content = load_test_fixture("Cargo.toml");
+        assert!(content.contains("[workspace]"));
+    }
+
+    #[test]
+    #[should_panic(expected = "load_test_fixture: failed to read")]
+    fn load_test_fixture_panics_on_missing() {
+        let _ = load_test_fixture("does/not/exist.yaml");
+    }
+}

--- a/crates/permit0-types/src/lib.rs
+++ b/crates/permit0-types/src/lib.rs
@@ -8,9 +8,9 @@ mod risk;
 mod taxonomy;
 mod tool_call;
 
-pub use taxonomy::{ALL_DOMAINS, ActionType, Domain, TaxonomyError, Verb, all_action_types};
 pub use decision::{DecisionFilter, DecisionRecord};
 pub use norm_action::{Entities, ExecutionMeta, NormAction, NormHash};
 pub use permission::Permission;
 pub use risk::{FlagRole, RiskScore, TIER_THRESHOLDS, Tier, to_risk_score};
+pub use taxonomy::{ALL_DOMAINS, ActionType, Domain, TaxonomyError, Verb, all_action_types};
 pub use tool_call::RawToolCall;

--- a/crates/permit0-types/src/lib.rs
+++ b/crates/permit0-types/src/lib.rs
@@ -1,14 +1,14 @@
 #![forbid(unsafe_code)]
 #![doc = "Shared types for the permit0 agent permission framework."]
 
-mod catalog;
 mod decision;
 mod norm_action;
 mod permission;
 mod risk;
+mod taxonomy;
 mod tool_call;
 
-pub use catalog::{ALL_DOMAINS, ActionType, CatalogError, Domain, Verb, all_action_types};
+pub use taxonomy::{ALL_DOMAINS, ActionType, CatalogError, Domain, Verb, all_action_types};
 pub use decision::{DecisionFilter, DecisionRecord};
 pub use norm_action::{Entities, ExecutionMeta, NormAction, NormHash};
 pub use permission::Permission;

--- a/crates/permit0-types/src/lib.rs
+++ b/crates/permit0-types/src/lib.rs
@@ -8,7 +8,7 @@ mod risk;
 mod taxonomy;
 mod tool_call;
 
-pub use taxonomy::{ALL_DOMAINS, ActionType, CatalogError, Domain, Verb, all_action_types};
+pub use taxonomy::{ALL_DOMAINS, ActionType, Domain, TaxonomyError, Verb, all_action_types};
 pub use decision::{DecisionFilter, DecisionRecord};
 pub use norm_action::{Entities, ExecutionMeta, NormAction, NormHash};
 pub use permission::Permission;

--- a/crates/permit0-types/src/norm_action.rs
+++ b/crates/permit0-types/src/norm_action.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::catalog::ActionType;
+use crate::taxonomy::ActionType;
 
 /// Opaque entity map — pack-defined fields.
 pub type Entities = serde_json::Map<String, serde_json::Value>;
@@ -14,11 +14,11 @@ pub type NormHash = [u8; 32];
 /// A structured, tool-agnostic representation of what an action *means*.
 /// This is the stable key used for risk rule lookup and caching.
 ///
-/// The `action_type` field is a validated `ActionType` from the closed catalog.
+/// The `action_type` field is a validated `ActionType` from the closed taxonomy.
 /// Normalizers MUST map to a known `domain.verb` pair — they cannot invent new ones.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NormAction {
-    /// Validated action type from the catalog (e.g. payments.charge).
+    /// Validated action type from the taxonomy (e.g. payments.charge).
     pub action_type: ActionType,
     /// Channel/vendor, e.g. "gmail", "stripe".
     pub channel: String,
@@ -36,12 +36,12 @@ pub struct ExecutionMeta {
 
 impl NormAction {
     /// Domain shorthand — delegates to `action_type.domain`.
-    pub fn domain(&self) -> crate::catalog::Domain {
+    pub fn domain(&self) -> crate::taxonomy::Domain {
         self.action_type.domain
     }
 
     /// Verb shorthand — delegates to `action_type.verb`.
-    pub fn verb(&self) -> crate::catalog::Verb {
+    pub fn verb(&self) -> crate::taxonomy::Verb {
         self.action_type.verb
     }
 
@@ -120,7 +120,7 @@ fn hex_prefix(hash: &[u8; 32]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::catalog::{Domain, Verb};
+    use crate::taxonomy::{Domain, Verb};
 
     fn test_action() -> NormAction {
         let mut entities = Entities::new();

--- a/crates/permit0-types/src/taxonomy.rs
+++ b/crates/permit0-types/src/taxonomy.rs
@@ -1,16 +1,16 @@
 #![forbid(unsafe_code)]
 
-//! The action catalog — the authoritative `domain.verb` taxonomy that all
-//! norm actions must conform to.
+//! The action taxonomy — the authoritative `domain.verb` classification that
+//! all norm actions must conform to.
 //!
 //! ## Domains
 //!
-//! Two tiers of detail in this catalog:
+//! Two tiers of detail in this taxonomy:
 //!
 //! - **`email`**: fully fleshed out (15 verbs), backed by real normalizers
 //!   and risk rules in `packs/email/`.
 //! - **All other domains**: declared as **placeholders** with a clean verb
-//!   list. They have no normalizers or risk rules yet — the catalog defines
+//!   list. They have no normalizers or risk rules yet — the taxonomy defines
 //!   the schema, future packs implement it.
 //!
 //! ## Verb design
@@ -29,7 +29,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-/// Domains in the action catalog.
+/// Domains in the action taxonomy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Domain {
@@ -300,7 +300,7 @@ impl fmt::Display for Domain {
     }
 }
 
-/// Verbs in the action catalog.
+/// Verbs in the action taxonomy.
 ///
 /// Generic verbs (`Get`, `List`, `Create`, `Update`, `Delete`, `Search`,
 /// `Move`, `Copy`, `Export`, `Send`, `Post`, `Schedule`, `Draft`) are
@@ -563,7 +563,7 @@ impl fmt::Display for Verb {
     }
 }
 
-/// A validated `domain.verb` pair from the action catalog.
+/// A validated `domain.verb` pair from the action taxonomy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ActionType {
     pub domain: Domain,
@@ -622,7 +622,7 @@ pub enum CatalogError {
     ParseError(String),
 }
 
-/// All domains in the catalog.
+/// All domains in the taxonomy.
 pub const ALL_DOMAINS: &[Domain] = &[
     Domain::Email,
     Domain::Message,
@@ -648,7 +648,7 @@ pub const ALL_DOMAINS: &[Domain] = &[
     Domain::Unknown,
 ];
 
-/// All verbs in the catalog (flat list, deduplicated).
+/// All verbs in the taxonomy (flat list, deduplicated).
 const ALL_VERBS: &[Verb] = &[
     // Generic CRUD + read
     Verb::Get,
@@ -769,7 +769,7 @@ const ALL_VERBS: &[Verb] = &[
     Verb::Unclassified,
 ];
 
-/// All valid `ActionType` entries in the catalog.
+/// All valid `ActionType` entries in the taxonomy.
 pub fn all_action_types() -> Vec<ActionType> {
     ALL_DOMAINS
         .iter()
@@ -861,7 +861,7 @@ mod tests {
         assert_eq!(all.len(), expected);
         assert!(
             all.len() > 100,
-            "catalog should have >100 entries, got {}",
+            "taxonomy should have >100 entries, got {}",
             all.len()
         );
     }

--- a/crates/permit0-types/src/taxonomy.rs
+++ b/crates/permit0-types/src/taxonomy.rs
@@ -572,11 +572,11 @@ pub struct ActionType {
 
 impl ActionType {
     /// Create a new ActionType, validating that the verb belongs to the domain.
-    pub fn new(domain: Domain, verb: Verb) -> Result<Self, CatalogError> {
+    pub fn new(domain: Domain, verb: Verb) -> Result<Self, TaxonomyError> {
         if domain.verbs().contains(&verb) {
             Ok(Self { domain, verb })
         } else {
-            Err(CatalogError::InvalidCombination { domain, verb })
+            Err(TaxonomyError::InvalidCombination { domain, verb })
         }
     }
 
@@ -586,14 +586,14 @@ impl ActionType {
     }
 
     /// Parse from a `domain.verb` string (e.g. "payment.charge").
-    pub fn parse(s: &str) -> Result<Self, CatalogError> {
+    pub fn parse(s: &str) -> Result<Self, TaxonomyError> {
         let (domain_str, verb_str) = s.split_once('.').ok_or_else(|| {
-            CatalogError::ParseError(format!("expected 'domain.verb', got '{s}'"))
+            TaxonomyError::ParseError(format!("expected 'domain.verb', got '{s}'"))
         })?;
         let domain = Domain::parse(domain_str)
-            .ok_or_else(|| CatalogError::UnknownDomain(domain_str.to_string()))?;
+            .ok_or_else(|| TaxonomyError::UnknownDomain(domain_str.to_string()))?;
         let verb =
-            Verb::parse(verb_str).ok_or_else(|| CatalogError::UnknownVerb(verb_str.to_string()))?;
+            Verb::parse(verb_str).ok_or_else(|| TaxonomyError::UnknownVerb(verb_str.to_string()))?;
         Self::new(domain, verb)
     }
 
@@ -611,7 +611,7 @@ impl fmt::Display for ActionType {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
-pub enum CatalogError {
+pub enum TaxonomyError {
     #[error("invalid combination: verb '{verb}' is not valid for domain '{domain}'")]
     InvalidCombination { domain: Domain, verb: Verb },
     #[error("unknown domain: '{0}'")]
@@ -810,7 +810,7 @@ mod tests {
         assert!(err.is_err());
         assert!(matches!(
             err.unwrap_err(),
-            CatalogError::InvalidCombination { .. }
+            TaxonomyError::InvalidCombination { .. }
         ));
     }
 
@@ -818,21 +818,21 @@ mod tests {
     fn parse_unknown_domain() {
         let err = ActionType::parse("foobar.send");
         assert!(err.is_err());
-        assert!(matches!(err.unwrap_err(), CatalogError::UnknownDomain(_)));
+        assert!(matches!(err.unwrap_err(), TaxonomyError::UnknownDomain(_)));
     }
 
     #[test]
     fn parse_unknown_verb() {
         let err = ActionType::parse("email.explode");
         assert!(err.is_err());
-        assert!(matches!(err.unwrap_err(), CatalogError::UnknownVerb(_)));
+        assert!(matches!(err.unwrap_err(), TaxonomyError::UnknownVerb(_)));
     }
 
     #[test]
     fn parse_no_dot() {
         let err = ActionType::parse("nodot");
         assert!(err.is_err());
-        assert!(matches!(err.unwrap_err(), CatalogError::ParseError(_)));
+        assert!(matches!(err.unwrap_err(), TaxonomyError::ParseError(_)));
     }
 
     #[test]

--- a/crates/permit0-types/src/taxonomy.rs
+++ b/crates/permit0-types/src/taxonomy.rs
@@ -592,8 +592,8 @@ impl ActionType {
         })?;
         let domain = Domain::parse(domain_str)
             .ok_or_else(|| TaxonomyError::UnknownDomain(domain_str.to_string()))?;
-        let verb =
-            Verb::parse(verb_str).ok_or_else(|| TaxonomyError::UnknownVerb(verb_str.to_string()))?;
+        let verb = Verb::parse(verb_str)
+            .ok_or_else(|| TaxonomyError::UnknownVerb(verb_str.to_string()))?;
         Self::new(domain, verb)
     }
 

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -1,8 +1,8 @@
-# NormAction Catalog
+# Action Type Taxonomy
 
 permit0 normalizes every tool call into a **NormAction** — a vendor-agnostic, policy-addressable representation of intent. Rules score, deny, allow, allowlist, or deny-list by NormAction, not by raw tool name — so a `Bash` call, an `http` call to Stripe, and a bank-pack `wire_transfer` all flow through the same set of policies.
 
-The canonical source of truth is `permit0_types::catalog` (see `crates/permit0-types/src/catalog.rs`). It defines **20 domains** × **~116 action_types**. Of those, this repo ships **10 with full packs** (normalizer + risk rule). The rest are declared — you can reference them in YAML and they'll parse fine — but they currently fall through to `HumanInTheLoop` because no risk rule exists yet.
+The canonical source of truth is `permit0_types::taxonomy` (see `crates/permit0-types/src/taxonomy.rs`). It defines **20 domains** × **~116 action_types**. Of those, this repo ships **10 with full packs** (normalizer + risk rule). The rest are declared — you can reference them in YAML and they'll parse fine — but they currently fall through to `HumanInTheLoop` because no risk rule exists yet.
 
 ## Anatomy of a NormAction
 
@@ -23,9 +23,9 @@ NormAction {
 - **`entities`** are what **rule `when` clauses** look at. They are normalized across tool surfaces — every shell tool extracts `command`, every write tool extracts `path` + `file_type`.
 - Rules can reference entities either directly (`command: { contains: "rm -rf" }`) or under the `entity.*` namespace (`entity.host: { not_in_set: "org.trusted_domains" }`). The `entity.*` form is preferred for normalizer-computed values.
 
-## Catalog Overview
+## Taxonomy Overview
 
-Legend: ✅ = pack shipped, 🟡 = catalog-declared, no pack yet (falls through to `HumanInTheLoop`).
+Legend: ✅ = pack shipped, 🟡 = taxonomy-declared, no pack yet (falls through to `HumanInTheLoop`).
 
 ### email — 9 verbs
 
@@ -399,7 +399,7 @@ Cross-pack, these entity keys are consistent, so rules written against one pack 
 
 ## What happens for declared-but-unpacked action_types?
 
-If you add a YAML rule referencing, say, `dev.deploy`, it parses — the catalog accepts it. But until someone ships a normalizer that produces `dev.deploy` and a risk rule scoring it, the engine path is:
+If you add a YAML rule referencing, say, `dev.deploy`, it parses — the taxonomy accepts it. But until someone ships a normalizer that produces `dev.deploy` and a risk rule scoring it, the engine path is:
 
 1. Raw tool call arrives.
 2. No normalizer matches → falls through to `ActionType::UNKNOWN` (= `unknown.unclassified`).
@@ -409,7 +409,7 @@ So declared-only action_types don't crash; they just bypass per-call scoring and
 
 ## Adding a new NormAction
 
-1. Pick a `domain.verb` pair from `permit0_types::catalog`. If nothing fits, add a new `Verb` variant to the enum (it's append-only and versioned).
+1. Pick a `domain.verb` pair from `permit0_types::taxonomy`. If nothing fits, add a new `Verb` variant to the enum (it's append-only and versioned).
 2. Add a normalizer YAML under `packs/<name>/normalizers/` with `match:` on the raw tool name + `normalize:` producing the action.
 3. Add a risk rule YAML under `packs/<name>/risk_rules/` with the same `action_type:`.
 4. Register both files in `packs/<name>/pack.yaml`.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -84,6 +84,6 @@ We will. For now everything is `pip install -e .` from this repo to make iterati
 ## Related docs
 
 - [`../README.md`](../README.md) — what permit0 is
-- [`../docs/norm_actions.md`](../docs/norm_actions.md) — the catalog of governed action types
+- [`../docs/taxonomy.md`](../docs/taxonomy.md) — the taxonomy of governed action types
 - [`../docs/dsl.md`](../docs/dsl.md) — pack / risk-rule authoring
 - [`../examples/`](../examples/) — single-file integration demos


### PR DESCRIPTION
## Summary

PR 1 of the pack taxonomy refactor (see [docs/design/pack-taxonomy-refactor.md](docs/design/pack-taxonomy-refactor.md)). Two pieces of foundation work that unblock PRs 2–5:

**Catalog → taxonomy rename:**
- `crates/permit0-types/src/catalog.rs` → `taxonomy.rs`
- `permit0_types::CatalogError` → `permit0_types::TaxonomyError`
- `docs/norm_actions/norm_actions.md` → `docs/taxonomy.md` (drop the nested directory)
- README headers: "Action Type Catalog" → "Action Type Taxonomy"

**Test fixture helper:**
- New `permit0-test-utils` crate exporting `load_test_fixture(rel_path)` that resolves paths via `CARGO_MANIFEST_DIR` from the workspace root.
- Replaces 7 `include_str!("../../../packs/...")` literals across 3 crates that would silently break when PR 3 reorganizes the `packs/` directory.

**Out of scope (per design doc):**
- `docs/permit.md` references "Catalog" extensively but is a forward-looking spec describing CLI subcommands (`permit0 catalog list/validate`) that don't exist yet. It will be revised as part of broader spec work.
- No SDK callers (permit0-py, permit0-node) reference `CatalogError` — verified via `grep -rn "CatalogError" --include='*.rs'`. The "minor bump + same-PR SDK update" plan from the eng review collapses to a no-op here.

## Bisectable commits

```
52ac99d style: rustfmt after rename
a438054 docs(readme): rename "Action Type Catalog" → "Action Type Taxonomy"
d8f3f57 docs: rename norm_actions.md → taxonomy.md, drop nested directory
da24742 refactor(types)!: rename CatalogError → TaxonomyError
66a3aa6 refactor(types): rename catalog.rs → taxonomy.rs
c8d1141 refactor(tests): replace 7 include_str! pack paths with load_test_fixture
352121f feat(test-utils): introduce permit0-test-utils crate
```

Each compiles and passes tests. Bisect-friendly.

## permit0-test-utils API

```rust
use permit0_test_utils::load_test_fixture;

let yaml = load_test_fixture("packs/email/normalizers/gmail_send.yaml");
```

Resolves from `CARGO_MANIFEST_DIR` of the test-utils crate, climbed two parents up to the workspace root. Panics with a clear message if the file is missing — fixtures going AWOL fail loudly, not silently. Three unit tests cover happy path, missing file, and workspace_root invariant.

## Sites converted

- `crates/permit0-engine/src/engine.rs` (3 const decls + 3 call sites in `build_test_engine_with_audit`)
- `crates/permit0-dsl/src/validate.rs::valid_risk_rule_passes`
- `crates/permit0-dsl/tests/pack_integration.rs` (3 const decls; replaced with helper functions)

## Test plan

- [x] `cargo check --workspace --all-targets` passes
- [x] `cargo test --workspace` passes (no failures; 3 pre-existing `#[ignore]` tests for pack scoring drift unchanged)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `permit0-test-utils` unit tests pass (workspace_root, fixture load, missing-file panic)
- [ ] CI on Ubuntu / macOS / Windows (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)