### PR TITLE
PR 8: tool_pattern enforcement in validator (closes cross-channel poisoning gap)

### DIFF
--- a/crates/permit0-cli/src/cmd/pack.rs
+++ b/crates/permit0-cli/src/cmd/pack.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use permit0_dsl::discover_normalizer_yamls;
 use permit0_dsl::normalizer::DslNormalizer;
-use permit0_dsl::pack_validate::{ViolationCode, validate_pack};
+use permit0_dsl::pack_validate::{ViolationCode, validate_channel_directories, validate_pack};
 use permit0_dsl::schema::PackManifest;
 use permit0_dsl::schema::risk_rule::RiskRuleDef;
 use permit0_dsl::validate;
@@ -139,6 +139,32 @@ pub fn validate(pack_path: &str) -> Result<()> {
                 println!("  ✗ {}: parse error: {e}", manifest_path.display());
                 total_errors += 1;
             }
+        }
+    }
+
+    // ── Per-channel tool_pattern enforcement (PR 8) ──
+    match validate_channel_directories(pack_dir) {
+        Ok(channel_violations) if !channel_violations.is_empty() => {
+            println!("\n── Channel manifest checks ──");
+            for v in &channel_violations {
+                let icon = match v.code {
+                    // Missing _channel.yaml in a per-channel directory
+                    // is a warning during the migration window;
+                    // tool-pattern mismatches are hard errors because
+                    // they signal active cross-channel poisoning.
+                    ViolationCode::MissingChannelManifest => "⚠",
+                    ViolationCode::ToolPatternMismatch => "✗",
+                    _ => "✗",
+                };
+                println!("  {icon} {} ({:?})", v.message, v.code);
+                if icon == "✗" {
+                    total_errors += 1;
+                }
+            }
+        }
+        Ok(_) => {}
+        Err(e) => {
+            println!("  ⚠ channel manifest check failed: {e}");
         }
     }
 

--- a/crates/permit0-dsl/src/lib.rs
+++ b/crates/permit0-dsl/src/lib.rs
@@ -19,4 +19,7 @@ pub use pack_loader::{
     ALIASES_FILENAME, CHANNEL_MANIFEST_FILENAME, DiscoveryError, PACK_MANIFEST_FILENAME,
     discover_alias_yamls, discover_normalizer_yamls, discover_packs,
 };
-pub use pack_validate::{ALWAYS_HUMAN_ACTION_TYPES, PackViolation, ViolationCode, validate_pack};
+pub use pack_validate::{
+    ALWAYS_HUMAN_ACTION_TYPES, PackViolation, ViolationCode, tool_pattern_matches,
+    validate_channel_directories, validate_pack,
+};

--- a/crates/permit0-dsl/src/pack_validate.rs
+++ b/crates/permit0-dsl/src/pack_validate.rs
@@ -89,6 +89,17 @@ pub enum ViolationCode {
     /// require explicit human review; gateless rules can let the engine
     /// auto-approve based on score alone.
     MissingGateOnCriticalAction,
+    /// A normalizer's `match.tool` doesn't satisfy the channel's
+    /// `tool_pattern` glob. Indicates cross-channel poisoning — a
+    /// normalizer placed in `normalizers/gmail/` claiming an `outlook_*`
+    /// tool would route Outlook traffic through gmail-channel risk
+    /// rules and aliases.
+    ToolPatternMismatch,
+    /// A `normalizers/<channel>/` directory exists but lacks an
+    /// `_channel.yaml`. The validator can't enforce `tool_pattern`
+    /// without the manifest; treat as warning rather than hard error
+    /// to keep coexistence with PR 2's flat normalizer layout.
+    MissingChannelManifest,
 }
 
 /// Run every manifest-level check and return a flat list of violations.
@@ -261,6 +272,169 @@ fn check_orphans(
             });
         }
     }
