### PR TITLE
docs(taxonomy): rewrite for accuracy + CI-enforced sync test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,7 @@ name = "permit0-types"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "permit0-test-utils",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/permit0-types/Cargo.toml
+++ b/crates/permit0-types/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+permit0-test-utils = { workspace = true }

--- a/crates/permit0-types/tests/taxonomy_doc_sync.rs
+++ b/crates/permit0-types/tests/taxonomy_doc_sync.rs
@@ -1,0 +1,132 @@
+//! Keep `docs/taxonomy.md` in sync with the canonical
+//! `permit0_types::taxonomy` enum.
+//!
+//! The doc is hand-written (it carries prose, threat scenarios,
+//! "✅ shipped" markers) but the enum is the source of truth. CI
+//! enforces both halves stay aligned:
+//!
+//! - **Every `Domain::Verb` in the enum appears in the doc.**
+//!   Missing a new verb in the doc is a CI failure, not a release
+//!   surprise.
+//! - **Every `domain.verb` mentioned in the doc parses as a valid
+//!   `ActionType`.** A typo or stale reference fails the build.
+//!
+//! When the enum changes, edit `docs/taxonomy.md` in the same PR.
+//! That's the price for keeping the doc human-readable instead of
+//! auto-generated.
+
+use permit0_test_utils::load_test_fixture;
+use permit0_types::{ALL_DOMAINS, ActionType, all_action_types};
+
+const TAXONOMY_DOC: &str = "docs/taxonomy.md";
+
+#[test]
+fn every_action_type_in_enum_appears_in_doc() {
+    let doc = load_test_fixture(TAXONOMY_DOC);
+    let mut missing = Vec::new();
+    for at in all_action_types() {
+        let needle = format!("`{}`", at.as_action_str());
+        if !doc.contains(&needle) {
+            missing.push(at.as_action_str());
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "the following action_types are in `permit0_types::taxonomy` \
+         but missing from {TAXONOMY_DOC} (look for them as `domain.verb` \
+         in backticks): {missing:?}\n\n\
+         Action: add a row in the matching `### <domain>` section of {TAXONOMY_DOC}.",
+    );
+}
+
+#[test]
+fn every_action_type_mentioned_in_doc_is_valid() {
+    let doc = load_test_fixture(TAXONOMY_DOC);
+    // Anchor on real domain names from the enum so file paths
+    // (`docs/taxonomy.md`), version ranges (`1.x`), Rust paths
+    // (`permit0_types::taxonomy`), and the literal placeholder
+    // `domain.verb` don't get flagged as invalid action types.
+    let known_domains: std::collections::BTreeSet<&'static str> =
+        ALL_DOMAINS.iter().map(|d| d.as_str()).collect();
+
+    let mut invalid: Vec<String> = Vec::new();
+    let mut idx = 0usize;
+    while let Some(open) = doc[idx..].find('`') {
+        let start = idx + open + 1;
+        let close_off = match doc[start..].find('`') {
+            Some(o) => o,
+            None => break,
+        };
+        let token = &doc[start..start + close_off];
+        idx = start + close_off + 1;
+
+        if !looks_like_action_type(token, &known_domains) {
+            continue;
+        }
+        if ActionType::parse(token).is_err() {
+            invalid.push(token.to_string());
+        }
+    }
+    invalid.sort();
+    invalid.dedup();
+    assert!(
+        invalid.is_empty(),
+        "the following `domain.verb` references in {TAXONOMY_DOC} do \
+         not parse as valid ActionTypes (typo or stale reference): \
+         {invalid:?}\n\n\
+         Action: either fix the spelling, or — if the verb is intentional \
+         and new — add the variant to `permit0_types::taxonomy::Verb` first."
+    );
+}
+
+/// "This token looks like a `domain.verb` action type" check.
+///
+/// Anchored on the closed set of domain names so non-action-type
+/// dotted strings (filenames like `dsl.md`, version ranges like `1.x`,
+/// the literal `domain.verb` placeholder in tutorial text) don't get
+/// scrutinized.
+fn looks_like_action_type(s: &str, known_domains: &std::collections::BTreeSet<&str>) -> bool {
+    let (domain, verb) = match s.split_once('.') {
+        Some(pair) => pair,
+        None => return false,
+    };
+    if !known_domains.contains(domain) {
+        return false;
+    }
+    if verb.is_empty() {
+        return false;
+    }
+    if s.matches('.').count() != 1 {
+        return false;
+    }
+    if s.chars()
+        .any(|c| c == '/' || c == ' ' || c == '\\' || c == ':')
+    {
+        return false;
+    }
+    verb.chars()
+        .all(|c| c.is_ascii_lowercase() || c == '_' || c.is_ascii_digit())
+}
+
+#[test]
+fn looks_like_action_type_filter() {
+    let domains: std::collections::BTreeSet<&str> =
+        ALL_DOMAINS.iter().map(|d| d.as_str()).collect();
+    // True positives — real action types.
+    assert!(looks_like_action_type("email.send", &domains));
+    assert!(looks_like_action_type("email.set_forwarding", &domains));
+    assert!(looks_like_action_type("unknown.unclassified", &domains));
+    // False positives the heuristic must reject.
+    assert!(!looks_like_action_type("README.md", &domains));
+    assert!(!looks_like_action_type("1.x", &domains));
+    assert!(!looks_like_action_type("docs/taxonomy.md", &domains));
+    assert!(!looks_like_action_type("permit0_types::taxonomy", &domains));
+    assert!(!looks_like_action_type("a.b.c", &domains));
+    assert!(!looks_like_action_type("", &domains));
+    assert!(!looks_like_action_type(".foo", &domains));
+    assert!(!looks_like_action_type("foo.", &domains));
+    assert!(!looks_like_action_type("dsl.md", &domains));
+    assert!(!looks_like_action_type("pack.yaml", &domains));
+    assert!(!looks_like_action_type("permit.md", &domains));
+    assert!(!looks_like_action_type("domain.verb", &domains));
+}

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -1,15 +1,21 @@
 # Action Type Taxonomy
 
-permit0 normalizes every tool call into a **NormAction** — a vendor-agnostic, policy-addressable representation of intent. Rules score, deny, allow, allowlist, or deny-list by NormAction, not by raw tool name — so a `Bash` call, an `http` call to Stripe, and a bank-pack `wire_transfer` all flow through the same set of policies.
+> **Source of truth.** The canonical list lives in
+> [`crates/permit0-types/src/taxonomy.rs`](../crates/permit0-types/src/taxonomy.rs).
+> If you find a discrepancy between this document and the code, **the
+> code wins**. A CI test (`taxonomy_doc_in_sync`) keeps this file
+> aligned with the enum — drift fails the build.
 
-The canonical source of truth is `permit0_types::taxonomy` (see `crates/permit0-types/src/taxonomy.rs`). It defines **20 domains** × **~116 action_types**. Of those, this repo ships **10 with full packs** (normalizer + risk rule). The rest are declared — you can reference them in YAML and they'll parse fine — but they currently fall through to `HumanInTheLoop` because no risk rule exists yet.
+permit0 normalizes every tool call into a **NormAction** — a vendor-agnostic, policy-addressable representation of intent. Risk rules score, deny, allow, allowlist, or deny-list by NormAction, not by raw tool name — so `gmail_send`, `outlook_send`, and a future `slack_send_dm` all flow through the same set of policies once they share an action type.
+
+The taxonomy is an **append-only enum** in `permit0-types`. New verbs land via PR; the enum's closed nature is what makes risk rules predictable across vendors. As of writing, it defines 22 domains.
 
 ## Anatomy of a NormAction
 
 ```
 NormAction {
-    action_type: "<domain>.<verb>"   // e.g. "payments.charge"
-    channel:     "<vendor/surface>"  // e.g. "stripe", "bash", "claude_code"
+    action_type: "<domain>.<verb>"   // e.g. "email.send"
+    channel:     "<vendor/surface>"  // e.g. "gmail", "outlook"
     entities:    { ... }             // semantically extracted fields
     execution:   {
         surface_tool:    "<raw tool name>"
@@ -18,86 +24,145 @@ NormAction {
 }
 ```
 
-- **`action_type`** is what **risk rules** match on — `packs/<pack>/risk_rules/<file>.yaml` has a top-level `action_type:` field.
-- **`channel`** is what **per-vendor overrides** can branch on (e.g. "Stripe charges go to Finance review, Adyen goes to Ops").
-- **`entities`** are what **rule `when` clauses** look at. They are normalized across tool surfaces — every shell tool extracts `command`, every write tool extracts `path` + `file_type`.
-- Rules can reference entities either directly (`command: { contains: "rm -rf" }`) or under the `entity.*` namespace (`entity.host: { not_in_set: "org.trusted_domains" }`). The `entity.*` form is preferred for normalizer-computed values.
+- **`action_type`** is what **risk rules** match on — `packs/<owner>/<pack>/risk_rules/<verb>.yaml` has a top-level `action_type:` field.
+- **`channel`** is what **per-vendor overrides** can branch on (e.g. "Gmail sends from the org primary domain go to Allow, Outlook from a personal account goes to HumanInTheLoop").
+- **`entities`** are what **rule `when` clauses** look at. They are normalized across tool surfaces — every email-domain normalizer extracts `to`/`subject`/`body`/`recipient_scope`/`domain`, regardless of whether the underlying tool was Gmail or Outlook.
+- Rules can reference entities directly (`subject: { contains: "password" }`) or under the `entity.*` namespace (`entity.recipient_scope: { equals: "external" }`). The `entity.*` form is preferred for normalizer-computed values.
 
-## Taxonomy Overview
+## Taxonomy
 
-Legend: ✅ = pack shipped, 🟡 = taxonomy-declared, no pack yet (falls through to `HumanInTheLoop`).
+Legend: ✅ = at least one in-tree pack ships a normalizer + risk rule for this action_type. 🟡 = taxonomy-declared, no pack yet (the engine returns `HumanInTheLoop` for any tool call that doesn't normalize to a covered action type).
 
-### email — 9 verbs
+Phase 1 ships exactly one pack: [`packs/permit0/email`](../packs/permit0/email/). Every other domain is declared and ready for a pack contribution.
 
-| action_type | Status | Notes |
-|---|:---:|---|
-| `email.search` | 🟡 | |
-| `email.get_thread` | 🟡 | |
-| `email.send` | ✅ | gmail pack |
-| `email.reply` | 🟡 | |
-| `email.forward` | 🟡 | Forward-to-external is a common exfil vector |
-| `email.draft` | 🟡 | |
-| `email.label` | 🟡 | |
-| `email.archive` | 🟡 | |
-| `email.delete` | 🟡 | |
+### `email` — 16 verbs
 
-### messages — 6 verbs
+Pack: [`packs/permit0/email`](../packs/permit0/email/) (Gmail + Outlook channels).
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `messages.send` | 🟡 | Slack/Discord/Teams DMs |
-| `messages.post_channel` | 🟡 | |
-| `messages.send_dm` | 🟡 | |
-| `messages.search` | 🟡 | |
-| `messages.react` | 🟡 | |
-| `messages.delete` | 🟡 | |
+| `email.search` | ✅ | |
+| `email.read` | ✅ | |
+| `email.read_thread` | ✅ | |
+| `email.list_mailboxes` | ✅ | |
+| `email.draft` | ✅ | |
+| `email.list_drafts` | ✅ | |
+| `email.send` | ✅ | Outbound — recipient_scope drives external-domain escalation |
+| `email.mark_read` | ✅ | |
+| `email.flag` | ✅ | |
+| `email.move` | ✅ | |
+| `email.archive` | ✅ | |
+| `email.mark_spam` | ✅ | |
+| `email.delete` | ✅ | |
+| `email.create_mailbox` | ✅ | |
+| `email.set_forwarding` | ✅ | Always-human gate — auto-forwarding is a textbook account-takeover tactic |
+| `email.add_delegate` | ✅ | Always-human gate — granting another user mailbox access |
 
-### content — 3 verbs
+### `message` — 8 verbs
+
+Slack, Discord, Teams, MS Teams, Mattermost, etc.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `content.post_social` | 🟡 | Twitter/LinkedIn/etc. |
-| `content.update_cms` | 🟡 | |
-| `content.send_newsletter` | 🟡 | Large-blast-radius — worth prioritizing |
+| `message.post_channel` | 🟡 | Public/private channel posts |
+| `message.send_dm` | 🟡 | 1:1 DMs — bypass channel-level moderation |
+| `message.send_sms` | 🟡 | SMS-style messaging |
+| `message.search` | 🟡 | Workspace history search |
+| `message.get` | 🟡 | Single-message fetch |
+| `message.react` | 🟡 | Emoji reactions |
+| `message.update` | 🟡 | Message edits — bulk edits look like coverup behavior |
+| `message.delete` | 🟡 | |
 
-### calendar — 6 verbs
+### `social` — 6 verbs
+
+Twitter/X, LinkedIn, Mastodon, Bluesky.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `calendar.list_events` | 🟡 | |
-| `calendar.get_event` | 🟡 | |
-| `calendar.create_event` | 🟡 | |
-| `calendar.update_event` | 🟡 | |
-| `calendar.delete_event` | 🟡 | |
+| `social.post` | 🟡 | Public broadcast — large blast radius |
+| `social.reply` | 🟡 | |
+| `social.delete` | 🟡 | |
+| `social.like` | 🟡 | |
+| `social.send_dm` | 🟡 | |
+| `social.search` | 🟡 | |
+
+### `cms` — 6 verbs
+
+WordPress, Contentful, Sanity, Webflow.
+
+| action_type | Status | Notes |
+|---|:---:|---|
+| `cms.publish` | 🟡 | Content goes live |
+| `cms.update` | 🟡 | |
+| `cms.unpublish` | 🟡 | |
+| `cms.schedule` | 🟡 | Future-dated publish — review window matters |
+| `cms.delete` | 🟡 | |
+| `cms.list` | 🟡 | |
+
+### `newsletter` — 5 verbs
+
+Mailchimp, Substack, Beehiiv, Customer.io.
+
+| action_type | Status | Notes |
+|---|:---:|---|
+| `newsletter.send` | 🟡 | Mass send — large blast radius, irreversible once sent |
+| `newsletter.schedule` | 🟡 | |
+| `newsletter.draft` | 🟡 | |
+| `newsletter.update` | 🟡 | |
+| `newsletter.unsubscribe` | 🟡 | |
+
+### `calendar` — 6 verbs
+
+Google Calendar, Outlook Calendar, Cal.com.
+
+| action_type | Status | Notes |
+|---|:---:|---|
+| `calendar.list` | 🟡 | |
+| `calendar.get` | 🟡 | |
+| `calendar.create` | 🟡 | |
+| `calendar.update` | 🟡 | |
+| `calendar.delete` | 🟡 | |
 | `calendar.rsvp` | 🟡 | |
 
-### tasks — 6 verbs
+### `task` — 8 verbs
+
+Jira, Linear, Asana, Trello, Monday.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `tasks.create` | 🟡 | Jira/Linear/Asana |
-| `tasks.assign` | 🟡 | |
-| `tasks.complete` | 🟡 | |
-| `tasks.update` | 🟡 | |
-| `tasks.delete` | 🟡 | |
-| `tasks.comment` | 🟡 | |
+| `task.create` | 🟡 | |
+| `task.get` | 🟡 | |
+| `task.list` | 🟡 | |
+| `task.update` | 🟡 | |
+| `task.complete` | 🟡 | |
+| `task.assign` | 🟡 | |
+| `task.delete` | 🟡 | |
+| `task.comment` | 🟡 | |
 
-### files — 10 verbs
+### `file` — 14 verbs
+
+Google Drive, OneDrive, Dropbox, S3, local filesystem.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `files.list` | ✅ | claude_code pack (`Glob`) |
-| `files.read` | ✅ | claude_code + filesystem packs |
-| `files.write` | ✅ | claude_code pack (`Write`, `Edit`) |
-| `files.delete` | 🟡 | |
-| `files.move` | 🟡 | |
-| `files.copy` | 🟡 | |
-| `files.share` | 🟡 | Google Drive / SharePoint / S3 presigned |
-| `files.upload` | 🟡 | |
-| `files.download` | 🟡 | |
-| `files.export` | 🟡 | Bulk-export risk is distinct from read |
+| `file.list` | 🟡 | |
+| `file.get` | 🟡 | |
+| `file.read` | 🟡 | |
+| `file.create` | 🟡 | |
+| `file.update` | 🟡 | |
+| `file.delete` | 🟡 | |
+| `file.delete_recursive` | 🟡 | Distinct from `delete` because the blast radius is qualitatively different |
+| `file.move` | 🟡 | |
+| `file.copy` | 🟡 | |
+| `file.share` | 🟡 | Share links / presigned URLs are exfil vectors |
+| `file.upload` | 🟡 | |
+| `file.download` | 🟡 | |
+| `file.export` | 🟡 | Bulk export is high sensitivity |
+| `file.search` | 🟡 | |
 
-### db — 7 verbs
+### `db` — 13 verbs
+
+Postgres, MySQL, MongoDB, BigQuery, Snowflake.
 
 | action_type | Status | Notes |
 |---|:---:|---|
@@ -105,297 +170,181 @@ Legend: ✅ = pack shipped, 🟡 = taxonomy-declared, no pack yet (falls through
 | `db.insert` | 🟡 | |
 | `db.update` | 🟡 | |
 | `db.delete` | 🟡 | |
-| `db.admin` | 🟡 | DDL / role management |
-| `db.export` | 🟡 | Bulk export — high sensitivity |
+| `db.create` | 🟡 | DDL — schema mutation |
+| `db.alter` | 🟡 | DDL |
+| `db.drop` | 🟡 | DDL — destructive |
+| `db.truncate` | 🟡 | Destructive but reversible from backup |
+| `db.grant_access` | 🟡 | Privilege escalation vector |
+| `db.revoke_access` | 🟡 | |
+| `db.export` | 🟡 | Bulk-export distinct from select — different sensitivity |
 | `db.backup` | 🟡 | |
+| `db.restore` | 🟡 | |
 
-### crm — 9 verbs
+### `crm` — 8 verbs
+
+Salesforce, HubSpot, Pipedrive, Attio.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `crm.search_contacts` | 🟡 | |
-| `crm.get_contact` | 🟡 | |
-| `crm.create_contact` | 🟡 | |
-| `crm.update_contact` | 🟡 | |
-| `crm.delete_contact` | 🟡 | |
-| `crm.create_deal` | 🟡 | |
-| `crm.update_deal` | 🟡 | |
+| `crm.list` | 🟡 | |
+| `crm.get` | 🟡 | |
+| `crm.search` | 🟡 | |
+| `crm.create` | 🟡 | |
+| `crm.update` | 🟡 | |
+| `crm.delete` | 🟡 | |
 | `crm.log_activity` | 🟡 | |
-| `crm.export` | 🟡 | Customer-list exfil |
+| `crm.export` | 🟡 | Customer-list exfil vector |
 
-### payments — 8 verbs
+### `payment` — 9 verbs
 
-| action_type | Status | Notes |
-|---|:---:|---|
-| `payments.charge` | ✅ | stripe pack |
-| `payments.refund` | 🟡 | stripe normalizer exists but **no risk rule** — falls through |
-| `payments.transfer` | ✅ | bank_transfer pack |
-| `payments.get_balance` | 🟡 | |
-| `payments.list_transactions` | 🟡 | |
-| `payments.create_invoice` | 🟡 | |
-| `payments.update_payment_method` | 🟡 | Card-on-file changes are high-risk |
-| `payments.create_subscription` | 🟡 | |
-
-### legal — 3 verbs
+Stripe, Square, PayPal, ACH/wire systems.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `legal.sign_document` | 🟡 | DocuSign / agents signing contracts |
+| `payment.charge` | 🟡 | Always-human gate when shipped |
+| `payment.refund` | 🟡 | Always-human gate when shipped |
+| `payment.transfer` | 🟡 | Always-human gate when shipped |
+| `payment.get_balance` | 🟡 | |
+| `payment.list` | 🟡 | |
+| `payment.get` | 🟡 | |
+| `payment.create` | 🟡 | |
+| `payment.update` | 🟡 | |
+| `payment.cancel_subscription` | 🟡 | |
+
+### `legal` — 3 verbs
+
+DocuSign, HelloSign, government filings.
+
+| action_type | Status | Notes |
+|---|:---:|---|
+| `legal.sign_document` | 🟡 | Agent signing on behalf of a user — high stakes |
 | `legal.submit_filing` | 🟡 | |
 | `legal.accept_terms` | 🟡 | |
 
-### iam — 8 verbs
+### `iam` — 10 verbs
+
+Okta, Auth0, AWS IAM, Google Workspace admin.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `iam.list_users` | 🟡 | |
-| `iam.create_user` | 🟡 | |
-| `iam.update_user` | 🟡 | |
-| `iam.delete_user` | 🟡 | |
-| `iam.assign_role` | 🟡 | Privilege-escalation vector |
-| `iam.revoke_role` | 🟡 | |
-| `iam.reset_password` | 🟡 | |
-| `iam.generate_api_key` | 🟡 | |
+| `iam.list` | 🟡 | |
+| `iam.get` | 🟡 | |
+| `iam.create` | 🟡 | Always-human gate when shipped |
+| `iam.update` | 🟡 | |
+| `iam.delete` | 🟡 | Always-human gate when shipped |
+| `iam.assign_role` | 🟡 | Always-human gate — privilege escalation vector |
+| `iam.revoke_role` | 🟡 | Always-human gate when shipped |
+| `iam.reset_password` | 🟡 | Always-human gate when shipped |
+| `iam.generate_api_key` | 🟡 | Always-human gate when shipped |
+| `iam.revoke_api_key` | 🟡 | |
 
-### secrets — 3 verbs
+### `secret` — 6 verbs
 
-| action_type | Status | Notes |
-|---|:---:|---|
-| `secrets.read` | 🟡 | Vault / AWS Secrets Manager / 1Password |
-| `secrets.create` | 🟡 | |
-| `secrets.rotate` | 🟡 | |
-
-### infra — 6 verbs
+Vault, AWS Secrets Manager, 1Password, Doppler.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `infra.list_resources` | 🟡 | |
-| `infra.create_resource` | 🟡 | Spawn instances / buckets |
-| `infra.modify_resource` | 🟡 | |
-| `infra.terminate_resource` | 🟡 | Destructive |
-| `infra.scale` | 🟡 | Cost-blast-radius |
-| `infra.modify_network` | 🟡 | Security-group / firewall changes |
+| `secret.get` | 🟡 | Always-human gate when shipped |
+| `secret.list` | 🟡 | |
+| `secret.create` | 🟡 | Always-human gate when shipped |
+| `secret.update` | 🟡 | Always-human gate when shipped |
+| `secret.rotate` | 🟡 | Always-human gate when shipped |
+| `secret.delete` | 🟡 | |
 
-### process — 4 verbs
+### `infra` — 6 verbs
 
-| action_type | Status | Notes |
-|---|:---:|---|
-| `process.shell` | ✅ | bash + claude_code packs |
-| `process.run_script` | 🟡 | |
-| `process.docker_run` | 🟡 | |
-| `process.lambda_invoke` | 🟡 | |
-
-### network — 3 verbs
+AWS, GCP, Azure, Terraform, Pulumi.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `network.http_get` | ✅ | claude_code pack (`WebFetch`, `WebSearch`) |
-| `network.http_post` | 🟡 | |
-| `network.webhook_send` | 🟡 | |
+| `infra.list` | 🟡 | |
+| `infra.get` | 🟡 | |
+| `infra.create` | 🟡 | |
+| `infra.update` | 🟡 | |
+| `infra.terminate` | 🟡 | Destructive |
+| `infra.scale` | 🟡 | Cost blast-radius |
 
-### dev — 9 verbs
+### `process` — 2 verbs
+
+Shell, subprocess, Lambda, Cloud Functions.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `dev.get_repo` | 🟡 | |
-| `dev.list_issues` | 🟡 | |
-| `dev.create_issue` | 🟡 | |
-| `dev.create_pr` | 🟡 | |
-| `dev.merge_pr` | 🟡 | High-risk — code lands on main |
+| `process.run` | 🟡 | Shell / subprocess — single highest blast-radius action type |
+| `process.invoke` | 🟡 | Function/lambda invoke |
+
+### `network` — 5 verbs
+
+HTTP clients, webhooks.
+
+| action_type | Status | Notes |
+|---|:---:|---|
+| `network.get` | 🟡 | |
+| `network.post` | 🟡 | |
+| `network.put` | 🟡 | |
+| `network.delete` | 🟡 | |
+| `network.send_webhook` | 🟡 | |
+
+### `dev` — 9 verbs
+
+GitHub, GitLab, CI/CD platforms.
+
+| action_type | Status | Notes |
+|---|:---:|---|
+| `dev.list` | 🟡 | |
+| `dev.get` | 🟡 | |
+| `dev.create` | 🟡 | |
+| `dev.update` | 🟡 | |
+| `dev.close_issue` | 🟡 | |
+| `dev.merge_pr` | 🟡 | Code lands on main |
 | `dev.push_code` | 🟡 | |
-| `dev.deploy` | 🟡 | Prod blast-radius |
+| `dev.deploy` | 🟡 | Production blast-radius |
 | `dev.run_pipeline` | 🟡 | |
-| `dev.create_release` | 🟡 | |
 
-### browser — 7 verbs
+### `browser` — 8 verbs
+
+Headless and headful browser automation.
 
 | action_type | Status | Notes |
 |---|:---:|---|
 | `browser.navigate` | 🟡 | |
 | `browser.click` | 🟡 | |
 | `browser.fill_form` | 🟡 | |
-| `browser.submit_form` | 🟡 | Actual action — often irreversible |
-| `browser.screenshot` | 🟡 | |
-| `browser.download` | 🟡 | |
+| `browser.submit_form` | 🟡 | Action — often irreversible |
+| `browser.take_screenshot` | 🟡 | |
+| `browser.download_file` | 🟡 | |
 | `browser.execute_js` | 🟡 | Arbitrary code in page context |
+| `browser.scrape` | 🟡 | |
 
-### device — 5 verbs
+### `device` — 5 verbs
+
+Robotics, IoT, smart home.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `device.unlock` | 🟡 | Physical/robotic surfaces |
 | `device.lock` | 🟡 | |
-| `device.camera_enable` | 🟡 | |
-| `device.camera_disable` | 🟡 | |
+| `device.unlock` | 🟡 | |
+| `device.enable` | 🟡 | |
+| `device.disable` | 🟡 | |
 | `device.move` | 🟡 | Robot/drone actuation |
 
-### ai — 3 verbs
+### `ai` — 5 verbs
+
+LLM APIs, agent invocations, embedding services, fine-tuning.
 
 | action_type | Status | Notes |
 |---|:---:|---|
-| `ai.prompt` | ✅ | claude_code pack (`Agent` — subagent invocation) |
+| `ai.prompt` | 🟡 | LLM call |
 | `ai.embed` | 🟡 | |
 | `ai.fine_tune` | 🟡 | |
+| `ai.invoke_agent` | 🟡 | Subagent invocation — recursive trust boundary |
+| `ai.generate_image` | 🟡 | |
 
-### unknown — 1 verb
+### `unknown` — 1 verb
 
 | action_type | Status | Notes |
 |---|:---:|---|
 | `unknown.unclassified` | — | Fallback for tool calls no normalizer matches. Engine returns `HumanInTheLoop`. |
-
-## Shipped NormActions (detailed)
-
-These are the 10 action_types with both a normalizer and a risk rule currently in the repo.
-
-| action_type | Normalizers (tool → channel) | Risk rule |
-|---|---|---|
-| `process.shell` | `Bash` → claude_code, `bash` → bash | `bash/risk_rules/shell.yaml` |
-| `files.write` | `Write` / `Edit` → claude_code | `claude_code/risk_rules/file_write.yaml` |
-| `files.read` | `Read` / `Grep` → claude_code, `file_read` → local | `filesystem/risk_rules/read.yaml` |
-| `files.list` | `Glob` → claude_code | `claude_code/risk_rules/file_list.yaml` |
-| `network.http_get` | `WebFetch` / `WebSearch` → claude_code | `claude_code/risk_rules/network.yaml` |
-| `ai.prompt` | `Agent` → claude_code | `claude_code/risk_rules/ai_prompt.yaml` |
-| `email.send` | `gmail_send` → gmail | `gmail/risk_rules/send.yaml` |
-| `payments.charge` | `http POST api.stripe.com/v1/charges` → stripe | `stripe/risk_rules/charge.yaml` |
-| `payments.refund` | `http POST api.stripe.com/v1/refunds` → stripe | — (falls through to HumanInTheLoop) |
-| `payments.transfer` | `bank_transfer` → bank | `bank_transfer/risk_rules/transfer.yaml` |
-
----
-
-### `process.shell`
-
-Shell / subprocess execution. The single highest-blast-radius action type in permit0 — hosts all the catastrophic-delete, privilege-escalation, and remote-code-execution gates.
-
-- **Normalizers**: `claude_code:bash` (`Bash`, priority 200), `permit0-pack-bash:shell` (`bash`, priority 90)
-- **Entities**: `command` (required), `pipe_count` (heuristic for chained command risk)
-- **Risk rule**: `packs/bash/risk_rules/shell.yaml`
-- **Built-in gates**: `catastrophic_recursive_delete`, `remote_code_execution`, `device_write`, `privilege_escalation`
-
-Example:
-```json
-{"tool_name": "Bash", "parameters": {"command": "sudo rm -rf /"}}
-```
-→ `process.shell` → `DENY` (Critical, gate `catastrophic_recursive_delete`).
-
----
-
-### `files.write`
-
-File creation or modification. Two Claude-Code tools normalize here: `Write` (new file) and `Edit` (in-place modification).
-
-- **Normalizers**: `claude_code:write` (priority 201), `claude_code:edit` (priority 202)
-- **Entities**: `path` (required, from `file_path`), `file_type` (code/data/config/binary), `path_depth`, `content_length` (Write) or `old_string_length` + `new_string_length` (Edit)
-- **Risk rule**: `packs/claude_code/risk_rules/file_write.yaml`
-- **Notable gates**: `ssh_directory_write`, writes under `/etc`, `/var`, `.claude/settings`, any `credentials` / `secret` / `.env` path fragment.
-
----
-
-### `files.read`
-
-File read or search. Covers direct reads and pattern-search tools.
-
-- **Normalizers**: `claude_code:read` (priority 203), `claude_code:grep` (priority 205), `filesystem:file_read` (priority 85)
-- **Entities**: `path` (required), `file_type`, `path_depth`, `pii` (filesystem pack only — via `detect_pii_patterns` over content)
-- **Risk rule**: `packs/filesystem/risk_rules/read.yaml`
-- **Notable gates**: `system_credential_access` (blocks reads of `/etc/shadow`, `/etc/passwd`, `.ssh/id_*`, known credential files).
-
----
-
-### `files.list`
-
-Filesystem enumeration / glob patterns. Separate from `files.read` because the blast radius is different — a `/**/*` glob enumerates an entire filesystem without reading any file content.
-
-- **Normalizer**: `claude_code:glob` (`Glob`, priority 204)
-- **Entities**: `pattern` (required), `path` (base directory)
-- **Risk rule**: `packs/claude_code/risk_rules/file_list.yaml`
-
----
-
-### `network.http_get`
-
-Outbound HTTP — both `WebFetch` (direct URL) and `WebSearch` (query → search engine).
-
-- **Normalizers**: `claude_code:web_fetch` (priority 207), `claude_code:web_search` (priority 208)
-- **Entities**: `url` (WebFetch) / `query` (WebSearch), `host` (via `url_host`), `is_private` (via `is_private_ip`, SSRF guard)
-- **Risk rule**: `packs/claude_code/risk_rules/network.yaml`
-- **Key rules**:
-  - Per-call: private-IP access → PRIVILEGE flag, known-exfil hostnames (`webhook.site`, `requestbin`, `ngrok`, `pipedream`) → EXPOSURE
-  - **Named-set-driven allowlist**: `entity.host: { not_in_set: "org.trusted_domains" }` → GOVERNANCE + destination amplifier. Default set defined in `permit0-scoring::default_named_sets`; override in the active profile.
-  - **Session attack-chain gates**: if the session has ever produced `HIGH`/`CRITICAL` tier (any action type), any subsequent outbound call is gated via `post_attack_chain_outbound_block`. Cross-action-type scrutiny via `max_tier` + `distinct_flags`.
-
----
-
-### `ai.prompt`
-
-Subagent invocation or LLM prompt submission.
-
-- **Normalizer**: `claude_code:agent` (`Agent`, priority 206)
-- **Entities**: `subagent_type` (default `"general-purpose"`), `prompt_length`
-- **Risk rule**: `packs/claude_code/risk_rules/ai_prompt.yaml`
-
----
-
-### `email.send`
-
-Outbound email.
-
-- **Normalizer**: `gmail:send` (`gmail_send`, priority 95)
-- **Entities**: `to` (required), `subject`, `body`, `recipient_scope` (self/internal/external/mixed via `recipient_scope(to, org_domain)`), `domain` (via `extract_domain`)
-- **Risk rule**: `packs/gmail/risk_rules/send.yaml`
-- **Notable rules**: multiple recipients / BCC-to-external / subject keywords (`password|reset|verify`) escalate sensitivity; session rule catches >50 sends/day.
-
----
-
-### `payments.charge`
-
-Stripe card charge creation.
-
-- **Normalizer**: `stripe:charges.create` (matches `http POST api.stripe.com/v1/charges`, priority 100)
-- **Entities**: `amount` (required), `currency` (default `"usd"`), `customer`, `amount_cents` (via `extract_amount_cents`)
-- **Risk rule**: `packs/stripe/risk_rules/charge.yaml`
-- **Notable rules**: amount-based amplifier scaling, currency / country risk bumps, session-level card-testing pattern detection.
-
----
-
-### `payments.refund`
-
-Stripe refund. Normalizer exists but no risk rule — currently falls through to `HumanInTheLoop`. File an issue or add your own rule.
-
-- **Normalizer**: `stripe:refunds.create` (priority 99)
-- **Entities**: `amount`, `currency`, `charge`, `reason`
-
----
-
-### `payments.transfer`
-
-Bank wire / ACH transfer.
-
-- **Normalizer**: `bank:wire_transfer` (`bank_transfer`, priority ~95)
-- **Entities**: `amount` (required), `currency` (default `"usd"`, lowercased), `recipient` (required, from `recipient_account`), `recipient_name`, `memo`
-- **Risk rule**: `packs/bank_transfer/risk_rules/transfer.yaml`
-- **Notable rules**: amount-tiered amplifiers, unknown-recipient gate, session-level APP-fraud / scatter-transfer detection (see `demos/demo1_app_fraud.py`).
-
-## Entities cheat sheet
-
-Cross-pack, these entity keys are consistent, so rules written against one pack often port to another:
-
-| Entity | Meaning | Packs producing it |
-|---|---|---|
-| `command` | shell command string | bash, claude_code (`Bash`) |
-| `path` | filesystem path | claude_code (Write/Edit/Read/Grep), filesystem |
-| `file_type` | `code`/`data`/`config`/`binary` | all file tools |
-| `path_depth` | integer, `/`-separated segments | all file tools |
-| `url` | full URL | claude_code (`WebFetch`) |
-| `host` | URL host, lowercased | claude_code (`WebFetch`) |
-| `is_private` | private IP / localhost check | claude_code (`WebFetch`) |
-| `amount` | monetary amount (raw) | stripe, bank_transfer |
-| `amount_cents` | monetary amount in cents | stripe |
-| `currency` | ISO currency, lowercased | stripe, bank_transfer |
-| `recipient` / `recipient_name` | bank transfer counterparty | bank_transfer |
-| `to` | email recipient(s) | gmail |
-| `recipient_scope` | `self`/`internal`/`external`/`mixed` | gmail |
-| `domain` | email recipient domain | gmail |
-| `pii` | bool, PII detected in content | filesystem |
 
 ## What happens for declared-but-unpacked action_types?
 
@@ -405,18 +354,20 @@ If you add a YAML rule referencing, say, `dev.deploy`, it parses — the taxonom
 2. No normalizer matches → falls through to `ActionType::UNKNOWN` (= `unknown.unclassified`).
 3. No risk rule for `unknown.unclassified` → engine returns `HumanInTheLoop`.
 
-So declared-only action_types don't crash; they just bypass per-call scoring and always ask a human. The path from 🟡 to ✅ is: write the normalizer, write a risk rule, register both in `pack.yaml`. See [`pack-contribution-guide.md`](./pack-contribution-guide.md).
+Declared-only action_types don't crash; they bypass per-call scoring and always ask a human. The path from 🟡 to ✅ is: write the normalizer, write a risk rule, register both in `pack.yaml`. See [`pack-contribution-guide.md`](./pack-contribution-guide.md).
 
 ## Adding a new NormAction
 
 1. Pick a `domain.verb` pair from `permit0_types::taxonomy`. If nothing fits, add a new `Verb` variant to the enum (it's append-only and versioned).
-2. Add a normalizer YAML under `packs/<name>/normalizers/` with `match:` on the raw tool name + `normalize:` producing the action.
-3. Add a risk rule YAML under `packs/<name>/risk_rules/` with the same `action_type:`.
-4. Register both files in `packs/<name>/pack.yaml`.
-5. Golden-test the end-to-end decision — see [`pack-contribution-guide.md`](./pack-contribution-guide.md) and `corpora/calibration/` for examples.
+2. Add a normalizer YAML under `packs/<owner>/<pack>/normalizers/<channel>/<verb>.yaml` with `match:` on the raw tool name + `normalize:` producing the action.
+3. Add a risk rule YAML under `packs/<owner>/<pack>/risk_rules/<verb>.yaml` with the same `action_type:`.
+4. List the action_type in `packs/<owner>/<pack>/pack.yaml` under `action_types:`.
+5. Update this document — both the per-domain table and the `taxonomy_doc_in_sync` test will catch you if you forget.
+6. Golden-test the end-to-end decision — see [`pack-contribution-guide.md`](./pack-contribution-guide.md) and `corpora/calibration/` for examples.
 
 ## Related docs
 
 - [`dsl.md`](./dsl.md) — full DSL reference: `when`/`then`, predicate operators including `in_set`, helper registry
 - [`permit.md`](./permit.md) — how Allow/Human/Deny is derived from a NormAction + RiskScore
 - [`pack-contribution-guide.md`](./pack-contribution-guide.md) — step-by-step for shipping a new pack
+- [`../packs/README.md`](../packs/README.md) — pack layout and trust tier semantics


### PR DESCRIPTION
The hand-written \`docs/taxonomy.md\` had drifted heavily from the canonical \`permit0_types::taxonomy\` enum. This PR realigns the doc with the enum and wires CI to keep them in sync going forward.

## Drift caught

| Issue | Example |
|---|---|
| Plurals vs. enum singulars | doc said \`messages\`/\`tasks\`/\`files\`/\`payments\`/\`secrets\`; enum has \`message\`/\`task\`/\`file\`/\`payment\`/\`secret\` |
| Wrong verb counts | every domain off by several verbs |
| Fictional shipped packs | "Shipped NormActions (detailed)" listed \`claude_code\`, \`filesystem\`, \`stripe\`, \`bash\`, \`bank_transfer\` packs that don't exist + action types like \`process.shell\`, \`files.write\`, \`network.http_get\`, \`payments.charge\` that aren't in the taxonomy |
| Missing domain | \`newsletter\` (5 verbs) absent from the doc entirely |
| Stale tutorial section | "Adding a new NormAction" pointed at schema v1 layout |

## Rewrite

- 22 domains × correct verb lists, generated against the enum
- Phase 1 ships exactly one pack (\`packs/permit0/email\`); all 16 email verbs marked ✅, everything else 🟡
- Dropped "Shipped NormActions (detailed)" and "Entities cheat sheet" — both described fictional packs
- "Adding a new NormAction" updated for schema v2 + per-channel layout
- New top-of-file note: "If you find a discrepancy between this document and the code, **the code wins**. A CI test (\`taxonomy_doc_in_sync\`) keeps this file aligned with the enum — drift fails the build."

## CI sync test

\`crates/permit0-types/tests/taxonomy_doc_sync.rs\` adds three checks:

| Test | Catches |
|---|---|
| \`every_action_type_in_enum_appears_in_doc\` | New \`Domain::Verb\` variant landed without doc update |
| \`every_action_type_mentioned_in_doc_is_valid\` | Typo or stale \`domain.verb\` reference in the doc |
| \`looks_like_action_type_filter\` | Coverage for the heuristic that distinguishes real action types from filenames (\`README.md\`), versions (\`1.x\`), Rust paths (\`permit0_types::taxonomy\`), and the placeholder \`domain.verb\` |

Detection verified by manually removing the \`email.set_forwarding\` row — test failed with the exact missing entry name.

\`permit0-test-utils\` added as a dev-dep so the test can resolve the doc path against the workspace root via \`load_test_fixture\`.

## Test plan

- [x] All 3 sync tests pass
- [x] Workspace tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Drift detection manually verified
- [ ] CI on Ubuntu / macOS / Windows (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)