### PR TITLE
docs: rename permit0-core references to permit0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
-repository = "https://github.com/permit0-ai/permit0-core"
+repository = "https://github.com/permit0-ai/permit0"
 rust-version = "1.85"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Agent actions (tool calls) ──► Normalize ──► Session-aware determini
 
 ```bash
 # 1. Install
-git clone https://github.com/anthropics/permit0-core.git && cd permit0-core
+git clone https://github.com/anthropics/permit0.git && cd permit0
 cargo build --release
 
 # 2. Start the admin dashboard
@@ -760,7 +760,7 @@ The **Audit Log** tab in the Web GUI also supports online viewing and export.
 ## Project Structure
 
 ```
-permit0-core/
+permit0/
 ├── crates/
 │   ├── permit0-engine          # Core decision pipeline
 │   ├── permit0-scoring         # 6-step hybrid scoring algorithm

--- a/clients/outlook-mcp/README.md
+++ b/clients/outlook-mcp/README.md
@@ -36,7 +36,7 @@ Claude Code  ──MCP/stdio──▶  permit0-outlook-mcp
 ### 1. Make sure the permit0 daemon is running
 
 ```bash
-cd /path/to/permit0-core
+cd /path/to/permit0
 cargo run -p permit0-cli -- serve --ui --port 9090
 ```
 

--- a/demos/outlook/README.md
+++ b/demos/outlook/README.md
@@ -7,7 +7,7 @@ A ~150-line Python script that demonstrates the production loop:
 
 ```bash
 # 1. Start permit0 (in another terminal)
-cd /home/hy/projs/permit0-core
+cd /home/hy/projs/permit0
 cargo run -p permit0-cli -- serve --ui --port 9090
 
 # 2. Install Python deps

--- a/demos/run_demo.py
+++ b/demos/run_demo.py
@@ -3,7 +3,7 @@
 Launch the permit0 demo server.
 
 Usage:
-    cd /path/to/permit0-core
+    cd /path/to/permit0
     source .venv/bin/activate
     export ANTHROPIC_API_KEY=sk-ant-...
     python demos/run_demo.py

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -51,7 +51,7 @@ claude --version
 ## 1. Build + start daemon (calibrate mode)
 
 ```bash
-git clone https://github.com/anthropics/permit0-core.git && cd permit0-core
+git clone https://github.com/anthropics/permit0.git && cd permit0
 cargo build --release
 export PATH="$PATH:$(pwd)/target/release"
 permit0 serve --calibrate --port 9090
@@ -105,7 +105,7 @@ JSON strings, and `permit0` may not be on Claude Code's PATH:
         "hooks": [
           {
             "type": "command",
-            "command": "/abs/path/to/permit0 hook --db /home/you/.permit0/sessions.db --packs-dir /abs/path/to/permit0-core/packs"
+            "command": "/abs/path/to/permit0 hook --db /home/you/.permit0/sessions.db --packs-dir /abs/path/to/permit0/packs"
           }
         ]
       }
@@ -169,7 +169,7 @@ Now Allow/Deny route by tier; identical norm_hash calls auto-replay your earlier
 
 - **Tools don't appear in Claude Code** → didn't fully quit/relaunch, OR MCP commands not on Claude Code's PATH (use absolute paths).
 - **Hook returns ask_user for everything** → check `curl localhost:9090/api/v1/health` and that `which permit0` resolves where Claude Code can find it.
-- **Hook can't find packs** → add `--packs-dir /absolute/path/to/permit0-core/packs` to the hook command.
+- **Hook can't find packs** → add `--packs-dir /absolute/path/to/permit0/packs` to the hook command.
 - **Different MCP host (Cursor / Cline / …)** → `permit0 hook --client {claude-code|claude-desktop|raw}`. Default is `claude-code` (strips `mcp__<server>__` prefix).
 
 ## Reset for a fresh calibration

--- a/docs/design/pack-taxonomy-refactor.md
+++ b/docs/design/pack-taxonomy-refactor.md
@@ -302,14 +302,14 @@ Move to a federated registry when ANY of:
 
 Phase 2 plan sketch lives in the working discussion doc;
 signing-infrastructure design is tracked in
