### PR TITLE
PR 7: rewrite `permit0 pack new` for schema v2 + per-channel layout

### DIFF
--- a/crates/permit0-cli/src/cmd/pack.rs
+++ b/crates/permit0-cli/src/cmd/pack.rs
@@ -262,118 +262,145 @@ struct FixtureDef {
     expected_permission: String,
 }
 
-/// Scaffold a new pack with normalizer, risk rule, and fixture stubs.
-pub fn new_pack(name: &str) -> Result<()> {
-    let pack_dir = Path::new("packs").join(name);
+/// Scaffold a new pack at `packs/<owner>/<name>/` by copying the
+/// in-tree template at `packs/_template/` and substituting TODO
+/// markers (`TODO_OWNER`, `TODO_NAME`, `TODO_CHANNEL`) with the
+/// caller-supplied values.
+///
+/// Argument shape: `<owner>/<name>` (e.g. `permit0/slack`,
+/// `alice/jira`). Missing slash → error with usage hint. The
+/// destination directory must not exist.
+///
+/// The output pack still has plenty of TODO markers (every
+/// per-verb stub, every action_type, every entity mapping). Those
+/// surface as hard validator errors so the contributor knows
+/// exactly what's left to fill in.
+pub fn new_pack(name_arg: &str) -> Result<()> {
+    let (owner, pack_name) = match name_arg.split_once('/') {
+        Some((o, n)) if !o.is_empty() && !n.is_empty() => (o, n),
+        _ => anyhow::bail!(
+            "expected `<owner>/<name>`, got \"{name_arg}\". Example: \
+             `permit0 pack new alice/jira`"
+        ),
+    };
+
+    let template_dir = Path::new("packs").join("_template");
+    if !template_dir.is_dir() {
+        anyhow::bail!(
+            "template not found at {} — make sure you're running from the workspace root",
+            template_dir.display()
+        );
+    }
+
+    let pack_dir = Path::new("packs").join(owner).join(pack_name);
     if pack_dir.exists() {
         anyhow::bail!("pack directory already exists: {}", pack_dir.display());
     }
+    if let Some(parent) = pack_dir.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
 
-    // Create directory structure
-    let normalizers_dir = pack_dir.join("normalizers");
-    let rules_dir = pack_dir.join("risk_rules");
-    let fixtures_dir = pack_dir.join("fixtures");
-    std::fs::create_dir_all(&normalizers_dir)?;
-    std::fs::create_dir_all(&rules_dir)?;
-    std::fs::create_dir_all(&fixtures_dir)?;
-
-    // Stub normalizer
-    let normalizer_stub = format!(
-        r#"id: {name}_default
-description: "Normalize {name} tool calls"
-priority: 100
-match:
-  tool: "{name}"
-action_type: "custom.{name}"
-channel: "{name}"
-entities:
-  - name: command
-    path: "$.parameters.command"
-    required: false
-    default: "unknown"
-"#
-    );
-    std::fs::write(
-        normalizers_dir.join(format!("{name}.normalizer.yaml")),
-        normalizer_stub,
-    )?;
-
-    // Stub risk rule
-    let risk_rule_stub = format!(
-        r#"id: {name}_base
-description: "Base risk rule for {name}"
-action_type: "custom.{name}"
-match:
-  tool: "{name}"
-flags:
-  - name: EXECUTION
-    role: secondary
-amplifiers: {{}}
-"#
-    );
-    std::fs::write(
-        rules_dir.join(format!("{name}.risk_rule.yaml")),
-        risk_rule_stub,
-    )?;
-
-    // Stub fixture
-    let fixture_stub = format!(
-        r#"tool_name: "{name}"
-parameters:
-  command: "test"
-expected_permission: "allow"
-"#
-    );
-    std::fs::write(
-        fixtures_dir.join(format!("{name}_basic.fixture.yaml")),
-        fixture_stub,
-    )?;
-
-    // README
-    let readme = format!(
-        r#"# {name} Pack
-
-A permit0 pack for `{name}` tool calls.
-
-## Structure
-
-```
-{name}/
-├── normalizers/
-│   └── {name}.normalizer.yaml
-├── risk_rules/
-│   └── {name}.risk_rule.yaml
-└── fixtures/
-    └── {name}_basic.fixture.yaml
-```
-
-## Usage
-
-```sh
-permit0 pack validate packs/{name}
-permit0 pack test packs/{name}
-```
-"#
-    );
-    std::fs::write(pack_dir.join("README.md"), readme)?;
+    // Recursive copy with substitution. We can't `cp -r` because we
+    // need to (a) rename TODO_CHANNEL directories and (b) substitute
+    // TODO markers inside YAML / Markdown contents.
+    let single_channel = pack_name; // sensible default; user renames later if multi-channel
+    copy_template_tree(&template_dir, &pack_dir, owner, pack_name, single_channel)?;
 
     println!("Created pack scaffold at {}", pack_dir.display());
-    println!("  normalizers/{name}.normalizer.yaml");
-    println!("  risk_rules/{name}.risk_rule.yaml");
-    println!("  fixtures/{name}_basic.fixture.yaml");
+    println!("  normalizers/{single_channel}/_channel.yaml");
+    println!("  normalizers/{single_channel}/aliases.yaml");
+    println!("  normalizers/{single_channel}/<verb>.yaml   ← rename TODO_VERB.yaml");
+    println!("  risk_rules/<verb>.yaml                    ← rename TODO_VERB.yaml");
+    println!("  pack.yaml");
     println!("  README.md");
+    println!("  CHANGELOG.md");
     println!();
     println!("Next steps:");
-    println!("  1. Edit the normalizer to match your tool's input format");
-    println!("  2. Add risk flags and amplifiers in the risk rule");
-    println!("  3. Add fixture test cases");
-    println!("  4. Run: permit0 pack validate packs/{name}");
+    println!("  1. Edit pack.yaml — fill in description, action_types, channels");
+    println!(
+        "  2. Rename normalizers/{single_channel}/TODO_VERB.yaml → <verb>.yaml; fill match.tool, action_type, entities"
+    );
+    println!(
+        "  3. Rename risk_rules/TODO_VERB.yaml → <verb>.yaml; fill flags / amplifiers / rules"
+    );
+    println!("  4. Add at least one fixture under tests/{single_channel}/");
+    println!("  5. Run: permit0 pack validate {}", pack_dir.display());
 
     Ok(())
 }
 
 fn is_yaml(path: &Path) -> bool {
     path.extension().is_some_and(|e| e == "yaml" || e == "yml")
+}
+
+/// Recursively copy `src` to `dst`, substituting template markers in
+/// path components AND file contents.
+///
+/// Substitutions:
+/// - `TODO_OWNER`   → `owner`
+/// - `TODO_NAME`    → `pack_name`
+/// - `TODO_CHANNEL` → `channel`
+///
+/// `.gitkeep` files in the template are dropped (they exist only to
+/// keep empty directories tracked by git in the source repo). Empty
+/// directories are still created.
+fn copy_template_tree(
+    src: &Path,
+    dst: &Path,
+    owner: &str,
+    pack_name: &str,
+    channel: &str,
+) -> Result<()> {
+    std::fs::create_dir_all(dst).with_context(|| format!("creating {}", dst.display()))?;
+
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let basename = entry.file_name();
+        let basename_str = basename.to_string_lossy();
+
+        if basename_str == ".gitkeep" {
+            continue;
+        }
+
+        let dst_basename = substitute_markers(&basename_str, owner, pack_name, channel);
+        let dst_path = dst.join(&*dst_basename);
+
+        if entry.file_type()?.is_dir() {
+            copy_template_tree(&src_path, &dst_path, owner, pack_name, channel)?;
+        } else {
+            let bytes = std::fs::read(&src_path)
+                .with_context(|| format!("reading {}", src_path.display()))?;
+            // Substitute markers only in text-ish files. YAML and
+            // Markdown is what the template ships; non-utf8 bytes get
+            // copied through unchanged.
+            let out = match std::str::from_utf8(&bytes) {
+                Ok(text) => substitute_markers(text, owner, pack_name, channel)
+                    .into_owned()
+                    .into_bytes(),
+                Err(_) => bytes,
+            };
+            std::fs::write(&dst_path, &out)
+                .with_context(|| format!("writing {}", dst_path.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn substitute_markers<'a>(
+    s: &'a str,
+    owner: &str,
+    pack_name: &str,
+    channel: &str,
+) -> std::borrow::Cow<'a, str> {
+    if !s.contains("TODO_OWNER") && !s.contains("TODO_NAME") && !s.contains("TODO_CHANNEL") {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let out = s
+        .replace("TODO_OWNER", owner)
+        .replace("TODO_NAME", pack_name)
+        .replace("TODO_CHANNEL", channel);
+    std::borrow::Cow::Owned(out)
 }
 
 /// Generate or refresh `pack.lock.yaml` for a pack directory.

--- a/crates/permit0-cli/tests/cli_tests.rs
+++ b/crates/permit0-cli/tests/cli_tests.rs
@@ -190,14 +190,33 @@ fn gateway_processes_jsonl() {
 
 #[test]
 fn pack_new_creates_scaffold() {
-    // Use a temp dir to avoid polluting the workspace
+    // PR 7 of the pack taxonomy refactor changed `pack new` to:
+    //   - require a `<owner>/<name>` argument
+    //   - copy the in-tree packs/_template/ and substitute markers
+    //   - place the result at packs/<owner>/<name>/
+    //
+    // The test runs in a temp dir so it doesn't pollute the workspace.
+    // Symlink the workspace's packs/_template into the temp dir so the
+    // scaffolder can find it.
     let tmp = std::env::temp_dir().join("permit0_test_pack_new");
     let _ = std::fs::remove_dir_all(&tmp);
     std::fs::create_dir_all(tmp.join("packs")).unwrap();
 
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+    let template_src = workspace_root.join("packs/_template");
+    let template_dst = tmp.join("packs/_template");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&template_src, &template_dst).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&template_src, &template_dst).unwrap();
+
     let output = Command::new(env!("CARGO_BIN_EXE_permit0"))
         .current_dir(&tmp)
-        .args(["pack", "new", "test_service"])
+        .args(["pack", "new", "alice/test_service"])
         .output()
         .unwrap();
     assert!(
@@ -206,20 +225,56 @@ fn pack_new_creates_scaffold() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // Verify scaffold files exist
+    // Verify scaffolded files exist (schema v2 + per-channel layout).
     assert!(
-        tmp.join("packs/test_service/normalizers/test_service.normalizer.yaml")
-            .exists()
+        tmp.join("packs/alice/test_service/pack.yaml").exists(),
+        "pack.yaml missing"
     );
     assert!(
-        tmp.join("packs/test_service/risk_rules/test_service.risk_rule.yaml")
-            .exists()
+        tmp.join("packs/alice/test_service/normalizers/test_service/_channel.yaml")
+            .exists(),
+        "_channel.yaml missing"
     );
     assert!(
-        tmp.join("packs/test_service/fixtures/test_service_basic.fixture.yaml")
-            .exists()
+        tmp.join("packs/alice/test_service/normalizers/test_service/aliases.yaml")
+            .exists(),
+        "aliases.yaml missing"
     );
-    assert!(tmp.join("packs/test_service/README.md").exists());
+    assert!(
+        tmp.join("packs/alice/test_service/normalizers/test_service/TODO_VERB.yaml")
+            .exists(),
+        "TODO_VERB.yaml stub missing"
+    );
+    assert!(
+        tmp.join("packs/alice/test_service/risk_rules/TODO_VERB.yaml")
+            .exists(),
+        "risk_rules TODO_VERB.yaml stub missing"
+    );
+
+    // pack.yaml should contain the substituted owner / pack name.
+    let pack_yaml =
+        std::fs::read_to_string(tmp.join("packs/alice/test_service/pack.yaml")).unwrap();
+    assert!(
+        pack_yaml.contains(r#"permit0_pack: "alice/test_service""#),
+        "permit0_pack not substituted: {pack_yaml}"
+    );
+    assert!(
+        pack_yaml.contains("name: test_service"),
+        "name not substituted: {pack_yaml}"
+    );
+
+    // Bad arg shape errors out cleanly.
+    let bad = Command::new(env!("CARGO_BIN_EXE_permit0"))
+        .current_dir(&tmp)
+        .args(["pack", "new", "no_slash_here"])
+        .output()
+        .unwrap();
+    assert!(!bad.status.success());
+    assert!(
+        String::from_utf8_lossy(&bad.stderr).contains("expected `<owner>/<name>`"),
+        "expected usage hint: stderr={}",
+        String::from_utf8_lossy(&bad.stderr)
+    );
 
     // Cleanup
     let _ = std::fs::remove_dir_all(&tmp);


### PR DESCRIPTION
> **Stacks on top of #13.**

## Summary

Rewrites \`permit0 pack new\` to scaffold from \`packs/_template/\` (introduced in PR 4) instead of generating a schema v1 / flat layout that no longer matches what the validator and engine expect.

\`\`\`
$ permit0 pack new alice/jira
Created pack scaffold at packs/alice/jira
  normalizers/jira/_channel.yaml
  normalizers/jira/aliases.yaml
  normalizers/jira/<verb>.yaml   ← rename TODO_VERB.yaml
  risk_rules/<verb>.yaml         ← rename TODO_VERB.yaml
  pack.yaml
  README.md
  CHANGELOG.md

Next steps:
  1. Edit pack.yaml — fill in description, action_types, channels
  2. Rename normalizers/jira/TODO_VERB.yaml → <verb>.yaml; ...
  ...
\`\`\`

## What changed

- Argument is now \`<owner>/<name>\` (required). Errors with a usage hint when the slash is missing — there's no sensible default since first-party (\`permit0/\`) vs community ownership drives the trust-tier derivation.
- The scaffolder copies \`packs/_template/\` recursively to \`packs/<owner>/<name>/\`, substituting \`TODO_OWNER\`, \`TODO_NAME\`, and \`TODO_CHANNEL\` markers in both path components AND file contents. Non-utf8 bytes pass through unchanged.
- \`.gitkeep\` files in the template are dropped (they exist only to keep empty test directories tracked in the source repo).
- Remaining \`TODO_VERB\` / \`TODO_DOMAIN\` markers are intentional — they surface as hard validator errors so the contributor knows exactly what's left to fill in.

## Verified

- \`permit0 pack new just-a-name\` errors with the usage hint
- \`permit0 pack new alice/jira\` produces the expected file tree with \`permit0_pack: "alice/jira"\` and \`name: jira\` correctly substituted
- The directory \`normalizers/TODO_CHANNEL/\` becomes \`normalizers/jira/\`
- \`permit0 pack validate packs/alice/jira\` errors on the remaining \`TODO_VERB\` / \`TODO_DOMAIN\` markers (expected)

## Test updates

\`cli_tests::pack_new_creates_scaffold\` was probing v1 file shapes (\`packs/test_service/normalizers/test_service.normalizer.yaml\`) that no longer exist. Updated to:
- Symlink \`packs/_template/\` into the test's temp dir so the scaffolder can find it
- Run \`pack new alice/test_service\`
- Verify the schema v2 file shape (\`pack.yaml\`, \`normalizers/test_service/_channel.yaml\`, \`normalizers/test_service/aliases.yaml\`, \`normalizers/test_service/TODO_VERB.yaml\`, \`risk_rules/TODO_VERB.yaml\`)
- Assert markers were substituted in \`pack.yaml\` (\`permit0_pack\` and \`name\`)
- Assert bad-arg path returns non-zero with the usage hint

## Test plan

- [x] Updated \`pack_new_creates_scaffold\` passes
- [x] Workspace tests pass (no regressions)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] CI on Ubuntu / macOS / Windows (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)