+}
+
+/// Match a tool name against a `_channel.yaml` `tool_pattern` glob.
+///
+/// Supported wildcards (intentionally minimal):
+/// - `*` matches any sequence of characters (including empty).
+/// - Everything else matches literally.
+///
+/// Examples:
+/// - `gmail_*` matches `gmail_send`, `gmail_archive`, but not
+///   `outlook_send` or just `gmail`.
+/// - `*` matches everything (escape hatch for legacy packs).
+/// - `gmail_send` matches only the literal name.
+///
+/// We don't pull in the `glob` crate for one matcher — patterns are
+/// short and the wildcard set is fixed. If patterns get more complex
+/// (character classes, recursive globs), revisit.
+pub fn tool_pattern_matches(pattern: &str, tool: &str) -> bool {
+    // Split on `*` and verify the parts appear in order in `tool`.
+    let parts: Vec<&str> = pattern.split('*').collect();
+    if parts.len() == 1 {
+        // No wildcards — literal match.
+        return parts[0] == tool;
+    }
+    let mut cursor = 0usize;
+    for (idx, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if idx == 0 {
+            // First non-empty part must be a prefix.
+            if !tool[cursor..].starts_with(part) {
+                return false;
+            }
+            cursor += part.len();
+        } else if idx == parts.len() - 1 {
+            // Last non-empty part must be a suffix.
+            return tool[cursor..].ends_with(part);
+        } else {
+            // Middle parts: any occurrence at-or-after `cursor`.
+            match tool[cursor..].find(part) {
+                Some(off) => cursor += off + part.len(),
+                None => return false,
+            }
+        }
+    }
+    true
+}
+
+/// Walk every `normalizers/<channel>/` subdirectory of a pack and
+/// verify each normalizer's `match.tool` satisfies the directory's
+/// `_channel.yaml` `tool_pattern`. Surfaces:
+/// - `ToolPatternMismatch` when a normalizer's tool name escapes
+///   the pattern (cross-channel poisoning).
+/// - `MissingChannelManifest` when a per-channel directory has
+///   normalizer YAMLs but no `_channel.yaml` (warning).
+///
+/// IO-bound, so this lives outside the pure `validate_pack`
+/// pipeline; the CLI calls it after the manifest checks. Returns an
+/// empty vec if the pack is still on the flat layout (no per-channel
+/// subdirectories).
+pub fn validate_channel_directories(
+    pack_dir: &std::path::Path,
+) -> Result<Vec<PackViolation>, std::io::Error> {
+    use crate::schema::pack::ChannelManifest;
+    let mut violations = Vec::new();
+
+    let normalizers_dir = pack_dir.join("normalizers");
+    if !normalizers_dir.is_dir() {
+        return Ok(violations);
+    }
+
+    for entry in std::fs::read_dir(&normalizers_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let basename = match path.file_name().and_then(|s| s.to_str()) {
+            Some(b) => b,
+            None => continue,
+        };
+        if basename.starts_with('_') || basename.starts_with('.') {
+            continue;
+        }
+
+        // Try to load _channel.yaml for the pattern. Surface a
+        // warning if missing; nothing else to enforce without it.
+        let channel_yaml_path = path.join(crate::CHANNEL_MANIFEST_FILENAME);
+        let pattern: Option<String> = if channel_yaml_path.is_file() {
+            let yaml = std::fs::read_to_string(&channel_yaml_path)?;
+            match serde_yaml::from_str::<ChannelManifest>(&yaml) {
+                Ok(m) => m.tool_pattern,
+                Err(_) => None,
+            }
+        } else {
+            violations.push(PackViolation {
+                code: ViolationCode::MissingChannelManifest,
+                message: format!(
+                    "normalizers/{basename}/ has normalizer YAMLs but no _channel.yaml \
+                     declaring `tool_pattern:`; tool-pattern enforcement skipped"
+                ),
+            });
+            None
+        };
+
+        let Some(pattern) = pattern else {
+            // _channel.yaml exists but doesn't declare tool_pattern;
+            // we already surfaced the manifest issue above (or chose
+            // to silently allow patternless channel manifests for
+            // back-compat). Skip enforcement.
+            continue;
+        };
+
+        // Check every normalizer YAML in the channel directory.
+        for sub in std::fs::read_dir(&path)? {
+            let sub = sub?;
+            let sub_path = sub.path();
+            let sub_basename = match sub_path.file_name().and_then(|s| s.to_str()) {
+                Some(b) => b,
+                None => continue,
+            };
+            if !sub_path
+                .extension()
+                .is_some_and(|e| e == "yaml" || e == "yml")
+            {
+                continue;
+            }
+            if sub_basename == crate::CHANNEL_MANIFEST_FILENAME
+                || sub_basename == crate::ALIASES_FILENAME
+            {
+                continue;
+            }
+            let yaml = std::fs::read_to_string(&sub_path)?;
+            // Pull `match.tool` out without deserializing the full
+            // normalizer schema. The normalizer DSL is permissive
+            // enough that re-parsing here would couple the validator
+            // to its evolution; a one-field probe is robust enough.
+            let parsed: serde_yaml::Value = match serde_yaml::from_str(&yaml) {
+                Ok(v) => v,
+                Err(_) => continue, // schema-level error already surfaced elsewhere
+            };
+            let Some(tool) = parsed
+                .get("match")
+                .and_then(|m| m.get("tool"))
+                .and_then(|t| t.as_str())
+            else {
+                continue;
+            };
+            if !tool_pattern_matches(&pattern, tool) {
+                violations.push(PackViolation {
+                    code: ViolationCode::ToolPatternMismatch,
+                    message: format!(
+                        "normalizers/{basename}/{sub_basename} has match.tool: \"{tool}\" \
+                         which does not match channel pattern \"{pattern}\" — \
+                         cross-channel poisoning suspected"
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(violations)
 }
 
 fn check_security_lint(risk_rule_targets: &[(String, RiskRuleDef)], out: &mut Vec<PackViolation>) {
@@ -506,6 +680,44 @@ session_rules: []
 "#
         );
         serde_yaml::from_str(&yaml).expect("valid risk rule")
+    }
+
+    // ── tool_pattern_matches ──
+
+    #[test]
+    fn tool_pattern_literal_matches_exactly() {
+        assert!(tool_pattern_matches("gmail_send", "gmail_send"));
+        assert!(!tool_pattern_matches("gmail_send", "gmail_archive"));
+        assert!(!tool_pattern_matches("gmail_send", "outlook_send"));
+    }
+
+    #[test]
+    fn tool_pattern_prefix_wildcard() {
+        assert!(tool_pattern_matches("gmail_*", "gmail_send"));
+        assert!(tool_pattern_matches("gmail_*", "gmail_archive"));
+        assert!(tool_pattern_matches("gmail_*", "gmail_"));
+        assert!(!tool_pattern_matches("gmail_*", "outlook_send"));
+        // Pattern requires the prefix to literally start the tool name.
+        assert!(!tool_pattern_matches("gmail_*", "x_gmail_send"));
+    }
+
+    #[test]
+    fn tool_pattern_suffix_wildcard() {
+        assert!(tool_pattern_matches("*_send", "gmail_send"));
+        assert!(tool_pattern_matches("*_send", "outlook_send"));
+        assert!(!tool_pattern_matches("*_send", "gmail_archive"));
+    }
+
+    #[test]
+    fn tool_pattern_universal() {
+        assert!(tool_pattern_matches("*", "anything"));
+        assert!(tool_pattern_matches("*", ""));
+    }
+
+    #[test]
+    fn tool_pattern_middle_wildcard() {
+        assert!(tool_pattern_matches("g*l_send", "gmail_send"));
+        assert!(!tool_pattern_matches("g*l_send", "gmail_archive"));
     }
 
     fn risk_rule_with_gate(action_type: &str) -> RiskRuleDef {

--- a/crates/permit0-dsl/src/schema/mod.rs
+++ b/crates/permit0-dsl/src/schema/mod.rs
@@ -8,8 +8,8 @@ pub mod risk_rule;
 pub use condition::{AnyMatch, ConditionExpr, Predicate, PredicateOps, UrlMatch};
 pub use normalizer::{ApiVersionDef, EntityDef, NormalizeDef, NormalizerDef};
 pub use pack::{
-    ChannelMeta, Maintainer, PACK_FORMAT_VERSION, PackManifest, TrustTier, derive_trust_tier,
-    extract_owner,
+    ChannelManifest, ChannelMeta, Maintainer, PACK_FORMAT_VERSION, PackManifest, TrustTier,
+    derive_trust_tier, extract_owner,
 };
 pub use risk_rule::{
     AddFlagDef, DimDeltaDef, DimValueDef, MutationDef, RiskBaseDef, RiskRuleDef, RuleDef,

--- a/crates/permit0-dsl/src/schema/pack.rs
+++ b/crates/permit0-dsl/src/schema/pack.rs
@@ -102,7 +102,7 @@ pub struct Maintainer {
     pub name: Option<String>,
 }
 
-/// Channel-level metadata (per-vendor).
+/// Channel-level metadata (per-vendor) declared in `pack.yaml`.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct ChannelMeta {
     /// Path to the MCP server adapter for this channel, e.g.
@@ -112,6 +112,46 @@ pub struct ChannelMeta {
     /// Display name (UI-facing).
     #[serde(default)]
     pub display_name: Option<String>,
+}
+
+/// `_channel.yaml` — full channel manifest sitting next to per-vendor
+/// normalizers under `normalizers/<channel>/`.
+///
+/// Distinct from [`ChannelMeta`] (which is the lightweight summary
+/// declared in `pack.yaml`'s `channels:` block). The `_channel.yaml`
+/// file is the authoritative per-channel record, including the
+/// `tool_pattern` glob the validator enforces against every normalizer
+/// in the directory to prevent cross-channel poisoning.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ChannelManifest {
+    /// Channel slug. Should match the directory name.
+    #[serde(default)]
+    pub channel: Option<String>,
+    /// Display name (UI-facing).
+    #[serde(default)]
+    pub display_name: Option<String>,
+    /// Path to the MCP server adapter for this channel.
+    #[serde(default)]
+    pub mcp_server: Option<String>,
+    /// Auth model: `oauth_user`, `api_key`, `mtls`, `none`.
+    #[serde(default)]
+    pub auth: Option<String>,
+    /// API documentation URL (informational).
+    #[serde(default)]
+    pub api_docs: Option<String>,
+    /// Glob pattern that every normalizer's `match.tool` in this
+    /// directory MUST satisfy. Uses simple `*` wildcards; for full
+    /// semantics see [`tool_pattern_matches`](super::super::pack_validate::tool_pattern_matches).
+    ///
+    /// The validator rejects normalizers whose `match.tool` doesn't
+    /// match. Guards against cross-channel poisoning where a
+    /// malicious normalizer in `normalizers/gmail/` claims
+    /// `outlook_send`.
+    #[serde(default)]
+    pub tool_pattern: Option<String>,
+    /// Maintainer handles (informational).
+    #[serde(default)]
+    pub maintainers: Vec<String>,
 }
 
 /// Authoritative pack trust tier.


### PR DESCRIPTION
> **Stacks on top of #14.**

## Summary

Closes the cross-channel poisoning gap PR 4 left as a manual review item. Every normalizer in \`normalizers/<channel>/\` now has its \`match.tool\` checked against the channel's \`_channel.yaml\` \`tool_pattern\` glob; mismatches surface as hard errors via \`permit0 pack validate\`.

## What lands

- **\`ChannelManifest\`** struct in \`permit0-dsl\` mirroring the full \`_channel.yaml\` shape. Distinct from \`ChannelMeta\` (the lightweight summary in \`pack.yaml\`'s \`channels:\` block) since the per-channel manifest is the authoritative record.

- **\`tool_pattern_matches(pattern, tool)\`** glob matcher with prefix/suffix/middle/universal \`*\` wildcards. Hand-rolled to avoid pulling in the \`glob\` crate for one short-pattern matcher.

- **\`validate_channel_directories(pack_dir)\`** IO-bound walker. Visits every \`normalizers/<channel>/\`, reads its \`_channel.yaml\`, verifies each normalizer's \`match.tool\` satisfies the declared pattern. Surfaces:
  - \`ToolPatternMismatch\` (hard error) — cross-channel poisoning
  - \`MissingChannelManifest\` (warning) — directory has normalizers but no \`_channel.yaml\`; tool-pattern enforcement skipped (allows coexistence with the legacy flat layout)

- **CLI**: \`permit0 pack validate\` runs the channel walker after manifest checks. New \`── Channel manifest checks ──\` section groups per-channel violations.

## Demo

\`\`\`
$ sed -i 's/tool: gmail_send/tool: outlook_send/' \\
      packs/permit0/email/normalizers/gmail/send.yaml
$ permit0 pack validate packs/permit0/email
...
── Channel manifest checks ──
  ✗ normalizers/gmail/send.yaml has match.tool: "outlook_send" \\
     which does not match channel pattern "gmail_*" — \\
     cross-channel poisoning suspected (ToolPatternMismatch)
Error: 1 error(s) in 48 files
\`\`\`

## Bisectable commits

\`\`\`
<this PR is one commit>
\`\`\`

## Test plan

- [x] 5 \`tool_pattern_matches\` unit tests (literal, prefix, suffix, middle, universal)
- [x] \`cargo test --workspace\` passes
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`permit0 pack validate packs/permit0/email\` reports "All 48 files valid" with zero violations on clean state
- [x] Cross-channel poisoning manually injected → \`ToolPatternMismatch\` surfaces → poisoning reverted → clean state restored
- [ ] CI on Ubuntu / macOS / Windows (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)