-[#18](https://github.com/permit0-ai/permit0-core/issues/18) as a
+[#18](https://github.com/permit0-ai/permit0/issues/18) as a
 prerequisite.
 
 ## Related artifacts
 
-- [#18](https://github.com/permit0-ai/permit0-core/issues/18) — pack
+- [#18](https://github.com/permit0-ai/permit0/issues/18) — pack
   signing infrastructure (Phase 2 prerequisite).
-- [#19](https://github.com/permit0-ai/permit0-core/issues/19) — taxonomy
+- [#19](https://github.com/permit0-ai/permit0/issues/19) — taxonomy
   version-resolver semantics for multi-pack installs.
-- `~/.gstack/projects/permit0-ai-permit0-core/sufu-claudequirky-ritchie-4ae70b-eng-review-test-plan-20260501-150322.md`
+- `~/.gstack/projects/permit0-ai-permit0/sufu-claudequirky-ritchie-4ae70b-eng-review-test-plan-20260501-150322.md`
   — test plan artifact consumable by `/qa` and `/qa-only`.

--- a/docs/permit.md
+++ b/docs/permit.md
@@ -157,7 +157,7 @@ The agent reviewer **never produces Allow** and **never issues tokens**. It is a
 ### Crate Layout
 
 ```
-permit0-core/
+permit0/
 ├── Cargo.toml                       # workspace
 ├── crates/
 │   ├── permit0-types/               # Tier, RiskScore, NormAction, Permission, RiskTemplate
@@ -2827,7 +2827,7 @@ Each phase produces something runnable end-to-end before adding sophistication. 
 
 **Crates created:**
 ```
-permit0-core/
+permit0/
 ├── Cargo.toml                     # workspace root
 ├── Cargo.lock                     # committed for reproducibility
 ├── crates/

--- a/examples/openai-agents-governed/README.md
+++ b/examples/openai-agents-governed/README.md
@@ -70,7 +70,7 @@ decisions are identical — only the registration step differs.
 ```
 ━━ OpenAI Agents SDK + permit0 ...
 openai-agents SDK not installed  (using fallback mock decorator).
-Packs loaded from: /.../permit0-core/packs
+Packs loaded from: /.../permit0/packs
 
 ━━ Scripted tool invocations (no API key required) ...
 

--- a/examples/openclaw-governed/README.md
+++ b/examples/openclaw-governed/README.md
@@ -1,6 +1,6 @@
 # OpenClaw + permit0 — single-file demo
 
-A self-contained TypeScript file demonstrating how to wrap [OpenClaw](https://github.com/openclaw/openclaw) skills with a [permit0](https://github.com/permit0-ai/permit0-core) policy check.
+A self-contained TypeScript file demonstrating how to wrap [OpenClaw](https://github.com/openclaw/openclaw) skills with a [permit0](https://github.com/permit0-ai/permit0) policy check.
 
 Read this if you want to see the wrapper pattern in one place. **For production use, the same surface plus a failed-open replay buffer ships as a published package** — see [`integrations/permit0-openclaw/`](../../integrations/permit0-openclaw/).
 

--- a/integrations/permit0-langgraph/pyproject.toml
+++ b/integrations/permit0-langgraph/pyproject.toml
@@ -44,9 +44,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/permit0/permit0-core"
-Repository = "https://github.com/permit0/permit0-core"
-Documentation = "https://github.com/permit0/permit0-core/tree/main/integrations/permit0-langgraph"
+Homepage = "https://github.com/permit0/permit0"
+Repository = "https://github.com/permit0/permit0"
+Documentation = "https://github.com/permit0/permit0/tree/main/integrations/permit0-langgraph"
 
 [tool.hatch.build.targets.wheel]
 packages = ["permit0_langgraph"]

--- a/integrations/permit0-openclaw/README.md
+++ b/integrations/permit0-openclaw/README.md
@@ -118,8 +118,8 @@ You need two things running: the permit0 daemon (HTTP server on `:9090`) and you
 **1. Build and run the daemon** (once per machine):
 
 ```bash
-git clone https://github.com/permit0-ai/permit0-core
-cd permit0-core
+git clone https://github.com/permit0-ai/permit0
+cd permit0
 cargo build --release
 ./target/release/permit0 serve --ui --port 9090
 ```

--- a/integrations/permit0-openclaw/package.json
+++ b/integrations/permit0-openclaw/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/permit0-ai/permit0-core.git",
+    "url": "https://github.com/permit0-ai/permit0.git",
     "directory": "integrations/permit0-openclaw"
   },
   "type": "module",

--- a/packs/community/README.md
+++ b/packs/community/README.md
@@ -2,7 +2,7 @@
 
 Phase 1 placeholder. Once the federated registry and signing
 infrastructure ship (Phase 2 — tracked in
-[#18](https://github.com/permit0-ai/permit0-core/issues/18)),
+[#18](https://github.com/permit0-ai/permit0/issues/18)),
 community-contributed packs will live in this directory.
 
 ## Phase 1 status

--- a/skills/permit0-claude-code-setup/SKILL.md
+++ b/skills/permit0-claude-code-setup/SKILL.md
@@ -60,8 +60,8 @@ Verify with `cargo --version`, `python3 --version`, `claude --version`.
 ### 1. Build permit0 + start daemon (calibrate mode)
 
 ```bash
-git clone https://github.com/anthropics/permit0-core.git
-cd permit0-core
+git clone https://github.com/anthropics/permit0.git
+cd permit0
 cargo build --release
 export PATH="$PATH:$(pwd)/target/release"
 permit0 serve --calibrate --port 9090
@@ -79,7 +79,7 @@ User opens http://localhost:9090/ui/ → enters reviewer name → leaves
 ### 2. Install MCP servers (in a new terminal)
 
 ```bash
-cd permit0-core
+cd permit0
 pip install -e clients/outlook-mcp
 pip install -e clients/gmail-mcp     # skip if Gmail not needed
 ```
@@ -129,7 +129,7 @@ Use absolute paths (PATH and `~` expansion can't be relied on):
         "hooks": [
           {
             "type": "command",
-            "command": "/abs/path/to/permit0 hook --db /home/<user>/.permit0/sessions.db --packs-dir /abs/path/to/permit0-core/packs"
+            "command": "/abs/path/to/permit0 hook --db /home/<user>/.permit0/sessions.db --packs-dir /abs/path/to/permit0/packs"
           }
         ]
       }
@@ -206,7 +206,7 @@ Walk the user through diagnostic commands when something doesn't work:
 | Symptom | Diagnosis | Fix |
 |---------|-----------|-----|
 | MCP tools don't appear in Claude Code | `which permit0-outlook-mcp` empty, OR didn't fully quit Claude Code | Add pip's bin dir to PATH (or use absolute path in `~/.claude.json`); fully quit + relaunch |
-| Claude Code "completely ignores" the hook (tool runs unprompted) | Most likely combo of: (1) wrong file — must be `~/.claude/settings.json`, not `~/.claude.json`; (2) wrong schema — must be nested `{matcher,hooks:[{type,command}]}`; (3) wrong output format — must be `hookSpecificOutput.permissionDecision` not legacy `{"decision":"..."}` ; (4) missing `--packs-dir` so engine build fails on stale `~/.permit0/packs/` | Run `cd /tmp && echo '{"tool_name":"mcp__permit0-outlook__outlook_search","tool_input":{}}' \| /abs/path/to/permit0 hook --db ~/.permit0/sessions.db --packs-dir /abs/path/to/permit0-core/packs` and check exit code is 0 + output starts with `{"hookSpecificOutput"`. If exit is nonzero, the engine build failed — check error message |
+| Claude Code "completely ignores" the hook (tool runs unprompted) | Most likely combo of: (1) wrong file — must be `~/.claude/settings.json`, not `~/.claude.json`; (2) wrong schema — must be nested `{matcher,hooks:[{type,command}]}`; (3) wrong output format — must be `hookSpecificOutput.permissionDecision` not legacy `{"decision":"..."}` ; (4) missing `--packs-dir` so engine build fails on stale `~/.permit0/packs/` | Run `cd /tmp && echo '{"tool_name":"mcp__permit0-outlook__outlook_search","tool_input":{}}' \| /abs/path/to/permit0 hook --db ~/.permit0/sessions.db --packs-dir /abs/path/to/permit0/packs` and check exit code is 0 + output starts with `{"hookSpecificOutput"`. If exit is nonzero, the engine build failed — check error message |
 | Hook returns `ask` (legacy: `ask_user`) for built-in tools (Bash etc.) | Expected — only the `email` pack ships normalizers; built-in tools fall through to `unknown.unclassified` → ask | Either accept (default human review), or add normalizers/risk rules under `packs/<your-domain>/` for the built-ins you use |
 | Daemon not reachable | `curl http://localhost:9090/api/v1/health` fails | Daemon crashed or was killed; restart in terminal 1. Or port collision — try a different port and update the hook URL via `PERMIT0_URL` env var |
 | Outlook auth: "AADSTS65001" | Work/school account requires admin consent for the public Graph PowerShell client | Use personal `@outlook.com` account, OR register own Azure App and set `MSGRAPH_CLIENT_ID` |


### PR DESCRIPTION
## Summary
- Replace 30 `permit0-core` references across 15 files with `permit0` to match the current repo name
- Affects repository URLs (Cargo.toml, package.json, pyproject.toml), clone instructions, and path references in READMEs/docs/skills
- No file or directory renames needed — workspace crate names (`permit0-types`, `permit0-engine`, etc.) were not affected

## Test plan
- [ ] Verify `cargo metadata` still resolves (Cargo.toml `repository` field changed)
- [ ] Spot-check updated clone instructions in READMEs render correctly
- [ ] Confirm no remaining `permit0-core` strings: `grep -rn "permit0-core" --exclude-dir=.git` returns empty