### PR TITLE
PR 4: community contribution scaffolding (template, packs/community/, contribution guide rewrite, PR template)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new-pack.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new-pack.md
@@ -1,0 +1,84 @@
+## Pack identity
+
+- **Pack:** `<owner>/<name>` (e.g. `permit0/slack`)
+- **Tier targeted:** built-in / community / verified
+- **Issue:** #<n> — link to the approved pack proposal
+
+## Scope
+
+<!-- One-paragraph description of what this pack governs. -->
+
+### Action types covered
+
+| `action_type` | Tools mapped | Risk rule |
+|---|---|---|
+| | | |
+
+### Channels
+
+| Channel | MCP server | Tool pattern |
+|---|---|---|
+| | | |
+
+## Threat model
+
+- **Catches:** <!-- specific attacker behaviors / operator mistakes this pack prevents -->
+- **Does NOT catch:** <!-- known limitations -->
+- **Known caveats:** <!-- edge cases, conditional alias overrides, parameter remapping gaps -->
+
+## Calibration
+
+- Tested against `<N>` golden fixtures under `tests/`.
+- Last calibrated: `<YYYY-MM-DD>`.
+- Cross-channel goldens? Yes / No
+- Security fixtures? Yes / No (required for `verified` tier)
+
+## Validation evidence
+
+```text
+$ permit0 pack validate packs/<owner>/<name>
+<paste the output — should report "All N files valid" with zero hard errors>
+```
+
+```text
+$ permit0 pack test packs/<owner>/<name>
+<paste fixture-pass output>
+```
+
+## Pre-merge checklist
+
+### Required for all tiers
+
+- [ ] `pack.yaml` declares `pack_format: 2`
+- [ ] `permit0_pack: "<owner>/<name>"` matches the directory path
+- [ ] `permit0 pack validate` reports zero hard errors
+- [ ] Every action type in `action_types:` has at least one normalizer + one risk rule
+- [ ] Every normalizer has a unique `priority:` (no collisions with other packs in the workspace)
+- [ ] `_channel.yaml` declares a `tool_pattern:` and every YAML in the channel directory's `match.tool` matches it
+- [ ] No legacy `vendor:` field in `pack.yaml`
+- [ ] At least 3 fixtures per action type (allow / deny / edge case)
+- [ ] README.md filled in (scope, threat model, channels, calibration date)
+- [ ] CHANGELOG.md entry for this version
+
+### Required for `built-in` and `verified` tiers
+
+- [ ] Every action type on the always-human list (`email.set_forwarding`, `email.add_delegate`, `iam.*`, `secret.*`, `payment.*`) that this pack covers has at least one `gate:` mutation in `rules:` or `session_rules:`
+- [ ] `tests/security/` includes fixtures for every known attack pattern in this domain
+- [ ] No regex with catastrophic backtracking in any rule
+- [ ] No `Downgrade` or `Override` mutation that could lower a critical action's risk to allow tier
+- [ ] Channel detection cannot be spoofed (entity values that drive routing come from the call payload, not from the model's free text)
+- [ ] Calibration corpus includes red-team-style cases
+
+### Maintenance commitment
+
+- [ ] At least one maintainer listed in `pack.yaml` `maintainers:`
+- [ ] Maintainer agrees to triage issues opened against this pack
+- [ ] License is Apache-2.0, MIT, or BSD-2/3 (copyleft licenses are flagged)
+
+## Related docs
+
+- [Pack contribution guide](../../docs/pack-contribution-guide.md)
+- [Layout reference](../../packs/README.md)
+- [Action taxonomy](../../docs/taxonomy.md)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/pack-contribution-guide.md
+++ b/docs/pack-contribution-guide.md
@@ -1,162 +1,185 @@
 # Pack Contribution Guide
 
-This guide walks you through contributing a new pack to permit0.
+This guide walks you through contributing a new pack to permit0. The
+end product is a directory under `packs/permit0/<name>/` (first-party)
+or `packs/<your-org>/<name>/` (community, Phase 2) that the engine
+loads to govern a domain of tool calls.
 
-## What is a Pack?
+## What is a pack?
 
-A pack teaches permit0 how to normalize and score tool calls for a
-specific service (e.g. Stripe, Gmail, Slack). Each pack contains:
+A pack teaches the engine how to govern one domain. Each pack ships:
 
-- **Normalizers** — YAML rules that map raw tool calls to canonical
-  `NormAction` structures with typed entities.
-- **Risk rules** — YAML rules that assign risk flags and amplifiers
-  based on entity values and patterns.
-- **Fixtures** — Test cases that verify the pack behaves correctly.
+- **Normalizers** — YAML rules that map raw tool calls (e.g.
+  `gmail_send`, `outlook_send`) onto a canonical `NormAction` with the
+  same `action_type` (e.g. `email.send`). Grouped by channel
+  (`normalizers/<channel>/<verb>.yaml`) so adding a vendor is one
+  directory drop.
+- **Risk rules** — YAML rules that score actions by `action_type`,
+  channel-agnostic. One file per verb under `risk_rules/`.
+- **Aliases** — Per-channel YAML tables that remap foreign MCP tool
+  names onto canonical permit0 normalizer names.
+- **Tests** — Fixture YAMLs under `tests/` (per-channel + shared +
+  security) the validator and `permit0 pack test` exercise.
+- **Manifest** — `pack.yaml` (schema v2) with metadata, channel
+  declarations, action type list, version, and trust tier.
 
-## Quick Start
+The full layout reference lives at
+[`packs/README.md`](../packs/README.md). The reference implementation
+is `packs/permit0/email/` — 32 normalizers + 16 risk rules covering
+Gmail + Outlook. Read it before writing your own.
+
+## Workflow
+
+### 1. Open an issue
+
+Before writing code, file an issue describing the pack:
+
+- Domain + service (e.g. "Slack — message domain")
+- Why permit0 needs this (concrete threat scenarios, not "it'd be nice")
+- Action types the pack will cover (must be valid `domain.verb` pairs
+  from `docs/taxonomy.md`)
+- Maintainer commitment (who keeps this alive)
+
+A core maintainer will triage. Possible outcomes: APPROVE, REQUEST_CHANGES,
+or DECLINE. If your action types aren't in the taxonomy yet, the
+maintainer will direct you to a taxonomy-update PR first.
+
+### 2. Scaffold
 
 ```sh
-# 1. Scaffold a new pack
-permit0 pack new my_service
+# Copy the template into the right location.
+# First-party packs (built-in tier):
+cp -r packs/_template packs/permit0/<name>
 
-# 2. Edit the generated files
-cd packs/my_service
-$EDITOR normalizers/my_service.normalizer.yaml
-$EDITOR risk_rules/my_service.risk_rule.yaml
+# Community packs (Phase 2 placement; Phase 1 only first-party):
+# cp -r packs/_template packs/<your-org>/<name>
 
-# 3. Validate your pack
-permit0 pack validate packs/my_service
-
-# 4. Run fixture tests
-permit0 pack test packs/my_service
-
-# 5. Submit a PR
-git checkout -b pack/my_service
-git add packs/my_service
-git commit -m "feat: add my_service pack"
+cd packs/permit0/<name>
 ```
 
-## Pack Directory Structure
+Replace every `TODO` marker in `pack.yaml`, the channel metadata,
+the example normalizer/risk-rule YAMLs, and the README. The
+validator rejects packs with unfilled TODOs.
 
-```
-packs/my_service/
-├── README.md                          # Description, examples, known limitations
-├── normalizers/
-│   └── my_service.normalizer.yaml     # Normalizer definition
-├── risk_rules/
-│   └── my_service.risk_rule.yaml      # Risk rule definition
-└── fixtures/
-    ├── basic.fixture.yaml             # Basic test case
-    └── high_risk.fixture.yaml         # Edge case test
-```
+### 3. Iterate
 
-## Writing a Normalizer
+```sh
+# Validate after every change. Fast; runs in milliseconds.
+permit0 pack validate packs/permit0/<name>
 
-A normalizer tells permit0 how to recognize and decompose a tool call:
+# Smoke test with a sample call once at least one normalizer +
+# risk rule pair is wired up.
+permit0 check --input '{"tool_name":"<your_tool>","parameters":{...}}'
 
-```yaml
-id: stripe_charge
-description: "Normalize Stripe charge creation"
-priority: 100
-
-match:
-  tool: "http"
-  url: { contains: "api.stripe.com/v1/charges" }
-
-action_type: "payment.charge"
-channel: "stripe"
-
-entities:
-  - name: amount
-    path: "$.parameters.body.amount"
-    required: true
-    type: number
-
-  - name: currency
-    path: "$.parameters.body.currency"
-    required: true
-    default: "usd"
-
-  - name: recipient
-    path: "$.parameters.body.destination"
-    required: false
+# Run the full fixture suite.
+permit0 pack test packs/permit0/<name>
 ```
 
-### Key Fields
+The validator checks 9 invariants (schema version, manifest hygiene,
+trust-tier consistency, taxonomy compliance, action-type coverage,
+normalizer/risk-rule orphans, security lint on critical actions). Run
+it after every meaningful change.
 
-| Field | Description |
-|-------|-------------|
-| `id` | Unique identifier (must be unique across all packs) |
-| `priority` | Higher = checked first (100 is default) |
-| `match` | Conditions to match raw tool calls |
-| `action_type` | Canonical `domain.verb` (see action type catalog) |
-| `channel` | Service name (e.g. "stripe", "gmail") |
-| `entities` | Extracted parameters with paths and types |
+### 4. Add fixtures
 
-## Writing a Risk Rule
+Place test cases under `tests/`:
 
-A risk rule assigns risk signals based on entity values:
+- `tests/<channel>/` — per-channel goldens (one YAML per scenario)
+- `tests/shared/` — cross-channel scenarios that should produce the
+  same canonical action regardless of vendor
+- `tests/security/` — known-attack patterns (required for verified+
+  tier; optional for community)
 
-```yaml
-id: stripe_high_value
-description: "Flag high-value Stripe charges"
-action_type: "payment.charge"
+Aim for ≥3 fixtures per `action_type`: one happy path (allow), one
+denial path (deny), one edge case.
 
-match:
-  tool: "http"
-  url: { contains: "api.stripe.com" }
+### 5. Open a PR
 
-flags:
-  - name: FINANCIAL
-    role: primary
-
-amplifiers:
-  amount:
-    source: "entity.amount"
-    scale: linear
-  destination:
-    source: "entity.recipient"
+```sh
+git checkout -b pack/<name>
+git add packs/permit0/<name>
+git commit -m "feat: add <name> pack"
+git push origin pack/<name>
+gh pr create --base main --template new-pack.md
 ```
 
-### Available Flags
+The PR template captures the security checklist, threat model, and
+calibration data. Fill it in honestly — gaps are flagged at review.
 
-`FINANCIAL`, `EXECUTION`, `DESTRUCTION`, `PHYSICAL`, `PRIVILEGE`,
-`EXPOSURE`, `GOVERNANCE`, `OUTBOUND`, `MUTATION`
+## What the validator checks
 
-### Flag Roles
+`permit0 pack validate` runs 9 manifest-level checks plus per-file
+schema validation:
 
-- `primary` — contributes more weight to the score
-- `secondary` — contributes less weight
+| Check | What it catches |
+|---|---|
+| Schema version | `pack_format` missing or != 2 |
+| Legacy vendor field | `vendor:` from schema v1 still present |
+| Malformed `permit0_pack` | missing `<owner>/<name>` slash |
+| Trust tier mismatch | declared tier != derived from owner; or Phase 2 tier declared in Phase 1 |
+| Unknown action type | entry not in the taxonomy |
+| Missing normalizer / risk rule | listed action type has no implementation |
+| Orphan normalizer / risk rule | implementation has no manifest entry |
+| Missing gate on critical action | `email.set_forwarding`, `iam.*`, `secret.*`, `payment.*` lacks any `gate:` mutation |
 
-## Writing Fixtures
+Every check is a hard error except coverage / orphan codes, which
+surface as warnings during the migration window.
 
-Fixtures are test cases that verify your normalizer and risk rules:
+## Common pitfalls
 
-```yaml
-tool_name: "http"
-parameters:
-  method: "POST"
-  url: "https://api.stripe.com/v1/charges"
-  body:
-    amount: 100
-    currency: "usd"
-expected_permission: "allow"
-```
+- **Priority collisions.** Each normalizer's `priority:` must be
+  unique within the registry. The engine errors at build time if two
+  share a value. Convention: 100 + N.
+- **Cross-channel poisoning.** A normalizer in `normalizers/gmail/`
+  with `match.tool: outlook_send` wrongly claims Outlook traffic. A
+  follow-up PR will wire a CI check that enforces `_channel.yaml`'s
+  `tool_pattern`. Until then, it's a manual review item.
+- **Critical actions without gates.** `email.set_forwarding`,
+  `email.add_delegate`, `iam.*`, `secret.*`, and `payment.*` MUST
+  include at least one `gate:` mutation in the rule's `rules:` or
+  `session_rules:`. The validator's security lint flags violations.
+- **`include_str!` paths.** Test fixtures load via
+  `permit0_test_utils::load_test_fixture("packs/<owner>/<name>/...")`
+  resolved at runtime — paths are workspace-relative. Don't use
+  `include_str!` with `../../../packs/...`; it breaks silently when
+  layouts move.
+- **Forgetting to update `action_types:`.** Adding a normalizer and
+  risk rule isn't enough — list the action_type in `pack.yaml` too.
+  The validator's coverage check catches this.
 
-## Validation Checklist
+## Versioning
 
-Before submitting:
+Pack versions follow SemVer:
 
-- [ ] `permit0 pack validate packs/my_service` passes
-- [ ] `permit0 pack test packs/my_service` passes
-- [ ] At least 3 fixture test cases (happy path, edge case, deny case)
-- [ ] Normalizer IDs are unique and descriptive
-- [ ] Risk flags are appropriate for the service domain
-- [ ] README.md documents the pack's purpose and known limitations
+- **Major bump** when:
+  - Removing an action_type the pack used to cover
+  - Loosening a deny rule (allowing what was previously denied)
+  - Renaming an entity field that risk rules reference
+- **Minor bump** when:
+  - Adding action_type coverage
+  - Tightening rules (more denies)
+  - Adding new entities
+- **Patch bump** when:
+  - Fixing a bug in a rule
+  - Improving entity extraction without changing decisions
+  - Fixture additions
 
-## Pack Staging Pipeline
+## Trust tiers
 
-1. Submit PR to `packs/community/` directory
-2. Automated CI runs `permit0 pack validate` and `permit0 pack test`
-3. Maintainer review
-4. Once approved, pack moves to `packs/verified/` in a follow-up PR
+The engine derives the authoritative tier from `permit0_pack`'s
+owner prefix. Your declaration in `pack.yaml` is informational.
+
+| Tier | Reachable | How |
+|---|---|---|
+| `built-in` | Phase 1 | place under `packs/permit0/` |
+| `community` | Phase 1 | default for non-permit0 owners |
+| `verified` | Phase 2 | community + signing co-sign |
+| `experimental` | Phase 2 | hidden, opt-in install |
+
+## Related docs
+
+- [`packs/README.md`](../packs/README.md) — layout overview + cardinality
+- [`docs/taxonomy.md`](taxonomy.md) — closed list of valid `domain.verb`
+- [`docs/dsl.md`](dsl.md) — DSL reference for normalizers + risk rules
+- [`packs/_template/`](../packs/_template/) — drop-in scaffold
+- [`packs/permit0/email/`](../packs/permit0/email/) — reference pack

--- a/packs/README.md
+++ b/packs/README.md
@@ -1,0 +1,115 @@
+# Packs
+
+permit0 packs bundle the pieces that teach the engine how to govern a
+domain: normalizers (raw tool call → canonical action), risk rules
+(action → score), aliases (foreign names → canonical), and metadata.
+
+## Layout
+
+```
+packs/
+├── permit0/                ← first-party packs (built-in tier)
+│   └── email/              ← unified Gmail + Outlook governance
+│       ├── pack.yaml
+│       ├── normalizers/
+│       │   ├── gmail/
+│       │   │   ├── _channel.yaml
+│       │   │   ├── aliases.yaml
+│       │   │   └── <verb>.yaml × 16
+│       │   └── outlook/
+│       │       ├── _channel.yaml
+│       │       ├── aliases.yaml
+│       │       └── <verb>.yaml × 16
+│       └── risk_rules/
+│           └── <verb>.yaml × 16  (channel-agnostic)
+├── _template/              ← scaffold for new packs (skipped by discovery)
+└── community/              ← Phase 2 placeholder; empty in Phase 1
+```
+
+## How packs become decisions
+
+```
+                        WORLD                        PACK                       POLICY
+                    ┌──────────┐         ┌─────────────────────────┐     ┌────────────────┐
+  agent calls ────► │   Tool   │ ──match──► Normalizer (YAML)      │ ───► │  ActionType    │
+                    │ (vendor) │ (1 file) │  per raw tool          │ N:1  │  domain.verb   │
+                    └──────────┘          │  normalizers/<ch>/<verb>.yaml │     │
+                    e.g.                  └─────────────────────────┘           │ 1:1
+                    gmail_send                                                   ▼
+                    outlook_send                                       ┌────────────────┐
+                                                                       │ Risk rule (YAML)│
+                                                                       │  risk_rules/    │
+                                                                       │  <verb>.yaml    │
+                                                                       └────────────────┘
+```
+
+- **N tools → 1 action_type.** Two tools that mean the same thing
+  share an action type (gmail_send + outlook_send → email.send).
+- **1 normalizer → 1 tool.** Each raw tool name needs its own mapper
+  because vendor parameter shapes differ.
+- **1 risk rule → 1 action_type.** Rules score the canonical action,
+  channel-agnostic.
+- **1 pack → many normalizers + many risk rules,** grouped by domain.
+
+Write your policy once at the action_type level and it covers every
+tool any pack maps into it.
+
+## Trust tiers
+
+The engine derives the authoritative tier from `permit0_pack`'s owner
+prefix. The `trust_tier:` field in `pack.yaml` is informational; the
+validator flags mismatches.
+
+| Tier | Path / source | Required signoff |
+|---|---|---|
+| `built-in` | `packs/permit0/<name>/` (first-party) | permit0 core team |
+| `verified` | community + permit0 co-sign | **Phase 2** (needs signing infra) |
+| `community` | everywhere else (default) | validation only |
+| `experimental` | hidden by default | **Phase 2** |
+
+## Adding a pack
+
+See [`docs/pack-contribution-guide.md`](../docs/pack-contribution-guide.md)
+for the full workflow. Quick start:
+
+```bash
+# Copy the template
+cp -r packs/_template packs/permit0/<name>     # first-party
+# or
+cp -r packs/_template packs/<your-org>/<name>  # community
+
+# Edit pack.yaml, normalizers/, risk_rules/
+$EDITOR packs/<owner>/<name>/pack.yaml
+
+# Validate
+permit0 pack validate packs/<owner>/<name>
+
+# Run fixtures
+permit0 pack test packs/<owner>/<name>
+```
+
+## What lives where
+
+- **Normalizer YAML** under `normalizers/<channel>/<verb>.yaml`.
+  Maps a raw tool call to a canonical action_type and extracts entities.
+- **Channel metadata** in `normalizers/<channel>/_channel.yaml`.
+  Captures the MCP server, auth model, and `tool_pattern` the validator
+  enforces against every YAML in the directory.
+- **Foreign-tool aliases** in `normalizers/<channel>/aliases.yaml`.
+  Rewrites third-party MCP tool names onto canonical permit0
+  normalizer names so policies route correctly.
+- **Risk rule YAML** under `risk_rules/<verb>.yaml`. One file per
+  action type; channel-agnostic. Defines the base flags + amplifiers
+  and conditional rules.
+- **`pack.yaml`** at the pack root. Schema v2 manifest; the
+  validator's source of truth.
+- **`tests/`** for fixtures: `<channel>/` for per-vendor goldens,
+  `shared/` for cross-channel scenarios, `security/` for known-attack
+  patterns (required for verified+ tier).
+
+## Reading the existing pack
+
+The first-party email pack (`packs/permit0/email/`) is the
+reference implementation. 32 normalizers + 16 risk rules covering
+Gmail and Outlook. Production-tested and the model every new pack
+should follow.

--- a/packs/_template/CHANGELOG.md
+++ b/packs/_template/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this pack are documented in this file. Format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- TODO
+
+## [0.1.0] - TODO_DATE
+
+### Added
+
+- Initial pack with TODO_VERB normalizers and risk rules for TODO_DOMAIN.

--- a/packs/_template/README.md
+++ b/packs/_template/README.md
@@ -1,0 +1,66 @@
+# TODO_NAME pack
+
+> Replace every TODO in this template before submitting.
+
+## Scope
+
+Brief, specific description of what this pack governs. State what's IN
+scope (which tools, which action types) and what's NOT.
+
+## Action types covered
+
+| action_type | Tools mapped | Risk rule |
+|---|---|---|
+| TODO_DOMAIN.TODO_VERB | TODO_TOOL_NAMES | risk_rules/TODO_VERB.yaml |
+
+## Threat model
+
+- **Catches:** what attacker behavior or operator mistake this pack
+  prevents — be specific. "Catches send-to-external-without-policy" is
+  better than "catches misuse".
+- **Does NOT catch:** known limitations. Not catching things is fine;
+  silently not catching them is not.
+- **Known caveats:** edge cases, parameter remapping gaps, conditional
+  alias overrides, etc.
+
+## Calibration data
+
+This pack was tested against TODO_N golden fixtures from
+`tests/shared/`. Last calibrated TODO_DATE.
+
+## Channels
+
+| Channel | MCP server | Auth | Notes |
+|---|---|---|---|
+| TODO | TODO | TODO | TODO |
+
+## Layout
+
+```
+packs/<owner>/<name>/
+├── pack.yaml
+├── README.md (this file)
+├── CHANGELOG.md
+├── normalizers/
+│   └── <channel>/
+│       ├── _channel.yaml      ← channel metadata + tool_pattern
+│       ├── aliases.yaml       ← foreign-MCP name remapping
+│       └── <verb>.yaml × N    ← one normalizer per verb
+├── risk_rules/
+│   └── <verb>.yaml × N        ← one rule per action_type, channel-agnostic
+└── tests/
+    ├── <channel>/             ← per-channel fixtures
+    ├── shared/                ← cross-channel goldens
+    └── security/              ← known-attack fixtures (verified+ tier)
+```
+
+## Compatibility
+
+- **permit0 engine:** `>=0.1.0,<0.2`
+- **taxonomy:** `1.x`
+- **MCP servers:** TODO
+
+## Contributing
+
+See [`docs/pack-contribution-guide.md`](../../docs/pack-contribution-guide.md)
+for the contribution workflow.

--- a/packs/_template/normalizers/TODO_CHANNEL/TODO_VERB.yaml
+++ b/packs/_template/normalizers/TODO_CHANNEL/TODO_VERB.yaml
@@ -1,0 +1,36 @@
+# Normalizer template for one verb on the TODO_CHANNEL backend.
+#
+# Replace every TODO. The `id` must be unique within this pack and
+# stable across releases — risk rules don't reference it directly,
+# but the registry uses it to detect duplicates.
+
+permit0_pack: "TODO_OWNER/TODO_NAME"
+id: "TODO_NAME:TODO_CHANNEL_TODO_VERB"
+
+# Priority determines normalizer-dispatch order when multiple
+# normalizers match. Higher = earlier. Each priority must be unique
+# within the registry; the engine errors at build time if two share.
+# Convention: 100 + N where N grows roughly with verb specificity.
+priority: 100
+
+match:
+  # The raw tool name the agent calls (after alias rewriting). Must
+  # match `tool_pattern` declared in `_channel.yaml`.
+  tool: TODO_CHANNEL_TODO_VERB
+
+normalize:
+  # Must be a real `domain.verb` from docs/taxonomy.md. The validator
+  # rejects unknown action types.
+  action_type: "TODO_DOMAIN.TODO_VERB"
+  domain: "TODO_DOMAIN"
+  verb: "TODO_VERB"
+  channel: "TODO_CHANNEL"
+
+  # Map raw parameters onto canonical entity names. Risk rules `when:`
+  # blocks reference these. Provide `optional: true` for params that
+  # may be absent.
+  entities:
+    TODO_ENTITY:
+      from: "TODO_PARAM_NAME"
+      type: "string"   # or: int, bool, float, list
+      # optional: true

--- a/packs/_template/normalizers/TODO_CHANNEL/_channel.yaml
+++ b/packs/_template/normalizers/TODO_CHANNEL/_channel.yaml
@@ -1,0 +1,18 @@
+# Channel metadata for the TODO_CHANNEL backend.
+#
+# `tool_pattern` is enforced by `permit0 pack validate`: every YAML
+# in this directory must have a `match.tool` matching the pattern.
+# This guards against cross-channel poisoning (a normalizer in
+# normalizers/TODO_CHANNEL/ trying to claim a tool from another vendor).
+#
+# `mcp_server` points at the MCP adapter this channel was designed
+# against. Reference, not bundling — packs and MCP servers are
+# separate concerns.
+
+channel: TODO_CHANNEL
+display_name: "TODO Display Name"
+mcp_server: "TODO/path/to/mcp"
+auth: oauth_user        # or: api_key, mtls, none
+api_docs: "TODO_URL"
+tool_pattern: "TODO_CHANNEL_*"
+maintainers: [TODO_OWNER]

--- a/packs/_template/normalizers/TODO_CHANNEL/aliases.yaml
+++ b/packs/_template/normalizers/TODO_CHANNEL/aliases.yaml
@@ -1,0 +1,24 @@
+permit0_pack: "TODO_OWNER/TODO_NAME"
+
+# Foreign-tool-name aliases for the TODO_CHANNEL backend.
+#
+# Maps non-canonical tool names (third-party MCP exports, vendor SDK
+# names, common shortenings) onto the names this pack's normalizers
+# match. Aliasing happens AFTER ClientKind prefix stripping and
+# BEFORE normalizer dispatch.
+#
+# See crates/permit0-normalize/src/alias.rs for the resolver semantics.
+# Conditional aliases (with `when:` blocks) are supported when one
+# foreign tool name overloads multiple semantic actions.
+
+aliases: []
+  # Flat alias:
+  # - tool: foreign_tool_name
+  #   rewrite_as: TODO_CHANNEL_canonical_name
+  #
+  # Conditional alias:
+  # - tool: ambiguous_foreign_name
+  #   when:
+  #     - if: { param: kind, equals: SPAM }
+  #       rewrite_as: TODO_CHANNEL_mark_spam
+  #     - default: TODO_CHANNEL_move

--- a/packs/_template/pack.yaml
+++ b/packs/_template/pack.yaml
@@ -1,0 +1,61 @@
+# Template pack manifest. Replace every TODO before submitting.
+#
+# This file is the source of truth for `permit0 pack validate`. The
+# validator cross-checks `action_types:` against your normalizers and
+# risk rules, derives `trust_tier` from the `permit0_pack:` owner, and
+# refuses to load packs that drift from these invariants.
+
+pack_format: 2
+
+# <owner>/<name>. Owner determines the derived trust tier:
+#   "permit0/<name>"     → built-in (first-party only)
+#   "<other>/<name>"     → community
+permit0_pack: "TODO_OWNER/TODO_NAME"
+name: TODO_NAME
+version: "0.1.0"
+description: "TODO: one-line summary of what this pack governs."
+license: Apache-2.0  # MIT and BSD-2/3 also OK; copyleft licenses are flagged by the validator.
+
+# Engine + taxonomy compatibility ranges. Pack rejected at load if the
+# engine version falls outside this range.
+permit0_engine: ">=0.1.0,<0.2"
+taxonomy: "1.x"
+
+# Self-declared trust tier. Informational — the engine derives the
+# authoritative value from `permit0_pack`'s owner. Only the BuiltIn
+# (path: packs/permit0/*) and Community defaults are reachable in
+# Phase 1; Verified and Experimental require Phase 2 signing
+# infrastructure.
+trust_tier: community
+
+maintainers:
+  - github: "@TODO_GITHUB_HANDLE"
+  # email: "TODO@example.com"
+  # name: "TODO Display Name"
+
+# Action types this pack is responsible for. The validator requires:
+#   1. each entry parses as a real `domain.verb` from the taxonomy
+#   2. each entry has at least one normalizer producing it
+#   3. each entry has exactly one risk rule covering it
+#
+# Drift here flags via CI before merge. See docs/taxonomy.md for the
+# closed list of valid domain.verb pairs.
+action_types:
+  - TODO_DOMAIN.TODO_VERB
+  # - email.send
+  # - payment.charge
+
+# Channels this pack supports. Each channel is a self-contained
+# subdirectory under normalizers/<channel>/ with its own
+# _channel.yaml, aliases.yaml, and per-verb normalizer YAMLs. Adding
+# a vendor = create one directory + drop in the verbs.
+channels:
+  TODO_CHANNEL:
+    mcp_server: "TODO/path/to/mcp"
+    display_name: "TODO Display Name"
+
+# Phase 2 forward-compat. Leave empty in Phase 1; populated by signing
+# infrastructure when the federated registry ships.
+signature: ""
+provenance: ""
+content_hash: ""

--- a/packs/_template/risk_rules/TODO_VERB.yaml
+++ b/packs/_template/risk_rules/TODO_VERB.yaml
@@ -1,0 +1,55 @@
+# Risk rule template for one action_type. One file per
+# domain.verb — channel-agnostic, since rules score the canonical
+# action regardless of which vendor surfaced it.
+#
+# Replace every TODO. The validator rejects rules whose action_type
+# isn't listed in pack.yaml's `action_types:`.
+
+permit0_pack: "TODO_OWNER/TODO_NAME"
+action_type: "TODO_DOMAIN.TODO_VERB"
+
+# Base flags + amplifiers. Flags are categorical: GOVERNANCE, EXPOSURE,
+# OUTBOUND, PRIVILEGE, etc. Roles are 'primary' or 'secondary'.
+# Amplifiers are 0..=30 weights on dimensions: scope, sensitivity,
+# destination, irreversibility, boundary, etc.
+base:
+  flags: {}
+  # flags:
+  #   GOVERNANCE: primary
+  #   EXPOSURE: secondary
+
+  amplifiers:
+    scope: 1
+  # amplifiers:
+  #   scope: 5
+  #   sensitivity: 10
+
+# Conditional rules — adjust the score based on entity values.
+rules: []
+  # - when:
+  #     destination:
+  #       in_set: org.trusted_domains
+  #   then:
+  #     - downgrade:
+  #         dim: destination
+  #         delta: 5
+  #
+  # - when:
+  #     sensitivity:
+  #       gte: 8
+  #   then:
+  #     # Critical action types should always include at least one
+  #     # `gate:` mutation; the validator's security lint enforces it
+  #     # for the always-human list.
+  #     - gate: "needs_human_review"
+
+# Session-level rules — adjust based on call patterns within one
+# session (e.g. >100 calls = bulk reconnaissance).
+session_rules: []
+  # - when:
+  #     record_count:
+  #       gt: 100
+  #   then:
+  #     - upgrade:
+  #         dim: scope
+  #         delta: 4

--- a/packs/_template/tests/TODO_CHANNEL/.gitkeep
+++ b/packs/_template/tests/TODO_CHANNEL/.gitkeep
@@ -1,0 +1,1 @@
+tests/TODO_CHANNEL: per-channel fixtures (one YAML per scenario)

--- a/packs/_template/tests/security/.gitkeep
+++ b/packs/_template/tests/security/.gitkeep
@@ -1,0 +1,1 @@
+tests/security: known-attack-pattern fixtures (required for verified+ tier)

--- a/packs/_template/tests/shared/.gitkeep
+++ b/packs/_template/tests/shared/.gitkeep
@@ -1,0 +1,1 @@
+tests/shared: cross-channel goldens (one YAML per scenario)

--- a/packs/community/README.md
+++ b/packs/community/README.md
@@ -1,0 +1,56 @@
+# Community packs
+
+Phase 1 placeholder. Once the federated registry and signing
+infrastructure ship (Phase 2 — see `TODOS.md`), community-contributed
+packs will live in this directory.
+
+## Phase 1 status
+
+- This directory is empty by design.
+- `packs/permit0/<name>/` is the only path the engine loads from
+  in-tree.
+- Pack discovery walks both `packs/<pack>/` (legacy) and
+  `packs/<owner>/<pack>/` (the new layout). The three-level shape
+  `packs/community/<author>/<pack>/` is **not yet** discovered — it
+  lights up when Phase 2 lands.
+
+## Phase 2 (when this directory becomes live)
+
+```
+packs/community/
+├── README.md            (this file)
+├── alice/
+│   └── jira/
+│       ├── pack.yaml    (trust_tier: community, derived from owner)
+│       └── ...
+├── bob/
+│   └── notion/
+│       └── ...
+└── ...
+```
+
+When this lands, the discovery walker will accept depth-3 layouts
+under `community/`, and `permit0 pack install <owner>/<name>` will
+fetch + verify lockfile signatures from the federated registry.
+
+## Why this directory exists today
+
+So contributors and reviewers can see exactly where Phase 2 packs
+will land. Treating community packs as a first-class concept from
+day one keeps the contribution UX clear: contributors who land first-
+party packs (path `packs/permit0/<name>/`) follow the same layout as
+contributors who'll eventually land community packs.
+
+## Trust tier semantics
+
+| Tier | Path | Reachable in Phase 1? |
+|---|---|---|
+| `built-in` | `packs/permit0/<name>/` | yes (path-derived) |
+| `community` | anywhere else (default) | yes (default for non-permit0 owners) |
+| `verified` | community + permit0 co-sign | no — needs signing infra |
+| `experimental` | hidden by default | no — needs signing infra |
+
+The `trust_tier:` field in `pack.yaml` is **informational only**. The
+engine derives the authoritative tier from `permit0_pack`'s owner
+prefix. A community pack declaring `trust_tier: built-in` does not
+become built-in; the validator flags the mismatch.


### PR DESCRIPTION
> **Stacks on top of #10.** Will rebase onto main once #10 merges.

## Summary

Wraps up the contribution surface for the pack taxonomy refactor. No code paths change — pure scaffolding + docs that match the actual schema v2 + per-channel layout PRs 2 and 3 introduced.

## What lands

### \`packs/_template/\` — drop-in starter

```
packs/_template/
├── pack.yaml                     ← schema v2 with TODO markers
├── README.md                     ← scope / threat model / channels template
├── CHANGELOG.md
├── normalizers/
│   └── TODO_CHANNEL/
│       ├── _channel.yaml         ← channel metadata + tool_pattern
│       ├── aliases.yaml
│       └── TODO_VERB.yaml
├── risk_rules/
│   └── TODO_VERB.yaml
└── tests/
    ├── TODO_CHANNEL/
    ├── shared/
    └── security/
```

Every TODO marker is intentionally invalid so \`permit0 pack validate\` errors loudly until filled in. Better to error than silently ship a half-templated pack. The leading underscore makes \`discover_packs\` skip it.

### \`packs/community/\` — Phase 2 placeholder

Empty in Phase 1 by design. README documents the Phase 2 depth-3 layout (\`community/<author>/<pack>/\`), why community packs declaring \`trust_tier: built-in\` are flagged as self-attestation, and the trust tier table.

### \`packs/README.md\` — top-level overview

- Layout diagram for all three locations (\`permit0/\`, \`_template/\`, \`community/\`)
- Cardinality flow (N tools → 1 action_type → 1 risk rule)
- Trust tier table tied to the manifest-vs-derived distinction
- File-type explainer (normalizer, risk rule, channel metadata, aliases)
- Quick-start using the template

### \`docs/pack-contribution-guide.md\` — full rewrite

The previous guide was schema v1 (referenced \`packs/<pack>/normalizers/<pack>.normalizer.yaml\` and the legacy flat directory). Both layouts are gone after PR 3.

Rewrite walks the modern flow: issue → triage → scaffold from \`_template/\` → iterate via \`permit0 pack validate\` → fixtures → PR via the \`new-pack.md\` template. Lists all 9 validator checks with what each catches, names 5 common pitfalls (priority collisions, cross-channel poisoning, missing gates on critical actions, \`include_str!\` traps, forgetting \`action_types:\` entries), each with the fix.

### \`.github/PULL_REQUEST_TEMPLATE/new-pack.md\`

Used via \`gh pr create --template new-pack.md\`. Captures:

- Pack identity (\`<owner>/<name>\`, tier targeted, issue link)
- Action-type + channel tables
- Threat model section (catches / does NOT catch / known caveats)
- Calibration evidence
- Validator + fixture-test output blocks
- Per-tier checklists:
  - **All tiers:** schema v2, no legacy fields, 3 fixtures per action_type, README/CHANGELOG, etc.
  - **Built-in / verified only:** gate-on-critical-action enforcement, security fixtures, no Downgrade/Override on critical actions, channel-detection spoof check, red-team calibration
  - **Maintenance:** maintainer commitment, license check

## Bisectable commits

```
d047595 docs: rewrite pack-contribution-guide for schema v2 + per-channel layout
24d46d1 feat: community contribution scaffolding
4b3401c feat(packs): _template/ scaffold for new pack contributions
```

## Test plan

- [x] \`cargo test --workspace\` passes (no code changes; just docs + scaffolding)
- [x] \`permit0 pack validate packs/permit0/email\` reports "All 48 files valid" with zero warnings (\`_template/\` correctly ignored by \`discover_packs\`)
- [x] \`permit0 pack validate packs/_template\` errors on TODO markers (intentional)
- [x] All cross-references in \`packs/README.md\` and \`docs/pack-contribution-guide.md\` resolve to real files in this PR series
- [ ] CI on Ubuntu / macOS / Windows (will run on push)

## Out of scope

- \`permit0 pack new <owner>/<name>\` CLI subcommand — left as a follow-up. Until it lands, contributors copy \`packs/_template/\` manually (the contribution guide documents this).
- Cross-channel \`tool_pattern\` enforcement in the validator — also a follow-up. Today it's a manual review item; a future PR wires it into \`permit0 pack validate\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)