### PR TITLE
PR 2: schema v2 + discovery + manifest validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,6 +1250,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "permit0-dsl",
  "permit0-engine",
  "permit0-normalize",
  "permit0-scoring",
@@ -1276,6 +1277,7 @@ name = "permit0-py"
 version = "0.1.0"
 dependencies = [
  "permit0-agent",
+ "permit0-dsl",
  "permit0-engine",
  "permit0-normalize",
  "permit0-scoring",

--- a/crates/permit0-cli/src/cmd/pack.rs
+++ b/crates/permit0-cli/src/cmd/pack.rs
@@ -1,13 +1,18 @@
 #![forbid(unsafe_code)]
 
+use std::collections::BTreeSet;
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use permit0_dsl::normalizer::DslNormalizer;
+use permit0_dsl::pack_validate::{ViolationCode, validate_pack};
+use permit0_dsl::schema::PackManifest;
 use permit0_dsl::schema::risk_rule::RiskRuleDef;
 use permit0_dsl::validate;
 
-/// Validate all normalizer and risk rule YAML files in a pack directory.
+/// Validate all normalizer and risk rule YAML files in a pack directory,
+/// then run manifest-level checks (schema version, trust tier consistency,
+/// action-type coverage, orphans, security lint).
 pub fn validate(pack_path: &str) -> Result<()> {
     let pack_dir = Path::new(pack_path);
     if !pack_dir.exists() {
@@ -17,7 +22,9 @@ pub fn validate(pack_path: &str) -> Result<()> {
     let mut total_errors = 0;
     let mut total_files = 0;
 
-    // Validate normalizers
+    // Validate normalizers (also collect produced action types for the
+    // manifest-level coverage / orphan checks below).
+    let mut normalizer_action_types = BTreeSet::new();
     let normalizers_dir = pack_dir.join("normalizers");
     if normalizers_dir.exists() {
         let mut normalizer_defs = Vec::new();
@@ -42,6 +49,7 @@ pub fn validate(pack_path: &str) -> Result<()> {
                         }
                         total_errors += errors.len();
                     }
+                    normalizer_action_types.insert(n.def().normalize.action_type.clone());
                     normalizer_defs.push(n.def().clone());
                 }
                 Err(e) => {
@@ -59,7 +67,9 @@ pub fn validate(pack_path: &str) -> Result<()> {
         total_errors += dup_errors.len();
     }
 
-    // Validate risk rules
+    // Validate risk rules (collect (action_type, def) pairs for the
+    // manifest-level checks below).
+    let mut risk_rule_targets: Vec<(String, RiskRuleDef)> = Vec::new();
     let rules_dir = pack_dir.join("risk_rules");
     if rules_dir.exists() {
         for entry in std::fs::read_dir(&rules_dir)? {
@@ -83,11 +93,50 @@ pub fn validate(pack_path: &str) -> Result<()> {
                         }
                         total_errors += errors.len();
                     }
+                    risk_rule_targets.push((rule.action_type.clone(), rule));
                 }
                 Err(e) => {
                     println!("  ✗ {}: parse error: {e}", path.display());
                     total_errors += 1;
                 }
+            }
+        }
+    }
+
+    // ── Manifest-level checks (PR 2) ──
+    let manifest_path = pack_dir.join("pack.yaml");
+    if manifest_path.exists() {
+        let manifest_yaml = std::fs::read_to_string(&manifest_path)
+            .with_context(|| format!("reading {}", manifest_path.display()))?;
+        match serde_yaml::from_str::<PackManifest>(&manifest_yaml) {
+            Ok(manifest) => {
+                let violations =
+                    validate_pack(&manifest, &normalizer_action_types, &risk_rule_targets);
+                if !violations.is_empty() {
+                    println!("\n── Manifest-level checks ──");
+                }
+                for v in &violations {
+                    let icon = match v.code {
+                        // The orphan / coverage codes are surfacing pack.yaml
+                        // hygiene issues, but PR 3 closes the existing email
+                        // gaps (outlook list_drafts, list_drafts risk rule).
+                        // Until then, surface them as warnings rather than
+                        // hard errors so existing CI keeps passing.
+                        ViolationCode::MissingNormalizer
+                        | ViolationCode::MissingRiskRule
+                        | ViolationCode::OrphanNormalizer
+                        | ViolationCode::OrphanRiskRule => "⚠",
+                        _ => "✗",
+                    };
+                    println!("  {icon} pack.yaml: {} ({:?})", v.message, v.code);
+                    if icon == "✗" {
+                        total_errors += 1;
+                    }
+                }
+            }
+            Err(e) => {
+                println!("  ✗ {}: parse error: {e}", manifest_path.display());
+                total_errors += 1;
             }
         }
     }

--- a/crates/permit0-cli/src/engine_factory.rs
+++ b/crates/permit0-cli/src/engine_factory.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use permit0_dsl::discover_packs;
 use permit0_engine::EngineBuilder;
 use permit0_scoring::{Guardrails, ProfileOverrides, ScoringConfig};
 
@@ -20,11 +21,10 @@ pub fn build_engine_builder_from_packs(
 
     let resolved_dir = resolve_packs_dir(packs_dir);
     if let Some(dir) = &resolved_dir {
-        for entry in std::fs::read_dir(dir)? {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
-                builder = install_pack(builder, &entry.path())?;
-            }
+        let pack_dirs = discover_packs(dir)
+            .with_context(|| format!("discovering packs in {}", dir.display()))?;
+        for pack_dir in pack_dirs {
+            builder = install_pack(builder, &pack_dir)?;
         }
     }
 

--- a/crates/permit0-dsl/src/lib.rs
+++ b/crates/permit0-dsl/src/lib.rs
@@ -5,8 +5,10 @@ pub mod eval;
 pub mod helpers;
 pub mod normalizer;
 pub mod pack_loader;
+pub mod pack_validate;
 pub mod risk_executor;
 pub mod schema;
 pub mod validate;
 
 pub use pack_loader::{DiscoveryError, PACK_MANIFEST_FILENAME, discover_packs};
+pub use pack_validate::{ALWAYS_HUMAN_ACTION_TYPES, PackViolation, ViolationCode, validate_pack};

--- a/crates/permit0-dsl/src/lib.rs
+++ b/crates/permit0-dsl/src/lib.rs
@@ -4,6 +4,9 @@
 pub mod eval;
 pub mod helpers;
 pub mod normalizer;
+pub mod pack_loader;
 pub mod risk_executor;
 pub mod schema;
 pub mod validate;
+
+pub use pack_loader::{DiscoveryError, PACK_MANIFEST_FILENAME, discover_packs};

--- a/crates/permit0-dsl/src/pack_loader.rs
+++ b/crates/permit0-dsl/src/pack_loader.rs
@@ -129,11 +129,8 @@ mod tests {
     /// Make a tempdir-like scratch root inside CARGO_TARGET_TMPDIR so the
     /// test is hermetic and doesn't depend on `tempfile`.
     fn scratch(name: &str) -> PathBuf {
-        let base = std::env::temp_dir().join(format!(
-            "permit0-discover-{}-{}",
-            name,
-            std::process::id()
-        ));
+        let base =
+            std::env::temp_dir().join(format!("permit0-discover-{}-{}", name, std::process::id()));
         let _ = fs::remove_dir_all(&base);
         fs::create_dir_all(&base).unwrap();
         base
@@ -180,12 +177,12 @@ mod tests {
         // and signing infrastructure ship. Test pinned so the limit
         // is intentional, not accidental.
         let root = scratch("phase-two");
-        write(
-            &root.join("community/alice/jira/pack.yaml"),
-            "name: jira",
-        );
+        write(&root.join("community/alice/jira/pack.yaml"), "name: jira");
         let packs = discover_packs(&root).unwrap();
-        assert!(packs.is_empty(), "phase-2 community packs not yet discoverable");
+        assert!(
+            packs.is_empty(),
+            "phase-2 community packs not yet discoverable"
+        );
     }
 
     #[test]
@@ -213,10 +210,7 @@ mod tests {
     fn caps_depth_at_two() {
         let root = scratch("deep");
         // Depth 3: ignored.
-        write(
-            &root.join("a/b/c/pack.yaml"),
-            "name: too-deep",
-        );
+        write(&root.join("a/b/c/pack.yaml"), "name: too-deep");
         let packs = discover_packs(&root).unwrap();
         assert!(packs.is_empty());
     }

--- a/crates/permit0-dsl/src/pack_loader.rs
+++ b/crates/permit0-dsl/src/pack_loader.rs
@@ -1,0 +1,253 @@
+#![forbid(unsafe_code)]
+
+//! Pack discovery — walks a packs root and returns every directory that
+//! contains a `pack.yaml`.
+//!
+//! Two layouts are supported simultaneously:
+//!
+//! 1. **Flat (legacy / PR 2)**: `<root>/<pack>/pack.yaml`.
+//! 2. **Owner-namespaced (PR 3)**: `<root>/<owner>/<pack>/pack.yaml`.
+//!
+//! Discovery walks at most two levels deep. Anything further is ignored
+//! to bound the cost on cold start. Symlinks are followed but a
+//! per-walk cycle guard prevents runaway recursion.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Filename the discovery routine looks for at each candidate level.
+pub const PACK_MANIFEST_FILENAME: &str = "pack.yaml";
+
+/// Errors discovery can surface. Only `Io` is fatal at the call site;
+/// `MalformedRoot` is informational.
+#[derive(Debug, thiserror::Error)]
+pub enum DiscoveryError {
+    #[error("packs root not found: {0}")]
+    NotFound(PathBuf),
+    #[error("packs root is not a directory: {0}")]
+    NotADirectory(PathBuf),
+    #[error("io error reading {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Walk `<root>` and return every directory containing `pack.yaml`,
+/// up to two levels deep. Results are sorted by path for deterministic
+/// load order.
+///
+/// Layout precedence at each entry:
+/// - If `<root>/<entry>/pack.yaml` exists → emit `<root>/<entry>` (flat).
+/// - Otherwise, descend one level: `<root>/<entry>/<sub>/pack.yaml` →
+///   emit `<root>/<entry>/<sub>` (owner-namespaced).
+///
+/// The two layouts can coexist during the PR 3 migration window. After
+/// PR 3, packs/permit0/email/ will be the only shape in the repo, but
+/// `~/.permit0/packs/` may still hold flat third-party packs from older
+/// releases.
+pub fn discover_packs(root: impl AsRef<Path>) -> Result<Vec<PathBuf>, DiscoveryError> {
+    let root = root.as_ref();
+    if !root.exists() {
+        return Err(DiscoveryError::NotFound(root.to_path_buf()));
+    }
+    if !root.is_dir() {
+        return Err(DiscoveryError::NotADirectory(root.to_path_buf()));
+    }
+
+    let mut packs = Vec::new();
+    let mut seen = HashSet::new();
+    walk_level(root, 0, &mut packs, &mut seen)?;
+    packs.sort();
+    Ok(packs)
+}
+
+fn walk_level(
+    dir: &Path,
+    depth: u8,
+    out: &mut Vec<PathBuf>,
+    seen: &mut HashSet<PathBuf>,
+) -> Result<(), DiscoveryError> {
+    if depth > 1 {
+        return Ok(());
+    }
+    // Cycle guard for symlinked dirs.
+    let canon = std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
+    if !seen.insert(canon) {
+        return Ok(());
+    }
+
+    let entries = std::fs::read_dir(dir).map_err(|e| DiscoveryError::Io {
+        path: dir.to_path_buf(),
+        source: e,
+    })?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| DiscoveryError::Io {
+            path: dir.to_path_buf(),
+            source: e,
+        })?;
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        // Skip dotfiles and underscore-prefixed dirs (reserved for
+        // metadata like _channel.yaml, _template).
+        let basename = entry.file_name();
+        if let Some(s) = basename.to_str()
+            && (s.starts_with('.') || s.starts_with('_'))
+        {
+            continue;
+        }
+
+        if path.join(PACK_MANIFEST_FILENAME).is_file() {
+            // Flat or owner-namespaced terminal: emit and stop descending.
+            out.push(path);
+            continue;
+        }
+        // No pack.yaml here. Recurse one level deeper if we are still at
+        // the root (depth == 0). Pack manifests must live at depth 1
+        // (flat) or depth 2 (owner-namespaced); anything deeper is ignored.
+        if depth == 0 {
+            walk_level(&path, depth + 1, out, seen)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    /// Make a tempdir-like scratch root inside CARGO_TARGET_TMPDIR so the
+    /// test is hermetic and doesn't depend on `tempfile`.
+    fn scratch(name: &str) -> PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "permit0-discover-{}-{}",
+            name,
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        base
+    }
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn flat_layout_finds_packs() {
+        let root = scratch("flat");
+        write(&root.join("email/pack.yaml"), "name: email");
+        write(&root.join("slack/pack.yaml"), "name: slack");
+
+        let packs = discover_packs(&root).unwrap();
+        assert_eq!(packs.len(), 2);
+        assert!(packs.iter().any(|p| p.ends_with("email")));
+        assert!(packs.iter().any(|p| p.ends_with("slack")));
+    }
+
+    #[test]
+    fn owner_namespaced_layout_finds_packs() {
+        let root = scratch("owner-ns");
+        write(&root.join("permit0/email/pack.yaml"), "name: email");
+        write(&root.join("permit0/slack/pack.yaml"), "name: slack");
+        write(&root.join("anthropic/audit/pack.yaml"), "name: audit");
+
+        let packs = discover_packs(&root).unwrap();
+        assert_eq!(packs.len(), 3);
+        assert!(packs.iter().any(|p| p.ends_with("permit0/email")));
+        assert!(packs.iter().any(|p| p.ends_with("permit0/slack")));
+        assert!(packs.iter().any(|p| p.ends_with("anthropic/audit")));
+    }
+
+    #[test]
+    fn three_level_community_layout_is_phase_two() {
+        // Phase 2 layout `<root>/community/<author>/<pack>/pack.yaml`
+        // is depth 3. PR 2's discovery deliberately stops at depth 2 —
+        // the community sub-tree lights up when the federated registry
+        // and signing infrastructure ship. Test pinned so the limit
+        // is intentional, not accidental.
+        let root = scratch("phase-two");
+        write(
+            &root.join("community/alice/jira/pack.yaml"),
+            "name: jira",
+        );
+        let packs = discover_packs(&root).unwrap();
+        assert!(packs.is_empty(), "phase-2 community packs not yet discoverable");
+    }
+
+    #[test]
+    fn mixed_layouts_coexist() {
+        let root = scratch("mixed");
+        write(&root.join("email/pack.yaml"), "name: email"); // flat
+        write(&root.join("permit0/slack/pack.yaml"), "name: slack"); // owner-ns
+        let packs = discover_packs(&root).unwrap();
+        assert_eq!(packs.len(), 2);
+    }
+
+    #[test]
+    fn skips_underscore_and_dot_dirs() {
+        let root = scratch("skip");
+        write(&root.join("email/pack.yaml"), "name: email");
+        write(&root.join("_template/pack.yaml"), "name: template");
+        write(&root.join(".hidden/pack.yaml"), "name: hidden");
+
+        let packs = discover_packs(&root).unwrap();
+        assert_eq!(packs.len(), 1);
+        assert!(packs[0].ends_with("email"));
+    }
+
+    #[test]
+    fn caps_depth_at_two() {
+        let root = scratch("deep");
+        // Depth 3: ignored.
+        write(
+            &root.join("a/b/c/pack.yaml"),
+            "name: too-deep",
+        );
+        let packs = discover_packs(&root).unwrap();
+        assert!(packs.is_empty());
+    }
+
+    #[test]
+    fn missing_root_errors() {
+        let err = discover_packs("/definitely/not/a/real/path-9b27ce").unwrap_err();
+        matches!(err, DiscoveryError::NotFound(_));
+    }
+
+    #[test]
+    fn empty_root_yields_no_packs() {
+        let root = scratch("empty");
+        let packs = discover_packs(&root).unwrap();
+        assert!(packs.is_empty());
+    }
+
+    #[test]
+    fn results_are_sorted_for_determinism() {
+        let root = scratch("sorted");
+        write(&root.join("zeta/pack.yaml"), "");
+        write(&root.join("alpha/pack.yaml"), "");
+        write(&root.join("permit0/middle/pack.yaml"), "");
+
+        let packs = discover_packs(&root).unwrap();
+        let names: Vec<_> = packs
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+}

--- a/crates/permit0-dsl/src/pack_validate.rs
+++ b/crates/permit0-dsl/src/pack_validate.rs
@@ -1,0 +1,530 @@
+#![forbid(unsafe_code)]
+
+//! Manifest-level pack validation.
+//!
+//! Per-file validation (normalizer YAML, risk rule YAML) lives in the
+//! pre-existing [`crate::validate`] module. This module checks the
+//! manifest itself plus cross-pack invariants that span the manifest
+//! and the filesystem:
+//!
+//! - Schema version (`pack_format: 2`).
+//! - Trust tier consistency (declared vs derived).
+//! - Action type taxonomy compliance (every entry is a real `domain.verb`).
+//! - Coverage (every action type has a normalizer + a risk rule).
+//! - Orphans (every normalizer / risk rule maps to a listed action type).
+//! - Security lint (no `allow` rule on critical action types).
+//!
+//! The validator returns a list of [`PackViolation`] rather than panicking
+//! so all problems surface in one pass — useful for CI output.
+
+use std::collections::BTreeSet;
+
+use crate::schema::pack::{
+    PACK_FORMAT_VERSION, PackManifest, TrustTier, derive_trust_tier, extract_owner,
+};
+use crate::schema::risk_rule::{MutationDef, RiskRuleDef, RuleDef, SessionRuleDef};
+use permit0_types::ActionType;
+
+/// Action types that MUST NOT carry an `allow` decision in any rule.
+/// These are bypass-class operations: their security impact is high
+/// enough that the engine should always require human-in-the-loop or
+/// explicit policy override, regardless of pack tier.
+///
+/// Maintained as a flat list rather than per-domain because the set is
+/// small and one-off; if it grows, restructure into a `BTreeMap<Domain, &[Verb]>`.
+pub const ALWAYS_HUMAN_ACTION_TYPES: &[&str] = &[
+    "email.set_forwarding",
+    "email.add_delegate",
+    "iam.create",
+    "iam.delete",
+    "iam.assign_role",
+    "iam.revoke_role",
+    "iam.reset_password",
+    "iam.generate_api_key",
+    "secret.get",
+    "secret.create",
+    "secret.update",
+    "secret.rotate",
+    "payment.charge",
+    "payment.transfer",
+    "payment.refund",
+];
+
+/// One violation produced by [`validate_pack`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackViolation {
+    pub code: ViolationCode,
+    pub message: String,
+}
+
+/// Categorical code for a violation. Stable identifier so CI can opt
+/// individual checks in or out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViolationCode {
+    /// `pack_format` is missing or not equal to the supported version.
+    SchemaVersion,
+    /// `vendor` field is set in a v2 manifest (dropped in schema v2).
+    LegacyVendorField,
+    /// `permit0_pack` is missing the `<owner>/<name>` slash separator.
+    MalformedPermit0Pack,
+    /// Self-declared `trust_tier` disagrees with the value derived from owner.
+    TrustTierMismatch,
+    /// An entry in `action_types:` is not a recognized `domain.verb` from
+    /// the action taxonomy.
+    UnknownActionType,
+    /// An action type listed in `action_types:` has no normalizer mapping
+    /// to it.
+    MissingNormalizer,
+    /// An action type listed in `action_types:` has no risk rule scoring it.
+    MissingRiskRule,
+    /// A normalizer maps to an action type not listed in the pack's
+    /// `action_types:`.
+    OrphanNormalizer,
+    /// A risk rule scores an action type not listed in the pack's
+    /// `action_types:`.
+    OrphanRiskRule,
+    /// A rule for a critical action type
+    /// (see [`ALWAYS_HUMAN_ACTION_TYPES`]) lacks any `gate` mutation
+    /// across both `rules` and `session_rules`. Critical actions must
+    /// require explicit human review; gateless rules can let the engine
+    /// auto-approve based on score alone.
+    MissingGateOnCriticalAction,
+}
+
+/// Run every manifest-level check and return a flat list of violations.
+///
+/// `normalizer_action_types` is the set of action types produced by the
+/// pack's normalizers (extracted from each normalizer's
+/// `produces.action_type` field).
+///
+/// `risk_rule_targets` is the list of (action_type, rule_def) pairs from
+/// the pack's risk rules.
+///
+/// Both are passed in by the caller so this module stays IO-free; the
+/// CLI subcommand handles loading.
+pub fn validate_pack(
+    manifest: &PackManifest,
+    normalizer_action_types: &BTreeSet<String>,
+    risk_rule_targets: &[(String, RiskRuleDef)],
+) -> Vec<PackViolation> {
+    let mut out = Vec::new();
+    check_schema_version(manifest, &mut out);
+    check_legacy_vendor(manifest, &mut out);
+    check_trust_tier(manifest, &mut out);
+    check_action_types_taxonomy(manifest, &mut out);
+    check_coverage(
+        manifest,
+        normalizer_action_types,
+        risk_rule_targets,
+        &mut out,
+    );
+    check_orphans(
+        manifest,
+        normalizer_action_types,
+        risk_rule_targets,
+        &mut out,
+    );
+    check_security_lint(risk_rule_targets, &mut out);
+    out
+}
+
+fn check_schema_version(m: &PackManifest, out: &mut Vec<PackViolation>) {
+    match m.pack_format {
+        Some(v) if v == PACK_FORMAT_VERSION => {}
+        Some(v) => out.push(PackViolation {
+            code: ViolationCode::SchemaVersion,
+            message: format!(
+                "pack_format: {v} is not supported; expected {PACK_FORMAT_VERSION}"
+            ),
+        }),
+        None => out.push(PackViolation {
+            code: ViolationCode::SchemaVersion,
+            message: format!(
+                "pack_format is missing; v2 manifests must declare `pack_format: {PACK_FORMAT_VERSION}`"
+            ),
+        }),
+    }
+}
+
+fn check_legacy_vendor(m: &PackManifest, out: &mut Vec<PackViolation>) {
+    if m.vendor.is_some() {
+        out.push(PackViolation {
+            code: ViolationCode::LegacyVendorField,
+            message:
+                "`vendor:` field is removed in schema v2; owner is derived from `permit0_pack:`"
+                    .to_string(),
+        });
+    }
+}
+
+fn check_trust_tier(m: &PackManifest, out: &mut Vec<PackViolation>) {
+    let Some(owner) = extract_owner(&m.permit0_pack) else {
+        out.push(PackViolation {
+            code: ViolationCode::MalformedPermit0Pack,
+            message: format!(
+                "permit0_pack: \"{}\" must be \"<owner>/<name>\"",
+                m.permit0_pack
+            ),
+        });
+        return;
+    };
+    let derived = derive_trust_tier(owner);
+    if let Some(declared) = m.trust_tier
+        && declared != derived
+    {
+        out.push(PackViolation {
+            code: ViolationCode::TrustTierMismatch,
+            message: format!(
+                "declared trust_tier: {declared:?} disagrees with derived: {derived:?} (owner=\"{owner}\")"
+            ),
+        });
+    }
+    // Phase 2 tiers cannot be derived in Phase 1 — flag any pack that
+    // self-attests to one. The mismatch above already catches owner=permit0
+    // declaring Verified/Experimental; this catches non-permit0 owners
+    // declaring Verified/Experimental too.
+    if matches!(
+        m.trust_tier,
+        Some(TrustTier::Verified | TrustTier::Experimental)
+    ) {
+        out.push(PackViolation {
+            code: ViolationCode::TrustTierMismatch,
+            message: "trust_tier: verified/experimental requires Phase 2 signing infrastructure"
+                .to_string(),
+        });
+    }
+}
+
+fn check_action_types_taxonomy(m: &PackManifest, out: &mut Vec<PackViolation>) {
+    for at in &m.action_types {
+        if ActionType::parse(at).is_err() {
+            out.push(PackViolation {
+                code: ViolationCode::UnknownActionType,
+                message: format!(
+                    "action_types entry \"{at}\" is not a valid `domain.verb` from the taxonomy"
+                ),
+            });
+        }
+    }
+}
+
+fn check_coverage(
+    m: &PackManifest,
+    normalizer_action_types: &BTreeSet<String>,
+    risk_rule_targets: &[(String, RiskRuleDef)],
+    out: &mut Vec<PackViolation>,
+) {
+    let risk_targets: BTreeSet<&str> = risk_rule_targets
+        .iter()
+        .map(|(at, _)| at.as_str())
+        .collect();
+
+    for at in &m.action_types {
+        if !normalizer_action_types.contains(at) {
+            out.push(PackViolation {
+                code: ViolationCode::MissingNormalizer,
+                message: format!("action_types lists \"{at}\" but no normalizer produces it"),
+            });
+        }
+        if !risk_targets.contains(at.as_str()) {
+            out.push(PackViolation {
+                code: ViolationCode::MissingRiskRule,
+                message: format!("action_types lists \"{at}\" but no risk rule covers it"),
+            });
+        }
+    }
+}
+
+fn check_orphans(
+    m: &PackManifest,
+    normalizer_action_types: &BTreeSet<String>,
+    risk_rule_targets: &[(String, RiskRuleDef)],
+    out: &mut Vec<PackViolation>,
+) {
+    let listed: BTreeSet<&str> = m.action_types.iter().map(String::as_str).collect();
+
+    for at in normalizer_action_types {
+        if !listed.contains(at.as_str()) {
+            out.push(PackViolation {
+                code: ViolationCode::OrphanNormalizer,
+                message: format!(
+                    "normalizer produces \"{at}\" but it's not listed in action_types"
+                ),
+            });
+        }
+    }
+    for (at, _) in risk_rule_targets {
+        if !listed.contains(at.as_str()) {
+            out.push(PackViolation {
+                code: ViolationCode::OrphanRiskRule,
+                message: format!("risk rule covers \"{at}\" but it's not listed in action_types"),
+            });
+        }
+    }
+}
+
+fn check_security_lint(risk_rule_targets: &[(String, RiskRuleDef)], out: &mut Vec<PackViolation>) {
+    let critical: BTreeSet<&str> = ALWAYS_HUMAN_ACTION_TYPES.iter().copied().collect();
+    for (at, rule) in risk_rule_targets {
+        if !critical.contains(at.as_str()) {
+            continue;
+        }
+        if !rule_has_gate(rule) {
+            out.push(PackViolation {
+                code: ViolationCode::MissingGateOnCriticalAction,
+                message: format!(
+                    "risk rule for critical action \"{at}\" must include at least one `gate:` \
+                     mutation (across `rules` or `session_rules`); without one, the engine can \
+                     auto-approve from score alone"
+                ),
+            });
+        }
+    }
+}
+
+/// Returns true if the risk rule contains at least one `Gate` mutation
+/// anywhere in its `rules` or `session_rules` `then:` blocks.
+fn rule_has_gate(rule: &RiskRuleDef) -> bool {
+    rule.rules.iter().any(rule_branch_has_gate)
+        || rule.session_rules.iter().any(session_branch_has_gate)
+}
+
+fn rule_branch_has_gate(branch: &RuleDef) -> bool {
+    branch.then.iter().any(mutation_is_gate)
+}
+
+fn session_branch_has_gate(branch: &SessionRuleDef) -> bool {
+    branch.then.iter().any(mutation_is_gate)
+}
+
+fn mutation_is_gate(m: &MutationDef) -> bool {
+    matches!(m, MutationDef::Gate { .. })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_manifest() -> PackManifest {
+        PackManifest {
+            pack_format: Some(2),
+            name: "email".into(),
+            version: "0.3.0".into(),
+            permit0_pack: "permit0/email".into(),
+            description: None,
+            homepage: None,
+            license: None,
+            permit0_engine: None,
+            taxonomy: None,
+            action_types: vec![],
+            maintainers: vec![],
+            channels: Default::default(),
+            trust_tier: None,
+            signature: None,
+            provenance: None,
+            content_hash: None,
+            normalizers: vec![],
+            risk_rules: vec![],
+            vendor: None,
+            min_engine_version: None,
+        }
+    }
+
+    #[test]
+    fn minimal_v2_passes() {
+        let m = minimal_manifest();
+        let v = validate_pack(&m, &BTreeSet::new(), &[]);
+        assert!(v.is_empty(), "expected zero violations, got: {v:#?}");
+    }
+
+    #[test]
+    fn missing_pack_format_fails() {
+        let mut m = minimal_manifest();
+        m.pack_format = None;
+        let v = validate_pack(&m, &BTreeSet::new(), &[]);
+        assert!(v.iter().any(|x| x.code == ViolationCode::SchemaVersion));
+    }
+
+    #[test]
+    fn wrong_pack_format_fails() {
+        let mut m = minimal_manifest();
+        m.pack_format = Some(1);
+        let v = validate_pack(&m, &BTreeSet::new(), &[]);
+        assert!(v.iter().any(|x| x.code == ViolationCode::SchemaVersion));
+    }
+
+    #[test]
+    fn legacy_vendor_field_flagged() {
+        let mut m = minimal_manifest();
+        m.vendor = Some("permit0".into());
+        let v = validate_pack(&m, &BTreeSet::new(), &[]);
+        assert!(v.iter().any(|x| x.code == ViolationCode::LegacyVendorField));
+    }
+
+    #[test]
+    fn malformed_permit0_pack_flagged() {
+        let mut m = minimal_manifest();
+        m.permit0_pack = "no-slash".into();
+        let v = validate_pack(&m, &BTreeSet::new(), &[]);
+        assert!(
+            v.iter()
+                .any(|x| x.code == ViolationCode::MalformedPermit0Pack)
+        );
+    }
+
+    #[test]
+    fn declared_built_in_for_non_permit0_owner_flagged() {
+        let mut m = minimal_manifest();
+        m.permit0_pack = "alice/jira".into();
+        m.trust_tier = Some(TrustTier::BuiltIn);
+        let v = validate_pack(&m, &BTreeSet::new(), &[]);
+        assert!(v.iter().any(|x| x.code == ViolationCode::TrustTierMismatch));
+    }
+
+    #[test]
+    fn declared_verified_phase_two_flagged() {
+        let mut m = minimal_manifest();
+        m.trust_tier = Some(TrustTier::Verified);
+        let v = validate_pack(&m, &BTreeSet::new(), &[]);
+        assert!(v.iter().any(|x| x.code == ViolationCode::TrustTierMismatch));
+    }
+
+    #[test]
+    fn unknown_action_type_flagged() {
+        let mut m = minimal_manifest();
+        m.action_types = vec!["bogus.invented".into()];
+        let v = validate_pack(&m, &BTreeSet::new(), &[]);
+        assert!(v.iter().any(|x| x.code == ViolationCode::UnknownActionType));
+    }
+
+    #[test]
+    fn missing_normalizer_flagged() {
+        let mut m = minimal_manifest();
+        m.action_types = vec!["email.send".into()];
+        // No normalizer; risk rule present.
+        let mut risk = sample_risk_rule("email.send");
+        risk.permit0_pack = "permit0/email".into();
+        let v = validate_pack(&m, &BTreeSet::new(), &[("email.send".into(), risk)]);
+        assert!(v.iter().any(|x| x.code == ViolationCode::MissingNormalizer));
+    }
+
+    #[test]
+    fn missing_risk_rule_flagged() {
+        let mut m = minimal_manifest();
+        m.action_types = vec!["email.send".into()];
+        let mut norms = BTreeSet::new();
+        norms.insert("email.send".to_string());
+        let v = validate_pack(&m, &norms, &[]);
+        assert!(v.iter().any(|x| x.code == ViolationCode::MissingRiskRule));
+    }
+
+    #[test]
+    fn orphan_normalizer_flagged() {
+        let m = minimal_manifest(); // action_types is empty
+        let mut norms = BTreeSet::new();
+        norms.insert("email.send".to_string());
+        let v = validate_pack(&m, &norms, &[]);
+        assert!(v.iter().any(|x| x.code == ViolationCode::OrphanNormalizer));
+    }
+
+    #[test]
+    fn orphan_risk_rule_flagged() {
+        let m = minimal_manifest();
+        let v = validate_pack(
+            &m,
+            &BTreeSet::new(),
+            &[("email.send".into(), sample_risk_rule("email.send"))],
+        );
+        assert!(v.iter().any(|x| x.code == ViolationCode::OrphanRiskRule));
+    }
+
+    #[test]
+    fn security_lint_flags_critical_action_without_gate() {
+        let mut m = minimal_manifest();
+        m.action_types = vec!["email.set_forwarding".into()];
+        let mut norms = BTreeSet::new();
+        norms.insert("email.set_forwarding".to_string());
+
+        // A rule with no Gate mutation anywhere — should be flagged.
+        let rule = gateless_risk_rule("email.set_forwarding");
+        let v = validate_pack(&m, &norms, &[("email.set_forwarding".into(), rule)]);
+        assert!(
+            v.iter()
+                .any(|x| x.code == ViolationCode::MissingGateOnCriticalAction),
+            "expected MissingGateOnCriticalAction, got: {v:#?}"
+        );
+    }
+
+    #[test]
+    fn security_lint_passes_when_critical_action_has_gate() {
+        let mut m = minimal_manifest();
+        m.action_types = vec!["email.set_forwarding".into()];
+        let mut norms = BTreeSet::new();
+        norms.insert("email.set_forwarding".to_string());
+
+        // A rule with a Gate mutation in `rules:` should not trip the lint.
+        let rule = risk_rule_with_gate("email.set_forwarding");
+        let v = validate_pack(&m, &norms, &[("email.set_forwarding".into(), rule)]);
+        assert!(
+            !v.iter()
+                .any(|x| x.code == ViolationCode::MissingGateOnCriticalAction),
+            "did not expect MissingGateOnCriticalAction, got: {v:#?}"
+        );
+    }
+
+    #[test]
+    fn security_lint_ignores_non_critical_action_types() {
+        // email.search is not on the always-human list, so missing gate
+        // is fine.
+        let mut m = minimal_manifest();
+        m.action_types = vec!["email.search".into()];
+        let mut norms = BTreeSet::new();
+        norms.insert("email.search".to_string());
+
+        let rule = gateless_risk_rule("email.search");
+        let v = validate_pack(&m, &norms, &[("email.search".into(), rule)]);
+        assert!(
+            !v.iter()
+                .any(|x| x.code == ViolationCode::MissingGateOnCriticalAction)
+        );
+    }
+
+    fn sample_risk_rule(action_type: &str) -> RiskRuleDef {
+        gateless_risk_rule(action_type)
+    }
+
+    fn gateless_risk_rule(action_type: &str) -> RiskRuleDef {
+        let yaml = format!(
+            r#"
+permit0_pack: "permit0/email"
+action_type: "{action_type}"
+base:
+  flags: {{}}
+  amplifiers: {{}}
+rules: []
+session_rules: []
+"#
+        );
+        serde_yaml::from_str(&yaml).expect("valid risk rule")
+    }
+
+    fn risk_rule_with_gate(action_type: &str) -> RiskRuleDef {
+        let yaml = format!(
+            r#"
+permit0_pack: "permit0/email"
+action_type: "{action_type}"
+base:
+  flags: {{}}
+  amplifiers: {{}}
+rules:
+  - when:
+      destination:
+        exists: true
+    then:
+      - gate: "human_review"
+session_rules: []
+"#
+        );
+        serde_yaml::from_str(&yaml).expect("valid risk rule")
+    }
+}

--- a/crates/permit0-dsl/src/schema/mod.rs
+++ b/crates/permit0-dsl/src/schema/mod.rs
@@ -7,7 +7,7 @@ pub mod risk_rule;
 
 pub use condition::{AnyMatch, ConditionExpr, Predicate, PredicateOps, UrlMatch};
 pub use normalizer::{ApiVersionDef, EntityDef, NormalizeDef, NormalizerDef};
-pub use pack::PackManifest;
+pub use pack::{ChannelMeta, Maintainer, PACK_FORMAT_VERSION, PackManifest, TrustTierDecl};
 pub use risk_rule::{
     AddFlagDef, DimDeltaDef, DimValueDef, MutationDef, RiskBaseDef, RiskRuleDef, RuleDef,
     SessionRuleDef, SplitDef,

--- a/crates/permit0-dsl/src/schema/mod.rs
+++ b/crates/permit0-dsl/src/schema/mod.rs
@@ -7,7 +7,10 @@ pub mod risk_rule;
 
 pub use condition::{AnyMatch, ConditionExpr, Predicate, PredicateOps, UrlMatch};
 pub use normalizer::{ApiVersionDef, EntityDef, NormalizeDef, NormalizerDef};
-pub use pack::{ChannelMeta, Maintainer, PACK_FORMAT_VERSION, PackManifest, TrustTierDecl};
+pub use pack::{
+    ChannelMeta, Maintainer, PACK_FORMAT_VERSION, PackManifest, TrustTier, derive_trust_tier,
+    extract_owner,
+};
 pub use risk_rule::{
     AddFlagDef, DimDeltaDef, DimValueDef, MutationDef, RiskBaseDef, RiskRuleDef, RuleDef,
     SessionRuleDef, SplitDef,

--- a/crates/permit0-dsl/src/schema/pack.rs
+++ b/crates/permit0-dsl/src/schema/pack.rs
@@ -51,11 +51,12 @@ pub struct PackManifest {
     pub channels: std::collections::BTreeMap<String, ChannelMeta>,
 
     /// Self-declared trust tier. **Informational only** — the engine
-    /// derives the authoritative tier from path (and, in Phase 2, signature).
-    /// A community pack declaring `trust_tier: built-in` does not become
-    /// built-in; the validator flags the mismatch.
+    /// derives the authoritative tier from `permit0_pack`'s owner prefix
+    /// (and, in Phase 2, signature). A community pack declaring
+    /// `trust_tier: built-in` does not become built-in; the validator
+    /// flags the mismatch.
     #[serde(default)]
-    pub trust_tier: Option<TrustTierDecl>,
+    pub trust_tier: Option<TrustTier>,
 
     /// Phase 2 forward-compat: signature over the pack's lockfile + manifest.
     /// Reserved; empty in Phase 1.
@@ -113,15 +114,54 @@ pub struct ChannelMeta {
     pub display_name: Option<String>,
 }
 
-/// Self-declared trust tier values accepted in `pack.yaml`. Engine derives
-/// the *authoritative* tier independently; this declaration is informational.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+/// Authoritative pack trust tier.
+///
+/// Distinct from `permit0_types::Tier` (the per-decision risk tier) — that
+/// classifies *requests* on a confidence scale, this classifies *packs* on
+/// a trust scale.
+///
+/// Used in two roles:
+/// - As an `Option<TrustTier>` in `PackManifest::trust_tier`: the *declared*
+///   value, informational only.
+/// - As the return value of [`derive_trust_tier`]: the *authoritative* value
+///   the engine uses for trust decisions.
+///
+/// Validators compare the declared and derived values and flag mismatches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum TrustTierDecl {
+pub enum TrustTier {
+    /// Maintained by the permit0 core team. Path: `packs/permit0/*`.
     BuiltIn,
+    /// Community-maintained, permit0-co-signed. Phase 2 (requires signing infra).
     Verified,
+    /// Community-maintained, no co-sign. Default for non-permit0 owners in Phase 1.
     Community,
+    /// Hidden by default; opt-in to install. Phase 2.
     Experimental,
+}
+
+/// Derive the authoritative trust tier from a pack's owner.
+///
+/// Phase 1 implementation:
+/// - `owner == "permit0"` → `TrustTier::BuiltIn`
+/// - everything else → `TrustTier::Community`
+///
+/// Phase 2 will extend this to consult the lockfile signature and the
+/// federated registry. Until then, `Verified` and `Experimental` are
+/// unreachable via derivation — packs declaring them are flagged by the
+/// validator.
+pub fn derive_trust_tier(owner: &str) -> TrustTier {
+    if owner == "permit0" {
+        TrustTier::BuiltIn
+    } else {
+        TrustTier::Community
+    }
+}
+
+/// Owner extracted from a `permit0_pack` manifest field (`<owner>/<name>`).
+/// Returns `None` if the field is missing the slash separator.
+pub fn extract_owner(permit0_pack: &str) -> Option<&str> {
+    permit0_pack.split_once('/').map(|(o, _)| o)
 }
 
 /// Current pack manifest schema version. Bump on breaking schema changes.
@@ -174,7 +214,7 @@ content_hash: ""
 "#;
         let m: PackManifest = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(m.pack_format, Some(2));
-        assert_eq!(m.trust_tier, Some(TrustTierDecl::BuiltIn));
+        assert_eq!(m.trust_tier, Some(TrustTier::BuiltIn));
         assert_eq!(m.channels.len(), 2);
         assert_eq!(
             m.channels.get("gmail").and_then(|c| c.mcp_server.as_deref()),
@@ -215,5 +255,41 @@ trust_tier: gold-plated
         let err = serde_yaml::from_str::<PackManifest>(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("gold-plated") || msg.contains("variant"));
+    }
+
+    #[test]
+    fn extracts_owner_from_permit0_pack() {
+        assert_eq!(extract_owner("permit0/email"), Some("permit0"));
+        assert_eq!(extract_owner("anthropic/audit"), Some("anthropic"));
+        assert_eq!(extract_owner("bad-no-slash"), None);
+        assert_eq!(extract_owner(""), None);
+    }
+
+    #[test]
+    fn derive_trust_tier_classifies_owners() {
+        assert_eq!(derive_trust_tier("permit0"), TrustTier::BuiltIn);
+        assert_eq!(derive_trust_tier("anthropic"), TrustTier::Community);
+        assert_eq!(derive_trust_tier("alice"), TrustTier::Community);
+        assert_eq!(derive_trust_tier(""), TrustTier::Community);
+    }
+
+    #[test]
+    fn declared_tier_can_disagree_with_derived() {
+        // Manifest declares built-in but owner is "alice" → derived is community.
+        // The validator (separate module) will flag this as a self-attestation
+        // mismatch. The derive function always returns the authoritative value.
+        let yaml = r#"
+pack_format: 2
+name: jira
+version: "0.1.0"
+permit0_pack: "alice/jira"
+trust_tier: built-in
+"#;
+        let m: PackManifest = serde_yaml::from_str(yaml).unwrap();
+        let owner = extract_owner(&m.permit0_pack).unwrap();
+        let derived = derive_trust_tier(owner);
+        assert_eq!(m.trust_tier, Some(TrustTier::BuiltIn));
+        assert_eq!(derived, TrustTier::Community);
+        assert_ne!(m.trust_tier.unwrap(), derived);
     }
 }

--- a/crates/permit0-dsl/src/schema/pack.rs
+++ b/crates/permit0-dsl/src/schema/pack.rs
@@ -217,7 +217,9 @@ content_hash: ""
         assert_eq!(m.trust_tier, Some(TrustTier::BuiltIn));
         assert_eq!(m.channels.len(), 2);
         assert_eq!(
-            m.channels.get("gmail").and_then(|c| c.mcp_server.as_deref()),
+            m.channels
+                .get("gmail")
+                .and_then(|c| c.mcp_server.as_deref()),
             Some("clients/gmail-mcp")
         );
         assert_eq!(m.action_types, vec!["email.send", "email.archive"]);

--- a/crates/permit0-dsl/src/schema/pack.rs
+++ b/crates/permit0-dsl/src/schema/pack.rs
@@ -3,20 +3,217 @@
 use serde::Deserialize;
 
 /// Pack manifest — `pack.yaml` at the root of a pack directory.
+///
+/// Schema v2 (introduced in PR 2 of the pack taxonomy refactor). The
+/// engine refuses to load any pack with `pack_format != Some(2)`. The
+/// previous schema (no `pack_format`, mandatory `vendor`, mandatory
+/// explicit `normalizers`/`risk_rules` lists) is unsupported.
 #[derive(Debug, Clone, Deserialize)]
 pub struct PackManifest {
+    /// Manifest schema version. Engine rejects anything other than `Some(2)`.
+    /// Wrapped in `Option` so absent → clear "missing pack_format" error
+    /// rather than a misleading serde mismatch.
+    #[serde(default)]
+    pub pack_format: Option<u32>,
+
     pub name: String,
     pub version: String,
     pub permit0_pack: String,
-    pub vendor: String,
+
     #[serde(default)]
     pub description: Option<String>,
-    pub normalizers: Vec<String>,
-    pub risk_rules: Vec<String>,
     #[serde(default)]
     pub homepage: Option<String>,
     #[serde(default)]
     pub license: Option<String>,
+
+    /// Engine compatibility range, e.g. `">=0.5.0,<0.6"`. Optional in
+    /// schema v2; mandatory once semver gating is wired up.
+    #[serde(default)]
+    pub permit0_engine: Option<String>,
+
+    /// Taxonomy compatibility range, e.g. `"1.x"`.
+    #[serde(default)]
+    pub taxonomy: Option<String>,
+
+    /// Action types this pack is responsible for. Validator cross-checks
+    /// against installed normalizers and risk rules.
+    #[serde(default)]
+    pub action_types: Vec<String>,
+
+    /// Pack maintainers (informational; not used for trust decisions).
+    #[serde(default)]
+    pub maintainers: Vec<Maintainer>,
+
+    /// Channel metadata. Keyed by channel slug (e.g. `gmail`, `outlook`).
+    /// Empty in PR 2; populated in PR 3 once normalizers are channel-grouped.
+    #[serde(default)]
+    pub channels: std::collections::BTreeMap<String, ChannelMeta>,
+
+    /// Self-declared trust tier. **Informational only** — the engine
+    /// derives the authoritative tier from path (and, in Phase 2, signature).
+    /// A community pack declaring `trust_tier: built-in` does not become
+    /// built-in; the validator flags the mismatch.
+    #[serde(default)]
+    pub trust_tier: Option<TrustTierDecl>,
+
+    /// Phase 2 forward-compat: signature over the pack's lockfile + manifest.
+    /// Reserved; empty in Phase 1.
+    #[serde(default)]
+    pub signature: Option<String>,
+
+    /// Phase 2 forward-compat: provenance attestation (build origin, signer
+    /// identity). Reserved; empty in Phase 1.
+    #[serde(default)]
+    pub provenance: Option<String>,
+
+    /// Phase 2 forward-compat: content hash of the pack's normalized
+    /// contents (lockfile-derived). Reserved; empty in Phase 1.
+    #[serde(default)]
+    pub content_hash: Option<String>,
+
+    /// Explicit normalizer file list. Empty → auto-discover from filesystem.
+    #[serde(default)]
+    pub normalizers: Vec<String>,
+
+    /// Explicit risk rule file list. Empty → auto-discover from filesystem.
+    #[serde(default)]
+    pub risk_rules: Vec<String>,
+
+    /// Legacy schema v1 field. Ignored in v2; left here so v1 manifests
+    /// produce a clean version-gate error rather than a serde failure.
+    #[serde(default)]
+    pub vendor: Option<String>,
+
+    /// Legacy schema v1 field. Ignored in v2.
     #[serde(default)]
     pub min_engine_version: Option<String>,
+}
+
+/// Pack maintainer record. Either GitHub handle or email; both optional.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct Maintainer {
+    #[serde(default)]
+    pub github: Option<String>,
+    #[serde(default)]
+    pub email: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// Channel-level metadata (per-vendor).
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ChannelMeta {
+    /// Path to the MCP server adapter for this channel, e.g.
+    /// `clients/gmail-mcp`.
+    #[serde(default)]
+    pub mcp_server: Option<String>,
+    /// Display name (UI-facing).
+    #[serde(default)]
+    pub display_name: Option<String>,
+}
+
+/// Self-declared trust tier values accepted in `pack.yaml`. Engine derives
+/// the *authoritative* tier independently; this declaration is informational.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TrustTierDecl {
+    BuiltIn,
+    Verified,
+    Community,
+    Experimental,
+}
+
+/// Current pack manifest schema version. Bump on breaking schema changes.
+pub const PACK_FORMAT_VERSION: u32 = 2;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_v2_manifest() {
+        let yaml = r#"
+pack_format: 2
+name: email
+version: "0.3.0"
+permit0_pack: "permit0/email"
+"#;
+        let m: PackManifest = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(m.pack_format, Some(2));
+        assert_eq!(m.name, "email");
+        assert!(m.normalizers.is_empty());
+        assert!(m.action_types.is_empty());
+        assert!(m.channels.is_empty());
+    }
+
+    #[test]
+    fn parses_full_v2_manifest() {
+        let yaml = r#"
+pack_format: 2
+name: email
+version: "0.3.0"
+permit0_pack: "permit0/email"
+permit0_engine: ">=0.5.0,<0.6"
+taxonomy: "1.x"
+trust_tier: built-in
+maintainers:
+  - github: "@permit0-team"
+channels:
+  gmail:
+    mcp_server: clients/gmail-mcp
+    display_name: "Gmail"
+  outlook:
+    mcp_server: clients/outlook-mcp
+action_types:
+  - email.send
+  - email.archive
+signature: ""
+provenance: ""
+content_hash: ""
+"#;
+        let m: PackManifest = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(m.pack_format, Some(2));
+        assert_eq!(m.trust_tier, Some(TrustTierDecl::BuiltIn));
+        assert_eq!(m.channels.len(), 2);
+        assert_eq!(
+            m.channels.get("gmail").and_then(|c| c.mcp_server.as_deref()),
+            Some("clients/gmail-mcp")
+        );
+        assert_eq!(m.action_types, vec!["email.send", "email.archive"]);
+    }
+
+    #[test]
+    fn parses_v1_manifest_without_pack_format() {
+        // The legacy schema (no pack_format, has vendor + explicit lists)
+        // still parses. The engine rejects it later via the version gate.
+        let yaml = r#"
+name: email
+version: "0.2.0"
+permit0_pack: "permit0/email"
+vendor: permit0
+normalizers:
+  - normalizers/gmail_send.yaml
+risk_rules:
+  - risk_rules/send.yaml
+"#;
+        let m: PackManifest = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(m.pack_format, None);
+        assert_eq!(m.vendor.as_deref(), Some("permit0"));
+        assert_eq!(m.normalizers.len(), 1);
+    }
+
+    #[test]
+    fn rejects_unknown_trust_tier_value() {
+        let yaml = r#"
+pack_format: 2
+name: email
+version: "0.3.0"
+permit0_pack: "permit0/email"
+trust_tier: gold-plated
+"#;
+        let err = serde_yaml::from_str::<PackManifest>(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("gold-plated") || msg.contains("variant"));
+    }
 }

--- a/crates/permit0-node/Cargo.toml
+++ b/crates/permit0-node/Cargo.toml
@@ -21,6 +21,7 @@ serde_yaml = { workspace = true }
 permit0-types = { workspace = true }
 permit0-scoring = { workspace = true }
 permit0-normalize = { workspace = true }
+permit0-dsl = { workspace = true }
 permit0-engine = { workspace = true }
 permit0-store = { workspace = true }
 

--- a/crates/permit0-node/src/lib.rs
+++ b/crates/permit0-node/src/lib.rs
@@ -302,54 +302,49 @@ fn load_config(profile_path: Option<&str>) -> Result<permit0_scoring::ScoringCon
 }
 
 /// Install all packs from a directory into the builder.
+///
+/// Uses `permit0_dsl::discover_packs` to find every pack manifest under
+/// `packs_dir`, including the owner-namespaced layout introduced in PR 3
+/// of the pack taxonomy refactor.
 fn install_packs_from_dir(mut builder: EngineBuilder, packs_dir: &Path) -> Result<EngineBuilder> {
-    let entries = std::fs::read_dir(packs_dir)
-        .map_err(|e| Error::from_reason(format!("reading packs dir: {e}")))?;
+    let pack_dirs = permit0_dsl::discover_packs(packs_dir)
+        .map_err(|e| Error::from_reason(format!("discovering packs: {e}")))?;
 
-    for entry in entries {
-        let entry = entry.map_err(|e| Error::from_reason(format!("reading entry: {e}")))?;
-        if entry
-            .file_type()
-            .map_err(|e| Error::from_reason(format!("file type: {e}")))?
-            .is_dir()
-        {
-            let pack_dir = entry.path();
-
-            // Install normalizers
-            let norm_dir = pack_dir.join("normalizers");
-            if norm_dir.exists() {
-                for f in std::fs::read_dir(&norm_dir)
-                    .map_err(|e| Error::from_reason(format!("reading normalizers: {e}")))?
-                {
-                    let f = f.map_err(|e| Error::from_reason(e.to_string()))?;
-                    let path = f.path();
-                    if path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
-                        let yaml = std::fs::read_to_string(&path).map_err(|e| {
-                            Error::from_reason(format!("reading {}: {e}", path.display()))
-                        })?;
-                        builder = builder.install_normalizer_yaml(&yaml).map_err(|e| {
-                            Error::from_reason(format!("normalizer {}: {e}", path.display()))
-                        })?;
-                    }
+    for pack_dir in pack_dirs {
+        // Install normalizers
+        let norm_dir = pack_dir.join("normalizers");
+        if norm_dir.exists() {
+            for f in std::fs::read_dir(&norm_dir)
+                .map_err(|e| Error::from_reason(format!("reading normalizers: {e}")))?
+            {
+                let f = f.map_err(|e| Error::from_reason(e.to_string()))?;
+                let path = f.path();
+                if path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
+                    let yaml = std::fs::read_to_string(&path).map_err(|e| {
+                        Error::from_reason(format!("reading {}: {e}", path.display()))
+                    })?;
+                    builder = builder.install_normalizer_yaml(&yaml).map_err(|e| {
+                        Error::from_reason(format!("normalizer {}: {e}", path.display()))
+                    })?;
                 }
             }
+        }
 
-            // Install risk rules
-            let rules_dir = pack_dir.join("risk_rules");
-            if rules_dir.exists() {
-                for f in std::fs::read_dir(&rules_dir)
-                    .map_err(|e| Error::from_reason(format!("reading risk_rules: {e}")))?
-                {
-                    let f = f.map_err(|e| Error::from_reason(e.to_string()))?;
-                    let path = f.path();
-                    if path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
-                        let yaml = std::fs::read_to_string(&path).map_err(|e| {
-                            Error::from_reason(format!("reading {}: {e}", path.display()))
-                        })?;
-                        builder = builder.install_risk_rule_yaml(&yaml).map_err(|e| {
-                            Error::from_reason(format!("risk rule {}: {e}", path.display()))
-                        })?;
-                    }
+        // Install risk rules
+        let rules_dir = pack_dir.join("risk_rules");
+        if rules_dir.exists() {
+            for f in std::fs::read_dir(&rules_dir)
+                .map_err(|e| Error::from_reason(format!("reading risk_rules: {e}")))?
+            {
+                let f = f.map_err(|e| Error::from_reason(e.to_string()))?;
+                let path = f.path();
+                if path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
+                    let yaml = std::fs::read_to_string(&path).map_err(|e| {
+                        Error::from_reason(format!("reading {}: {e}", path.display()))
+                    })?;
+                    builder = builder.install_risk_rule_yaml(&yaml).map_err(|e| {
+                        Error::from_reason(format!("risk rule {}: {e}", path.display()))
+                    })?;
                 }
             }
         }

--- a/crates/permit0-py/Cargo.toml
+++ b/crates/permit0-py/Cargo.toml
@@ -20,6 +20,7 @@ serde_yaml = { workspace = true }
 permit0-types = { workspace = true }
 permit0-scoring = { workspace = true }
 permit0-normalize = { workspace = true }
+permit0-dsl = { workspace = true }
 permit0-engine = { workspace = true }
 permit0-agent = { workspace = true }
 permit0-store = { workspace = true }

--- a/crates/permit0-py/src/lib.rs
+++ b/crates/permit0-py/src/lib.rs
@@ -711,54 +711,49 @@ fn parse_profile_overrides(
 }
 
 /// Install all packs from a directory into the builder.
+///
+/// Uses `permit0_dsl::discover_packs` to find every pack manifest under
+/// `packs_dir`, including the owner-namespaced layout introduced in PR 3
+/// of the pack taxonomy refactor.
 fn install_packs_from_dir(mut builder: EngineBuilder, packs_dir: &Path) -> PyResult<EngineBuilder> {
-    let entries = std::fs::read_dir(packs_dir)
-        .map_err(|e| PyRuntimeError::new_err(format!("reading packs dir: {e}")))?;
+    let pack_dirs = permit0_dsl::discover_packs(packs_dir)
+        .map_err(|e| PyRuntimeError::new_err(format!("discovering packs: {e}")))?;
 
-    for entry in entries {
-        let entry = entry.map_err(|e| PyRuntimeError::new_err(format!("reading entry: {e}")))?;
-        if entry
-            .file_type()
-            .map_err(|e| PyRuntimeError::new_err(format!("file type: {e}")))?
-            .is_dir()
-        {
-            let pack_dir = entry.path();
-
-            // Install normalizers
-            let norm_dir = pack_dir.join("normalizers");
-            if norm_dir.exists() {
-                for f in std::fs::read_dir(&norm_dir)
-                    .map_err(|e| PyRuntimeError::new_err(format!("reading normalizers: {e}")))?
-                {
-                    let f = f.map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-                    let path = f.path();
-                    if path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
-                        let yaml = std::fs::read_to_string(&path).map_err(|e| {
-                            PyRuntimeError::new_err(format!("reading {}: {e}", path.display()))
-                        })?;
-                        builder = builder.install_normalizer_yaml(&yaml).map_err(|e| {
-                            PyRuntimeError::new_err(format!("normalizer {}: {e}", path.display()))
-                        })?;
-                    }
+    for pack_dir in pack_dirs {
+        // Install normalizers
+        let norm_dir = pack_dir.join("normalizers");
+        if norm_dir.exists() {
+            for f in std::fs::read_dir(&norm_dir)
+                .map_err(|e| PyRuntimeError::new_err(format!("reading normalizers: {e}")))?
+            {
+                let f = f.map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+                let path = f.path();
+                if path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
+                    let yaml = std::fs::read_to_string(&path).map_err(|e| {
+                        PyRuntimeError::new_err(format!("reading {}: {e}", path.display()))
+                    })?;
+                    builder = builder.install_normalizer_yaml(&yaml).map_err(|e| {
+                        PyRuntimeError::new_err(format!("normalizer {}: {e}", path.display()))
+                    })?;
                 }
             }
+        }
 
-            // Install risk rules
-            let rules_dir = pack_dir.join("risk_rules");
-            if rules_dir.exists() {
-                for f in std::fs::read_dir(&rules_dir)
-                    .map_err(|e| PyRuntimeError::new_err(format!("reading risk_rules: {e}")))?
-                {
-                    let f = f.map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-                    let path = f.path();
-                    if path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
-                        let yaml = std::fs::read_to_string(&path).map_err(|e| {
-                            PyRuntimeError::new_err(format!("reading {}: {e}", path.display()))
-                        })?;
-                        builder = builder.install_risk_rule_yaml(&yaml).map_err(|e| {
-                            PyRuntimeError::new_err(format!("risk rule {}: {e}", path.display()))
-                        })?;
-                    }
+        // Install risk rules
+        let rules_dir = pack_dir.join("risk_rules");
+        if rules_dir.exists() {
+            for f in std::fs::read_dir(&rules_dir)
+                .map_err(|e| PyRuntimeError::new_err(format!("reading risk_rules: {e}")))?
+            {
+                let f = f.map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+                let path = f.path();
+                if path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
+                    let yaml = std::fs::read_to_string(&path).map_err(|e| {
+                        PyRuntimeError::new_err(format!("reading {}: {e}", path.display()))
+                    })?;
+                    builder = builder.install_risk_rule_yaml(&yaml).map_err(|e| {
+                        PyRuntimeError::new_err(format!("risk rule {}: {e}", path.display()))
+                    })?;
                 }
             }
         }

--- a/crates/permit0-shell-dispatch/Cargo.toml
+++ b/crates/permit0-shell-dispatch/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 permit0-types = { workspace = true }
+permit0-dsl = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
@@ -16,5 +17,4 @@ shlex = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-permit0-dsl = { workspace = true }
 permit0-normalize = { workspace = true }

--- a/crates/permit0-shell-dispatch/src/yaml/loader.rs
+++ b/crates/permit0-shell-dispatch/src/yaml/loader.rs
@@ -49,21 +49,26 @@ pub fn load_yaml_dir<P: AsRef<Path>>(dir: P) -> Result<Vec<YamlCommandParser>, L
     load_files_merging_by_program(&yaml_files)
 }
 
-/// Scan `<packs_dir>/*/dispatchers/*.yaml` and produce one parser per
-/// program. Packs without a `dispatchers/` subdirectory are skipped.
+/// Scan every pack under `packs_dir` for a `dispatchers/` subdirectory and
+/// produce one parser per program. Packs without a `dispatchers/`
+/// subdirectory are skipped.
+///
+/// Pack discovery delegates to `permit0_dsl::discover_packs`, which finds
+/// packs at depth 1 (flat legacy layout) and depth 2 (owner-namespaced
+/// layout introduced in PR 3 of the pack taxonomy refactor).
 ///
 /// `packs_dir` is typically the repo-root `packs/` directory.
 pub fn load_pack_dispatchers<P: AsRef<Path>>(
     packs_dir: P,
 ) -> Result<Vec<YamlCommandParser>, LoadError> {
-    let base = packs_dir.as_ref().to_path_buf();
-    let packs = read_dir_sorted(&base)?;
+    let base = packs_dir.as_ref();
+    let packs = permit0_dsl::discover_packs(base).map_err(|e| LoadError::Io {
+        path: base.display().to_string(),
+        source: std::io::Error::other(e.to_string()),
+    })?;
 
     let mut all_files = Vec::new();
     for pack_dir in packs {
-        if !pack_dir.is_dir() {
-            continue;
-        }
         let dispatchers = pack_dir.join("dispatchers");
         if !dispatchers.is_dir() {
             continue;
@@ -213,8 +218,12 @@ dispatches:
     #[test]
     fn pack_layout_discovers_dispatchers() {
         let base = tmp_dir();
-        // packs/gmail/dispatchers/gog.yaml
+        // Each pack directory needs pack.yaml — that is what
+        // permit0_dsl::discover_packs uses to identify a pack.
+
+        // packs/gmail/{pack.yaml,dispatchers/gog.yaml}
         std::fs::create_dir_all(base.join("gmail/dispatchers")).unwrap();
+        write(&base.join("gmail"), "pack.yaml", "name: gmail");
         write(
             &base.join("gmail/dispatchers"),
             "gog.yaml",
@@ -226,8 +235,9 @@ dispatches:
     parameters: {}
 "#,
         );
-        // packs/stripe/dispatchers/gog.yaml — same program, different rules
+        // packs/stripe/{pack.yaml,dispatchers/gog.yaml} — same program, different rules
         std::fs::create_dir_all(base.join("stripe/dispatchers")).unwrap();
+        write(&base.join("stripe"), "pack.yaml", "name: stripe");
         write(
             &base.join("stripe/dispatchers"),
             "gog.yaml",
@@ -239,8 +249,9 @@ dispatches:
     parameters: {}
 "#,
         );
-        // packs/bash/no-dispatchers/ → ignored
+        // packs/bash/{pack.yaml,normalizers/...} — no dispatchers/ → ignored
         std::fs::create_dir_all(base.join("bash/normalizers")).unwrap();
+        write(&base.join("bash"), "pack.yaml", "name: bash");
         write(
             &base.join("bash/normalizers"),
             "shell.yaml",
@@ -250,6 +261,33 @@ dispatches:
         let parsers = load_pack_dispatchers(&base).unwrap();
         assert_eq!(parsers.len(), 1);
         assert_eq!(parsers[0].rule_count(), 2);
+
+        std::fs::remove_dir_all(&base).unwrap();
+    }
+
+    #[test]
+    fn pack_layout_supports_owner_namespaced() {
+        // PR 3 layout: packs/<owner>/<pack>/dispatchers/<file>.yaml.
+        // Verifies discover_packs's depth-2 walk reaches the
+        // dispatcher YAMLs.
+        let base = tmp_dir();
+        std::fs::create_dir_all(base.join("permit0/email/dispatchers")).unwrap();
+        write(&base.join("permit0/email"), "pack.yaml", "name: email");
+        write(
+            &base.join("permit0/email/dispatchers"),
+            "gog.yaml",
+            r#"
+program: gog
+dispatches:
+  - match: { subcommands: [gmail, send] }
+    tool_name: gmail_send
+    parameters: {}
+"#,
+        );
+
+        let parsers = load_pack_dispatchers(&base).unwrap();
+        assert_eq!(parsers.len(), 1);
+        assert_eq!(parsers[0].rule_count(), 1);
 
         std::fs::remove_dir_all(&base).unwrap();
     }

--- a/crates/permit0-ui/src/pack_routes.rs
+++ b/crates/permit0-ui/src/pack_routes.rs
@@ -221,23 +221,16 @@ pub async fn list_packs(
         )
     })?;
 
-    let entries = std::fs::read_dir(&packs_dir).map_err(|e| {
+    let pack_dirs = permit0_dsl::discover_packs(&packs_dir).map_err(|e| {
         err_response::<Vec<PackSummary>>(
             StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("failed to read packs directory: {e}"),
+            &format!("failed to discover packs: {e}"),
         )
     })?;
 
     let mut summaries = Vec::new();
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
+    for path in pack_dirs {
         let manifest_path = path.join("pack.yaml");
-        if !manifest_path.exists() {
-            continue;
-        }
         let content = match std::fs::read_to_string(&manifest_path) {
             Ok(c) => c,
             Err(_) => continue,

--- a/crates/permit0-ui/src/pack_routes.rs
+++ b/crates/permit0-ui/src/pack_routes.rs
@@ -49,6 +49,9 @@ fn err_response<T: Serialize>(status: StatusCode, msg: &str) -> (StatusCode, Jso
 pub struct PackSummary {
     pub name: String,
     pub version: String,
+    /// Pack owner. Derived from `permit0_pack` ("<owner>/<name>") since
+    /// schema v2 drops the explicit `vendor` field. Falls back to the
+    /// legacy `vendor` value if `permit0_pack` is malformed.
     pub vendor: String,
     pub description: Option<String>,
     pub normalizer_count: usize,
@@ -63,6 +66,18 @@ pub struct PackDetail {
     pub description: Option<String>,
     pub normalizers: Vec<String>,
     pub risk_rules: Vec<String>,
+}
+
+/// Resolve the pack owner. Pulls from `permit0_pack` ("<owner>/<name>") in
+/// schema v2; falls back to the legacy `vendor` field for transitional
+/// safety.
+fn resolve_owner(manifest: &PackManifest) -> String {
+    manifest
+        .permit0_pack
+        .split_once('/')
+        .map(|(owner, _)| owner.to_string())
+        .or_else(|| manifest.vendor.clone())
+        .unwrap_or_default()
 }
 
 #[derive(Debug, Serialize)]
@@ -231,12 +246,13 @@ pub async fn list_packs(
             Ok(m) => m,
             Err(_) => continue,
         };
+        let vendor = resolve_owner(&manifest);
         summaries.push(PackSummary {
             normalizer_count: manifest.normalizers.len(),
             risk_rule_count: manifest.risk_rules.len(),
             name: manifest.name,
             version: manifest.version,
-            vendor: manifest.vendor,
+            vendor,
             description: manifest.description,
         });
     }
@@ -276,10 +292,11 @@ pub async fn get_pack(
     let normalizers = list_yaml_files(&pack_path.join("normalizers"));
     let risk_rules = list_yaml_files(&pack_path.join("risk_rules"));
 
+    let vendor = resolve_owner(&manifest);
     Ok(ok_response(PackDetail {
         name: manifest.name,
         version: manifest.version,
-        vendor: manifest.vendor,
+        vendor,
         description: manifest.description,
         normalizers,
         risk_rules,

--- a/packs/email/pack.yaml
+++ b/packs/email/pack.yaml
@@ -1,54 +1,67 @@
-name: email
-version: "0.2.0"
+# Email pack — unified Gmail + Outlook governance.
+#
+# Schema v2 (introduced PR 2 of the pack taxonomy refactor). The engine
+# version-gates on `pack_format: 2`; v1 manifests are rejected with a
+# clear error pointing at this file.
+#
+# `normalizers:` and `risk_rules:` are intentionally absent — the engine
+# auto-discovers every YAML under `normalizers/` and `risk_rules/`.
+# Add files; don't touch this file.
+
+pack_format: 2
 permit0_pack: "permit0/email"
-vendor: permit0
-description: "Unified email norm actions (15 verbs) with Gmail and Outlook normalizers"
-normalizers:
-  # Outlook
-  - normalizers/outlook_search.yaml
-  - normalizers/outlook_read.yaml
-  - normalizers/outlook_read_thread.yaml
-  - normalizers/outlook_list_mailboxes.yaml
-  - normalizers/outlook_draft.yaml
-  - normalizers/outlook_send.yaml
-  - normalizers/outlook_mark_read.yaml
-  - normalizers/outlook_flag.yaml
-  - normalizers/outlook_move.yaml
-  - normalizers/outlook_archive.yaml
-  - normalizers/outlook_mark_spam.yaml
-  - normalizers/outlook_delete.yaml
-  - normalizers/outlook_create_mailbox.yaml
-  - normalizers/outlook_set_forwarding.yaml
-  - normalizers/outlook_add_delegate.yaml
-  # Gmail
-  - normalizers/gmail_search.yaml
-  - normalizers/gmail_read.yaml
-  - normalizers/gmail_read_thread.yaml
-  - normalizers/gmail_list_mailboxes.yaml
-  - normalizers/gmail_draft.yaml
-  - normalizers/gmail_send.yaml
-  - normalizers/gmail_mark_read.yaml
-  - normalizers/gmail_flag.yaml
-  - normalizers/gmail_move.yaml
-  - normalizers/gmail_archive.yaml
-  - normalizers/gmail_mark_spam.yaml
-  - normalizers/gmail_delete.yaml
-  - normalizers/gmail_create_mailbox.yaml
-  - normalizers/gmail_set_forwarding.yaml
-  - normalizers/gmail_add_delegate.yaml
-risk_rules:
-  - risk_rules/search.yaml
-  - risk_rules/read.yaml
-  - risk_rules/read_thread.yaml
-  - risk_rules/list_mailboxes.yaml
-  - risk_rules/draft.yaml
-  - risk_rules/send.yaml
-  - risk_rules/mark_read.yaml
-  - risk_rules/flag.yaml
-  - risk_rules/move.yaml
-  - risk_rules/archive.yaml
-  - risk_rules/mark_spam.yaml
-  - risk_rules/delete.yaml
-  - risk_rules/create_mailbox.yaml
-  - risk_rules/set_forwarding.yaml
-  - risk_rules/add_delegate.yaml
+name: email
+version: "0.3.0"
+description: "Unified email actions across Gmail and Outlook (16 verbs, 31 normalizers)."
+license: Apache-2.0
+
+# Engine + taxonomy compatibility. The engine refuses to load packs
+# pinned outside the supported semver range.
+permit0_engine: ">=0.1.0,<0.2"
+taxonomy: "1.x"
+
+# Self-declared trust tier. The engine derives the authoritative tier
+# from `<owner>` in `permit0_pack` (and, in Phase 2, signature). This
+# field is informational; mismatch is flagged by `permit0 pack validate`.
+trust_tier: built-in
+
+maintainers:
+  - github: "@permit0-team"
+
+# Action types this pack is responsible for. Validator cross-checks
+# every entry has at least one normalizer mapping to it AND a risk rule
+# covering it (orphan check). Drift here flags via CI before merge.
+action_types:
+  - email.search
+  - email.read
+  - email.read_thread
+  - email.list_mailboxes
+  - email.draft
+  - email.list_drafts
+  - email.send
+  - email.mark_read
+  - email.flag
+  - email.move
+  - email.archive
+  - email.mark_spam
+  - email.delete
+  - email.create_mailbox
+  - email.set_forwarding
+  - email.add_delegate
+
+# Channel metadata. PR 3 will move normalizers into per-channel
+# subdirectories under normalizers/{gmail,outlook}/. For now the
+# normalizer YAMLs are still flat with prefix-based naming.
+channels:
+  gmail:
+    mcp_server: clients/gmail-mcp
+    display_name: "Gmail (Google)"
+  outlook:
+    mcp_server: clients/outlook-mcp
+    display_name: "Outlook (Microsoft 365)"
+
+# Phase 2 forward-compat. Empty in Phase 1; populated when the
+# federated registry + signing infrastructure ships.
+signature: ""
+provenance: ""
+content_hash: ""


### PR DESCRIPTION
## Summary

Lays the foundation for the pack taxonomy refactor's owner-namespaced layout. Three pieces, all on the **OLD** flat pack directory (PR 3 moves the files):

1. **Pack manifest schema v2** — `PackManifest` gains `pack_format`, `permit0_engine`, `taxonomy`, `action_types`, `maintainers`, `channels`, `trust_tier`, plus the reserved Phase 2 fields (`signature`, `provenance`, `content_hash`). Drops `vendor` and the explicit `normalizers:` / `risk_rules:` lists. The legacy fields are kept as parseable-but-flagged so v1 manifests produce a clean violation rather than a serde error.

2. **Single-source pack discovery** — new `permit0_dsl::discover_packs(root)` walks 1-level (flat legacy) and 2-level (owner-namespaced PR 3 layout) layouts in one pass, returning a deterministic sorted `Vec<PathBuf>`. Three-level community layout is intentionally NOT discovered yet (Phase 2 territory; pinned by a regression test). Replaces inline `read_dir` loops in five consumers: `engine_factory`, `permit0-py`, `permit0-node`, `permit0-shell-dispatch`, and `permit0-ui`.

3. **Manifest-level validator** — new `permit0_dsl::pack_validate` module with 9 checks surfaced via `permit0 pack validate`:

   | Code | Surfaces |
   |---|---|
   | `SchemaVersion` | missing or wrong `pack_format` |
   | `LegacyVendorField` | leftover `vendor:` in v2 |
   | `MalformedPermit0Pack` | missing `<owner>/<name>` slash |
   | `TrustTierMismatch` | declared tier disagrees with derived; or Phase 2 tier declared |
   | `UnknownActionType` | entry not in the action taxonomy |
   | `MissingNormalizer` / `MissingRiskRule` | listed action type has no implementation |
   | `OrphanNormalizer` / `OrphanRiskRule` | implementation has no manifest entry |
   | `MissingGateOnCriticalAction` | critical actions (set_forwarding, iam.*, secret.*, payment.*) have no `gate:` mutation |

   Coverage / orphan codes surface as ⚠ warnings rather than ✗ errors so PR 3's pre-existing `email.list_drafts` gap stays visible without breaking CI. Other codes are hard errors.

4. **TrustTier enum** — single type for both declared (manifest field) and derived (computed from owner). `permit0` owner → `BuiltIn`, everything else → `Community`. `Verified` and `Experimental` reachable only via signing infrastructure (Phase 2). Lives in `permit0-dsl` rather than `permit0-types` to avoid name collision with the existing risk-tier `Tier` enum.

5. **`packs/email/pack.yaml` migrated to schema v2** — drops `vendor`, drops explicit file lists, adds `pack_format: 2`, `channels:`, `action_types:`, reserved Phase 2 fields. `permit0 pack validate packs/email` reports `All 46 files valid` with the expected list_drafts warning.

## Deferred to PR 2.5

The design doc bundled lockfile generation and lockfile-driven engine load into PR 2. Splitting them out keeps this PR review-able while the lockfile work is its own discrete change:

- `permit0 pack lock` subcommand (lockfile generation, sha256 over normalizer + risk rule files)
- `pack.lock.yaml` schema
- Engine: lockfile-driven load with filesystem-walk fallback + `--strict-lockfile` flag

Without the lockfile, the engine still loads packs via `discover_packs` + filesystem walks (the existing path). PR 3's file restructure is unblocked.

## Bisectable commits

```
086a65a feat(dsl,cli): manifest-level pack validator with 9 checks
f99f82b feat(dsl): TrustTier enum + manifest-based authoritative derivation
23587a5 chore: cargo update Cargo.lock after dep additions
c0e31a2 feat: route 5 pack consumers through discover_packs
81b4e75 feat(dsl): discover_packs() walks flat + owner-namespaced layouts
8e9bb05 feat(packs): migrate email pack manifest to schema v2
5fa7c26 feat(dsl): pack manifest schema v2 fields
```

Each commit compiles and passes tests. Bisect-friendly.

## Test plan

- [x] `cargo test --workspace` — full suite green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] 9 `pack_loader` unit tests cover flat / owner-ns / mixed / depth cap / Phase 2 placeholder / dot/underscore skipping / determinism
- [x] 15 `pack_validate` unit tests cover every violation code including the declared-vs-derived divergence and gateless-critical-action detection
- [x] 4 schema parsing tests cover minimal v2 / full v2 / legacy v1 / unknown-trust-tier
- [x] `permit0 pack validate packs/email` reports 46 files valid + 1 expected warning
- [x] `cli_tests::pack_validate_email` passes
- [ ] CI on Ubuntu / macOS / Windows (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)