### PR TITLE
PR 9: first community pack walkthrough — packs/permit0/slack

### DIFF
--- a/crates/permit0-normalize/src/alias.rs
+++ b/crates/permit0-normalize/src/alias.rs
@@ -73,6 +73,10 @@ enum Matcher {
     /// Match if the param value is an array containing this scalar, or a
     /// string containing this substring.
     Contains(serde_json::Value),
+    /// Match if the param value is a string starting with this prefix.
+    /// Useful for ID-prefix routing (e.g. Slack channel IDs starting
+    /// with "D" for DMs vs "C" for public channels).
+    StartsWith(String),
 }
 
 impl Matcher {
@@ -84,6 +88,10 @@ impl Matcher {
                     serde_json::Value::String(n) => s.contains(n.as_str()),
                     _ => false,
                 },
+                _ => false,
+            },
+            Self::StartsWith(prefix) => match value {
+                serde_json::Value::String(s) => s.starts_with(prefix.as_str()),
                 _ => false,
             },
         }
@@ -267,15 +275,28 @@ struct ConditionYaml {
     param: String,
     #[serde(default)]
     contains: Option<serde_yaml::Value>,
+    /// String-prefix matcher for ID-prefix routing (e.g. Slack
+    /// channel IDs starting with `D` for DMs).
+    #[serde(default)]
+    starts_with: Option<String>,
 }
 
 impl ConditionYaml {
     fn compile(&self, tool: &str) -> Result<Condition, RegistryError> {
-        let matcher = match &self.contains {
-            Some(v) => Matcher::Contains(yaml_to_json(v.clone())),
-            None => {
+        let matcher = match (&self.contains, &self.starts_with) {
+            (Some(v), None) => Matcher::Contains(yaml_to_json(v.clone())),
+            (None, Some(prefix)) => Matcher::StartsWith(prefix.clone()),
+            (Some(_), Some(_)) => {
                 return Err(RegistryError::AliasParse(format!(
-                    "alias '{tool}' condition for param '{}' has no matcher (expected 'contains')",
+                    "alias '{tool}' condition for param '{}' has multiple matchers \
+                     (use one of `contains` or `starts_with`)",
+                    self.param
+                )));
+            }
+            (None, None) => {
+                return Err(RegistryError::AliasParse(format!(
+                    "alias '{tool}' condition for param '{}' has no matcher \
+                     (expected 'contains' or 'starts_with')",
                     self.param
                 )));
             }

--- a/packs/permit0/slack/CHANGELOG.md
+++ b/packs/permit0/slack/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this pack are documented in this file. Format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] - 2026-05-01
+
+### Added
+
+- Initial Slack pack covering five message-domain verbs:
+  `message.post_channel`, `message.send_dm`, `message.search`,
+  `message.react`, and `message.update`.
+- Foreign-tool aliases for Slack Web API method names
+  (`chat.postMessage`, `chat.update`, `search.messages`,
+  `reactions.add` after prefix strip) plus common community-MCP
+  shortenings (`post_message`, `send_dm`, `search`, `react`).
+- DM-vs-channel disambiguation via conditional alias on the
+  `channel` parameter: D/U-prefixed channel IDs route to
+  `slack_send_dm`, everything else to `slack_post_channel`.
+- Risk rules with always-human gate on DMs and session-rule
+  escalation for bulk posting / DM / search / update patterns.
+- One shared calibration fixture for the public-channel post
+  happy path.

--- a/packs/permit0/slack/README.md
+++ b/packs/permit0/slack/README.md
@@ -1,0 +1,102 @@
+# Slack pack
+
+Message-domain governance for Slack workspaces. Covers the verbs an
+LLM agent reaches for most often when wired to a Slack MCP server.
+
+## Scope
+
+**In scope.** Five message-domain verbs covering the bulk of
+Slack-MCP traffic: posting to public/private channels, DMing
+individuals, searching message history, reacting to messages, and
+editing messages the bot previously authored.
+
+**Out of scope (deferred to a follow-up).** `message.get` (reading
+single messages), `message.delete` (removing messages), and
+`message.send_sms` (Slack does not natively send SMS). Adding these
+later is one normalizer + one risk rule + an `action_types:` bump.
+
+**Out of scope (won't fix in this pack).** Slack Workflows, Slack
+Connect (cross-org channels), file uploads, channel admin
+(`channels.create`, `channels.archive`). Those belong in separate
+domain packs (`workflow`, `infra`, `file`) once the taxonomy fleshes
+them out.
+
+## Action types covered
+
+| action_type | Tools mapped | Risk rule |
+|---|---|---|
+| `message.post_channel` | `slack_post_channel`, `chat_post_message` (channel ID), `post_message` (channel ID) | [`risk_rules/post_channel.yaml`](risk_rules/post_channel.yaml) |
+| `message.send_dm` | `slack_send_dm`, `chat_post_message` (D/U-prefixed), `post_message` (D/U-prefixed), `send_dm` | [`risk_rules/send_dm.yaml`](risk_rules/send_dm.yaml) |
+| `message.search` | `slack_search`, `search_messages`, `search` | [`risk_rules/search.yaml`](risk_rules/search.yaml) |
+| `message.react` | `slack_react`, `reactions_add`, `react` | [`risk_rules/react.yaml`](risk_rules/react.yaml) |
+| `message.update` | `slack_update`, `chat_update` | [`risk_rules/update.yaml`](risk_rules/update.yaml) |
+
+## Threat model
+
+**Catches:**
+- Bulk DM social-engineering (>5 DMs in one session escalates `scope`).
+- Channel/DM disambiguation confusion — `chat.postMessage` to a U-prefixed channel is a DM, not a public post; the alias resolver routes them to different action types so policies that allow public posts can't accidentally allow DMs.
+- Block Kit posts with interactive UI elements (action-bearing buttons get a higher `scope` amplifier than plain text).
+- Bulk channel posting that looks like spam or stuffing (>10 posts/session escalates).
+- Bulk message editing that shapes like coverup behavior (>5 edits/session escalates `irreversibility`).
+- Reconnaissance via aggressive search (>50 search calls/session escalates).
+
+**Does NOT catch:**
+- Slack Workflows triggered by Block Kit actions — the agent's post is governed, but downstream workflow execution is a separate concern.
+- Cross-workspace Slack Connect leakage — the workspace-level audit trail covers this; the pack treats all channels uniformly.
+- File uploads attached to messages (`files.upload`) — out of scope; needs a `file.upload` action type when added.
+
+**Known caveats:**
+- The DM-vs-channel disambiguation is parameter-based: an MCP that surfaces channel IDs as opaque IDs without the C/D/U prefix will route incorrectly. Most Slack SDKs preserve the prefix; if yours doesn't, use a conditional alias on a different param.
+- Reactions don't carry parameter context worth scoring beyond presence. Workspace-level workflows that load-bear on specific reactions (e.g. `:white_check_mark:` triggering deploys) need a per-workspace risk-rule overlay rather than a base-pack policy.
+
+## Calibration data
+
+This pack ships with one golden fixture under `tests/shared/`. Add more before promoting beyond the initial 0.1.0 release. Last calibrated 2026-05-01.
+
+## Channels
+
+| Channel | MCP server | Auth | Notes |
+|---|---|---|---|
+| `slack` | [`clients/slack-mcp`](../../../clients/slack-mcp) (planned) | `oauth_user` | Slack Web API methods, snake_case after prefix strip |
+
+## Layout
+
+```
+packs/permit0/slack/
+├── pack.yaml
+├── pack.lock.yaml
+├── README.md (this file)
+├── CHANGELOG.md
+├── normalizers/
+│   └── slack/
+│       ├── _channel.yaml         ← channel metadata + tool_pattern: slack_*
+│       ├── aliases.yaml          ← Slack Web API + community-MCP names
+│       ├── post_channel.yaml
+│       ├── send_dm.yaml
+│       ├── search.yaml
+│       ├── react.yaml
+│       └── update.yaml
+├── risk_rules/
+│   ├── post_channel.yaml
+│   ├── send_dm.yaml
+│   ├── search.yaml
+│   ├── react.yaml
+│   └── update.yaml
+└── tests/
+    └── shared/
+        └── post-to-public-channel.yaml
+```
+
+## Compatibility
+
+- **permit0 engine:** `>=0.1.0,<0.2`
+- **taxonomy:** `1.x`
+- **MCP servers:** Slack Web API (any MCP wrapping it; `clients/slack-mcp/` planned in-tree)
+
+## Contributing
+
+See [`docs/pack-contribution-guide.md`](../../../docs/pack-contribution-guide.md)
+for the contribution workflow. The Slack pack is intentionally minimal
+right now — adding `get`, `delete`, and richer reaction policy is the
+natural next contribution.

--- a/packs/permit0/slack/normalizers/slack/_channel.yaml
+++ b/packs/permit0/slack/normalizers/slack/_channel.yaml
@@ -1,0 +1,18 @@
+# Channel metadata for the slack backend.
+#
+# `tool_pattern` is enforced by `permit0 pack validate` (PR 8 of the
+# pack taxonomy refactor): every YAML in this directory must have a
+# `match.tool` matching the glob. Cross-channel poisoning gets caught
+# at validate time, not at runtime when an agent has already escaped.
+#
+# `aliases.yaml` next to this file holds foreign-MCP name rewrites
+# (Slack's official MCP, community SDKs) that route to canonical
+# slack_* normalizer names.
+
+channel: slack
+display_name: "Slack"
+mcp_server: clients/slack-mcp
+auth: oauth_user
+api_docs: https://api.slack.com/methods
+tool_pattern: "slack_*"
+maintainers: [permit0]

--- a/packs/permit0/slack/normalizers/slack/aliases.yaml
+++ b/packs/permit0/slack/normalizers/slack/aliases.yaml
@@ -1,0 +1,59 @@
+permit0_pack: "permit0/slack"
+
+# Slack-channel foreign-tool-name aliases.
+#
+# Maps Slack Web API method names (chat.postMessage, etc.) and common
+# community-MCP exports onto canonical permit0 normalizer names so
+# policies and risk rules apply uniformly.
+#
+# Aliasing happens AFTER ClientKind prefix stripping (mcporter's
+# `slack.chat_post` becomes `chat_post`) and BEFORE normalizer
+# dispatch. See crates/permit0-normalize/src/alias.rs for resolver
+# semantics.
+#
+# Slack tools converge: `chat.postMessage` posts to a channel OR a DM
+# depending on whether the `channel` param is a channel ID (C…) or a
+# user/IM ID (D… / U…). The conditional alias below routes those two
+# cases to different action types so policies that allow public
+# channel posts don't accidentally allow DMs to coworkers.
+
+aliases:
+  # ── Slack Web API method names (snake_case after prefix strip) ──
+
+  - tool: chat_post_message
+    when:
+      # DMs use D-prefix (IM channel IDs) or U-prefix (user IDs that
+      # Slack auto-resolves to an IM).
+      - if: { param: channel, starts_with: "D" }
+        rewrite_as: slack_send_dm
+      - if: { param: channel, starts_with: "U" }
+        rewrite_as: slack_send_dm
+      - default: slack_post_channel
+
+  - tool: chat_update
+    rewrite_as: slack_update
+
+  - tool: search_messages
+    rewrite_as: slack_search
+
+  - tool: reactions_add
+    rewrite_as: slack_react
+
+  # ── Common community-MCP names ──
+
+  - tool: post_message
+    when:
+      - if: { param: channel, starts_with: "D" }
+        rewrite_as: slack_send_dm
+      - if: { param: channel, starts_with: "U" }
+        rewrite_as: slack_send_dm
+      - default: slack_post_channel
+
+  - tool: send_dm
+    rewrite_as: slack_send_dm
+
+  - tool: search
+    rewrite_as: slack_search
+
+  - tool: react
+    rewrite_as: slack_react

--- a/packs/permit0/slack/normalizers/slack/post_channel.yaml
+++ b/packs/permit0/slack/normalizers/slack/post_channel.yaml
@@ -1,0 +1,29 @@
+permit0_pack: "permit0/slack"
+id: "slack:slack_post_channel"
+priority: 200
+match:
+  tool: slack_post_channel
+normalize:
+  action_type: "message.post_channel"
+  domain: "message"
+  verb: "post_channel"
+  channel: "slack"
+  entities:
+    target_channel:
+      from: "channel"
+      type: "string"
+    text:
+      from: "text"
+      type: "string"
+      optional: true
+    blocks:
+      # Block Kit payloads can carry interactive buttons that change
+      # the audit trail's apparent intent — surface their presence so
+      # risk rules can flag posts with action-bearing UI.
+      from: "blocks"
+      type: "list"
+      optional: true
+    thread_ts:
+      from: "thread_ts"
+      type: "string"
+      optional: true

--- a/packs/permit0/slack/normalizers/slack/react.yaml
+++ b/packs/permit0/slack/normalizers/slack/react.yaml
@@ -1,0 +1,24 @@
+permit0_pack: "permit0/slack"
+id: "slack:slack_react"
+priority: 203
+match:
+  tool: slack_react
+normalize:
+  action_type: "message.react"
+  domain: "message"
+  verb: "react"
+  channel: "slack"
+  entities:
+    target_channel:
+      from: "channel"
+      type: "string"
+    timestamp:
+      from: "timestamp"
+      type: "string"
+    name:
+      # Emoji name without colons. The risk rule is mostly indifferent
+      # to which reaction — but recording it lets policies block
+      # specific signaling reactions like :white_check_mark: that
+      # might be load-bearing in incident workflows.
+      from: "name"
+      type: "string"

--- a/packs/permit0/slack/normalizers/slack/search.yaml
+++ b/packs/permit0/slack/normalizers/slack/search.yaml
@@ -1,0 +1,22 @@
+permit0_pack: "permit0/slack"
+id: "slack:slack_search"
+priority: 202
+match:
+  tool: slack_search
+normalize:
+  action_type: "message.search"
+  domain: "message"
+  verb: "search"
+  channel: "slack"
+  entities:
+    query:
+      from: "query"
+      type: "string"
+    sort:
+      from: "sort"
+      type: "string"
+      optional: true
+    count:
+      from: "count"
+      type: "int"
+      optional: true

--- a/packs/permit0/slack/normalizers/slack/send_dm.yaml
+++ b/packs/permit0/slack/normalizers/slack/send_dm.yaml
@@ -1,0 +1,24 @@
+permit0_pack: "permit0/slack"
+id: "slack:slack_send_dm"
+priority: 201
+match:
+  tool: slack_send_dm
+normalize:
+  action_type: "message.send_dm"
+  domain: "message"
+  verb: "send_dm"
+  channel: "slack"
+  entities:
+    recipient:
+      # Either an IM channel ID (D…) or a direct user ID (U…); the
+      # alias resolver routes both to this normalizer.
+      from: "channel"
+      type: "string"
+    text:
+      from: "text"
+      type: "string"
+      optional: true
+    thread_ts:
+      from: "thread_ts"
+      type: "string"
+      optional: true

--- a/packs/permit0/slack/normalizers/slack/update.yaml
+++ b/packs/permit0/slack/normalizers/slack/update.yaml
@@ -1,0 +1,25 @@
+permit0_pack: "permit0/slack"
+id: "slack:slack_update"
+priority: 204
+match:
+  tool: slack_update
+normalize:
+  action_type: "message.update"
+  domain: "message"
+  verb: "update"
+  channel: "slack"
+  entities:
+    target_channel:
+      from: "channel"
+      type: "string"
+    timestamp:
+      from: "ts"
+      type: "string"
+    text:
+      from: "text"
+      type: "string"
+      optional: true
+    blocks:
+      from: "blocks"
+      type: "list"
+      optional: true

--- a/packs/permit0/slack/pack.lock.yaml
+++ b/packs/permit0/slack/pack.lock.yaml
@@ -1,0 +1,45 @@
+lockfile_version: 1
+permit0_pack: permit0/slack
+pack_version: 0.1.0
+pack_format: 2
+generated_at: 2026-05-02T00:04:47Z
+files:
+- path: normalizers/slack/_channel.yaml
+  sha256: 7c66fb4b937a03222f7a49a85e5264b8067a45a1f35113b29ec3e49dce383127
+  size: 655
+- path: normalizers/slack/aliases.yaml
+  sha256: 3aba9871c4b0f9561f81596cb75bf287440b90360d2a08c115903f368305713f
+  size: 1825
+- path: normalizers/slack/post_channel.yaml
+  sha256: c23463a9aec2ad16f03f939a880fc38c956cbc65a44cc5c76c2cf38cc030a7c2
+  size: 719
+- path: normalizers/slack/react.yaml
+  sha256: cd93dc091ddc68cdf9f4efaab8149b25aba3f274d0fce423a265fc751a639ea9
+  size: 634
+- path: normalizers/slack/search.yaml
+  sha256: df35f5d8537192367e19eee2f8145996acef934454b815d20a64d114accde628
+  size: 401
+- path: normalizers/slack/send_dm.yaml
+  sha256: 686dd1af6606a5007d47cc907208961fcc6b9abfc39670dcda18f3e7ab24aca8
+  size: 548
+- path: normalizers/slack/update.yaml
+  sha256: 173ddf043e68d1863bcf17f90dff02b80701e76c1095a8b06a5dbc2ddc6ff738
+  size: 468
+- path: pack.yaml
+  sha256: eb29cb74a1ac04a8004839c84e7bf33db12ef1ad22456201fded966abaf98c6d
+  size: 1282
+- path: risk_rules/post_channel.yaml
+  sha256: bc19bf2ea49ab5c93f70d89c87f6f03ad351355d42272a30169e98ea9a9a6170
+  size: 1038
+- path: risk_rules/react.yaml
+  sha256: 8b302f65f57906ca8fc11fdd0ada2ca9cc8fc11364c9f1b7a141ce37e00d5bcc
+  size: 423
+- path: risk_rules/search.yaml
+  sha256: 947872690803f81087311b9f5fae14ebcf2dd4cffa421c3518676c0f21f4aa5c
+  size: 418
+- path: risk_rules/send_dm.yaml
+  sha256: 2d1e8716c4df2e80ccaea36a02cca78d3eaf52d92487a476cadd0096883ee9c5
+  size: 1072
+- path: risk_rules/update.yaml
+  sha256: 6454d76023da908dc477e0399a046f49056665c7d30e1b7324bd4b0abb4f9363
+  size: 758

--- a/packs/permit0/slack/pack.yaml
+++ b/packs/permit0/slack/pack.yaml
@@ -1,0 +1,45 @@
+# Slack pack — message-domain governance for Slack workspaces.
+#
+# Covers the verbs an LLM agent reaches for most often when wired to a
+# Slack MCP server: posting to channels, sending DMs, searching
+# message history, reacting to messages, and editing messages it
+# previously authored. See README.md for the full threat model.
+
+pack_format: 2
+
+permit0_pack: "permit0/slack"
+name: slack
+version: "0.1.0"
+description: "Slack message-domain governance: post, DM, search, react, update."
+license: Apache-2.0
+
+permit0_engine: ">=0.1.0,<0.2"
+taxonomy: "1.x"
+
+# packs/permit0/* derives BuiltIn — declaration is informational.
+trust_tier: built-in
+
+maintainers:
+  - github: "@permit0-team"
+
+# Five message-domain verbs covering the bulk of Slack-MCP traffic.
+# get/delete/send_sms in the taxonomy are intentionally deferred to a
+# follow-up — adding them later is one normalizer + one risk rule + an
+# action_types: bump (minor version per the SemVer rules in
+# docs/pack-contribution-guide.md).
+action_types:
+  - message.post_channel
+  - message.send_dm
+  - message.search
+  - message.react
+  - message.update
+
+channels:
+  slack:
+    mcp_server: clients/slack-mcp
+    display_name: "Slack"
+
+# Phase 2 forward-compat. Empty in Phase 1.
+signature: ""
+provenance: ""
+content_hash: ""

--- a/packs/permit0/slack/risk_rules/post_channel.yaml
+++ b/packs/permit0/slack/risk_rules/post_channel.yaml
@@ -1,0 +1,35 @@
+permit0_pack: "permit0/slack"
+action_type: "message.post_channel"
+# Default tier: LOW — public channel posts are visible to whoever's
+# in the channel, but the blast radius is bounded by membership.
+# Amplifiers escalate when the message lands somewhere wider (a
+# company-wide channel) or carries action-bearing UI (Block Kit
+# buttons that can trigger workflows).
+base:
+  flags:
+    OUTBOUND: secondary
+  amplifiers:
+    scope: 3
+    sensitivity: 2
+rules:
+  # Block Kit blocks can render interactive buttons. A model posting
+  # a button labeled "Approve and ship" is a different blast radius
+  # than a plain text update — escalate.
+  - when:
+      blocks:
+        exists: true
+    then:
+      - upgrade:
+          dim: scope
+          delta: 5
+session_rules:
+  # >10 channel posts in a session = automation, not a teammate.
+  # Possibly fine for a status-bot, possibly spam — let policy decide
+  # at a higher tier.
+  - when:
+      record_count:
+        gt: 10
+    then:
+      - upgrade:
+          dim: scope
+          delta: 4

--- a/packs/permit0/slack/risk_rules/react.yaml
+++ b/packs/permit0/slack/risk_rules/react.yaml
@@ -1,0 +1,12 @@
+permit0_pack: "permit0/slack"
+action_type: "message.react"
+# Default tier: MINIMAL — emoji reactions are low-impact ambient
+# signal. The rare exceptions are reactions that load-bear in a
+# workflow (e.g. :white_check_mark: as a deploy-approval signal in
+# some ops cultures) — that's a per-workspace policy concern, not
+# something to bake into the pack.
+base:
+  flags: {}
+  amplifiers: {}
+rules: []
+session_rules: []

--- a/packs/permit0/slack/risk_rules/search.yaml
+++ b/packs/permit0/slack/risk_rules/search.yaml
@@ -1,0 +1,18 @@
+permit0_pack: "permit0/slack"
+action_type: "message.search"
+# Default tier: MINIMAL — read-only search across the workspace's
+# message history. Same reconnaissance shape as email search:
+# bulk-querying is a signal worth escalating.
+base:
+  flags: {}
+  amplifiers:
+    scope: 1
+rules: []
+session_rules:
+  - when:
+      record_count:
+        gt: 50
+    then:
+      - upgrade:
+          dim: scope
+          delta: 4

--- a/packs/permit0/slack/risk_rules/send_dm.yaml
+++ b/packs/permit0/slack/risk_rules/send_dm.yaml
@@ -1,0 +1,34 @@
+permit0_pack: "permit0/slack"
+action_type: "message.send_dm"
+# Default tier: MEDIUM — DMs are private 1:1 communication. An LLM
+# initiating a DM with a coworker is qualitatively different from
+# posting in a public channel: there's no audience to spot a wrong
+# tone, social-engineering attempts have a clearer target, and the
+# message bypasses any moderation that exists at the channel level.
+base:
+  flags:
+    OUTBOUND: primary
+    BOUNDARY: secondary
+  amplifiers:
+    scope: 5
+    boundary: 8
+    sensitivity: 4
+rules:
+  # DMs to multiple distinct recipients in a session escalate fast.
+  # That's the bulk-DM social-engineering signature.
+  - when:
+      recipient:
+        exists: true
+    then:
+      # Always-human gate for DMs — the scoring tier may be Medium
+      # but the workflow should always surface for review until the
+      # user explicitly allowlists per-recipient or per-thread.
+      - gate: "slack_dm_human_review"
+session_rules:
+  - when:
+      record_count:
+        gt: 5
+    then:
+      - upgrade:
+          dim: scope
+          delta: 6

--- a/packs/permit0/slack/risk_rules/update.yaml
+++ b/packs/permit0/slack/risk_rules/update.yaml
@@ -1,0 +1,25 @@
+permit0_pack: "permit0/slack"
+action_type: "message.update"
+# Default tier: LOW — editing a message the bot previously authored
+# is benign in most cases. Two amplifiers worth noting:
+#
+# 1. Editing across thread/channel boundaries is unusual; a model
+#    that's editing somewhere it didn't post probably picked up the
+#    timestamp from a leaked context. (Slack APIs allow editing only
+#    your own messages, so this is mostly defense in depth.)
+# 2. Bulk edits in a session shape like coverup behavior — escalate.
+base:
+  flags:
+    OUTBOUND: secondary
+  amplifiers:
+    scope: 2
+    irreversibility: 4
+rules: []
+session_rules:
+  - when:
+      record_count:
+        gt: 5
+    then:
+      - upgrade:
+          dim: irreversibility
+          delta: 6

--- a/packs/permit0/slack/tests/shared/post-to-public-channel.yaml
+++ b/packs/permit0/slack/tests/shared/post-to-public-channel.yaml
@@ -1,0 +1,12 @@
+# Cross-channel-by-vendor calibration: a plain text post to a public
+# Slack channel. Should route via the alias resolver from
+# `chat_post_message` → `slack_post_channel`, score Minimal (scope=3,
+# sensitivity=2 from base; no Block Kit blocks so no further upgrade —
+# combined weight stays below the Low threshold), and decide Allow.
+name: slack_post_to_public_channel_simple
+tool_name: chat_post_message
+parameters:
+  channel: "C1234567890"           # C-prefixed → public/private channel, NOT a DM
+  text: "Build #4567 succeeded."
+expected_tier: "Minimal"
+expected_permission: "Allow"


### PR DESCRIPTION
> **Stacks on top of #15.** Validates the entire pack taxonomy refactor sequence against a real second pack.

## Summary

Closes the "first community pack walkthrough" TODO. Adds \`packs/permit0/slack\` covering five message-domain verbs end-to-end: schema v2 manifest, per-channel layout, foreign-MCP aliases, risk rules with always-human gating on DMs, calibration fixture, generated lockfile.

Also extends the alias matcher with \`starts_with\` (alongside the existing \`contains\`) so Slack channel-ID prefix routing — \`D\`/\`U\` prefix → DM, \`C\` prefix → channel — works without false positives.

## Slack pack scope

| Verb | Tools mapped | Risk rule highlights |
|---|---|---|
| \`message.post_channel\` | \`slack_post_channel\`, \`chat_post_message\` (C-prefix), \`post_message\` (C-prefix) | Low base; +5 scope on Block Kit; +4 scope on >10 posts/session |
| \`message.send_dm\` | \`slack_send_dm\`, \`chat_post_message\` (D/U-prefix), \`post_message\` (D/U-prefix), \`send_dm\` | Medium base + **always-human gate**; +6 scope on >5 DMs/session |
| \`message.search\` | \`slack_search\`, \`search_messages\`, \`search\` | Minimal base; +4 scope on >50 searches/session |
| \`message.react\` | \`slack_react\`, \`reactions_add\`, \`react\` | Minimal — ambient signal |
| \`message.update\` | \`slack_update\`, \`chat_update\` | Low base; +6 irreversibility on >5 edits/session (coverup shape) |

DM-vs-channel disambiguation via the new \`starts_with\` matcher routes \`chat.postMessage\` to \`message.send_dm\` when the channel param starts with D/U, and to \`message.post_channel\` otherwise. Policies that allow public-channel posts can't accidentally allow DMs.

## What lands

### \`crates/permit0-normalize/src/alias.rs\`

\`Matcher\` gains \`StartsWith(String)\`. \`ConditionYaml\` accepts \`starts_with\` alongside \`contains\` (rejects both, rejects neither). Schema:

\`\`\`yaml
aliases:
  - tool: chat_post_message
    when:
      - if: { param: channel, starts_with: "D" }
        rewrite_as: slack_send_dm
      - default: slack_post_channel
\`\`\`

### \`packs/permit0/slack/\`

13-file pack with:
- \`pack.yaml\` (schema v2, 5 \`action_types\`, channel: slack)
- \`pack.lock.yaml\` (committed; passes \`pack lock --check\`)
- \`README.md\` with full threat model + channels table + layout reference
- \`CHANGELOG.md\` with the 0.1.0 entry
- \`normalizers/slack/_channel.yaml\` (tool_pattern: \`slack_*\`)
- \`normalizers/slack/aliases.yaml\` (Slack Web API + community names; \`starts_with\` routing)
- 5 verb normalizers
- 5 risk rules
- 1 calibration fixture under \`tests/shared/\`

## End-to-end verification

\`\`\`
$ permit0 pack validate packs/permit0/slack
All 10 files valid.

$ permit0 pack validate packs/permit0/email
All 48 files valid.

$ permit0 calibrate test
── Corpus: corpora/calibration ──
  ✓ gmail_simple_email: tier=LOW perm=ALLOW
  ✓ outlook_simple_email: tier=LOW perm=ALLOW
── Corpus: packs/permit0/email/tests/shared ──
  ✓ email_send_shared_pack_local: tier=LOW perm=ALLOW
── Corpus: packs/permit0/slack/tests/shared ──
  ✓ slack_post_to_public_channel_simple: tier=MINIMAL perm=ALLOW
4 passed, 0 failed, 4 total (3 corpora scanned)

$ permit0 --strict-lockfile check --input '{"tool_name":"chat_post_message","parameters":{"channel":"D123","text":"Hi"}}'
Action: message.send_dm     ← alias resolver routed D-prefix → DM
\`\`\`

## What this validates about the refactor sequence

| Refactor PR | Validated by Slack pack |
|---|---|
| PR 1 (catalog → taxonomy) | \`message.send_dm\` etc. parse as valid taxonomy entries |
| PR 2 (schema v2 + discovery) | Slack manifest in v2 format; \`discover_packs\` finds both packs |
| PR 3 (per-channel layout) | \`normalizers/slack/\` self-contained; \`tool_pattern\` enforced |
| PR 4 (template + community) | Pack scaffolded from \`packs/_template/\` then filled in |
| PR 5 (calibration discovery) | Slack \`tests/shared/\` runs alongside email + cross-pack corpora |
| PR 6 (lockfile) | Slack \`pack.lock.yaml\` generated; \`--strict-lockfile\` works |
| PR 7 (\`pack new\`) | Used to bootstrap the directory |
| PR 8 (tool_pattern) | Slack normalizers all match \`slack_*\` |

## Bisectable commits

\`\`\`
0b96986 feat(normalize): alias matcher gains starts_with for ID-prefix routing
<slack pack commit>
\`\`\`

## Test plan

- [x] \`cargo test --workspace\` passes
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`permit0 pack validate packs/permit0/slack\` reports 10 files valid
- [x] \`permit0 pack validate packs/permit0/email\` still reports 48 files valid (no regression)
- [x] \`permit0 calibrate test\` reports 4/4 across 3 corpora
- [x] Channel/DM disambiguation works (\`chat_post_message\` with \`channel: "D…"\` → \`message.send_dm\`; with \`channel: "C…"\` → \`message.post_channel\`)
- [x] \`--strict-lockfile\` mode loads both packs without warnings
- [ ] CI on Ubuntu / macOS / Windows (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)