### PR TITLE
Add planning workflow skills (write, review, revise)

### DIFF
--- a/skills/reviewing-plan-docs/SKILL.md
+++ b/skills/reviewing-plan-docs/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: reviewing-plan-docs
+description: >-
+  Review planning documents by reading the plan docs and doing a thorough
+  codebase walkthrough, then writing detailed review docs. Use when the user
+  asks to review, audit, critique, or validate a plan, design doc, or spec
+  in the permit0 repository.
+---
+
+# Reviewing Plan Docs for permit0
+
+## When to Use
+
+Use this skill when the user asks you to review, audit, critique, or validate
+planning documents under `docs/plans/<feature>/`. The output is a set of
+review docs written to `docs/plan-reviews/<feature>/`.
+
+## Workflow
+
+### Phase 1: Read the Plan
+
+Read every file in `docs/plans/<feature>/` in numbered order. For each doc,
+note:
+
+- What it claims (the design decisions, schemas, code changes).
+- What assumptions it makes.
+- What it explicitly defers or omits.
+
+### Phase 2: Codebase Walkthrough
+
+Do a thorough read of the actual source code that the plan references. This
+is not optional -- you must verify claims against real code.
+
+For integration plans, always read:
+
+1. **The reference implementation** the plan says it is based on. For example,
+   if the plan says "replicate the Claude Code integration," read
+   `crates/permit0-cli/src/cmd/hook.rs` end to end.
+2. **The crate(s) the plan says it will modify.** Read every file in those
+   crates, not just the ones the plan mentions.
+3. **The crates the plan says are NOT modified.** Spot-check at least the
+   public API surface to verify the plan's claim that no changes are needed.
+4. **Packs and risk rules** if the feature touches normalization or scoring
+   (read `packs/permit0/email/` as the reference pack).
+5. **The daemon/serve code** if the feature involves `--remote` mode
+   (`crates/permit0-cli/src/cmd/serve.rs`).
+6. **Tests** -- read existing test files to understand current coverage and
+   what the plan's new tests need to complement.
+
+### Phase 3: Write the Review
+
+Write review docs to `docs/plan-reviews/<feature>/`. One review file per
+plan doc, plus a summary.
+
+## Output Structure
+
+```
+docs/plan-reviews/<feature>/
+  00-summary.md               # Overall verdict and key findings
+  01-review-overview.md       # Review of 00-overview.md
+  02-review-protocol.md       # Review of 01-protocol.md
+  03-review-implementation.md # Review of 02-implementation.md
+  04-review-configuration.md  # Review of 03-configuration.md
+  05-review-testing.md        # Review of 04-testing.md
+  06-review-limitations.md    # Review of 05-limitations.md
+```
+
+Skip review files for plan docs that don't exist (e.g. if there is no
+`01-protocol.md`, skip `02-review-protocol.md`).
+
+## Review Doc Format
+
+Every review doc must follow this structure:
+
+```markdown
+# Review: <plan doc title>
+
+**Reviewer:** Cursor Agent (session <timestamp or ID>)
+**Plan doc:** `docs/plans/<feature>/<filename>`
+**Review date:** <date>
+
+## Verdict
+
+One of: APPROVE | APPROVE WITH COMMENTS | REQUEST CHANGES | REJECT
+
+## Summary
+
+2-3 sentences: what the plan doc gets right, what it gets wrong.
+
+## Detailed Findings
+
+### Finding 1: <short title>
+
+**Severity:** Critical | Major | Minor | Nit
+**Location:** <section or line reference in the plan doc>
+**Claim:** <what the plan says>
+**Reality:** <what the code actually does>
+**Recommendation:** <what to change>
+
+### Finding 2: ...
+
+## Verified Claims
+
+List the specific claims you checked against the codebase and confirmed
+are correct. This is as important as the findings -- it shows the review
+was thorough.
+
+## Questions for the Author
+
+Numbered list of open questions that the reviewer could not resolve by
+reading the code.
+```
+
+## Summary Doc Format (00-summary.md)
+
+```markdown
+# Plan Review Summary: <feature>
+
+**Reviewer:** Cursor Agent (session <timestamp or ID>)
+**Review date:** <date>
+**Plan location:** `docs/plans/<feature>/`
+
+## Overall Verdict
+
+One of: APPROVE | APPROVE WITH COMMENTS | REQUEST CHANGES | REJECT
+
+## Key Findings
+
+Bulleted list of the most important findings across all review docs,
+ordered by severity.
+
+## Statistics
+
+| Metric | Count |
+|--------|-------|
+| Plan docs reviewed | N |
+| Critical findings | N |
+| Major findings | N |
+| Minor findings | N |
+| Nits | N |
+| Verified claims | N |
+| Open questions | N |
+
+## Recommendation
+
+1-2 paragraphs: should the team proceed with implementation as-is,
+or are changes needed first?
+```
+
+## Distinguishing Your Review
+
+Multiple agents may review the same plan. To make your review
+distinguishable:
+
+1. **Always include the reviewer line:** `**Reviewer:** Cursor Agent
+   (session <unique identifier>)` -- use the current timestamp or
+   conversation ID.
+2. **Cite specific file paths and line numbers** from the codebase when
+   verifying or disputing claims. Other reviewers may make the same point
+   but your evidence trail will differ.
+3. **Include a "Verified Claims" section** -- this is your proof-of-work
+   showing which parts of the codebase you actually read.
+
+## What Makes a Good Review
+
+### DO
+
+- **Verify every code snippet** in the plan against the actual source.
+  Plans often show idealized code that doesn't match current function
+  signatures or module structure.
+- **Check for missing error handling.** Plans often describe the happy path
+  and skip what happens on failure.
+- **Validate the "files NOT changed" list.** If the plan claims the engine
+  is untouched, confirm no engine changes are actually needed.
+- **Look for wire-format mismatches.** If the plan describes a JSON schema
+  for communication between two components, verify both sides agree. This is
+  where bugs hide (e.g. one side sends `"human"`, the other expects
+  `"humanintheloop"`).
+- **Check that test coverage matches the claimed behavior.** If the plan
+  says "HITL maps to deny," there should be a test for that.
+- **Flag implicit assumptions.** If the plan assumes network access in a
+  sandboxed environment, call it out.
+
+### DON'T
+
+- Don't rubber-stamp. If you only found nits, you probably didn't read
+  deeply enough.
+- Don't rewrite the plan. Findings should be specific and actionable, not
+  alternative designs.
+- Don't skip the codebase walkthrough. A review based only on reading the
+  plan docs is not a review -- it's proofreading.
+
+## Severity Definitions
+
+| Severity | Meaning |
+|----------|---------|
+| Critical | The plan is wrong in a way that would cause a security hole, data loss, or silent governance bypass if implemented as written. |
+| Major | The plan has a significant gap or incorrect assumption that would cause bugs or user confusion, but not a security issue. |
+| Minor | The plan is imprecise or incomplete in a way that would slow down implementation but not cause defects. |
+| Nit | Style, naming, or documentation improvement. |

--- a/skills/revising-plan-docs/SKILL.md
+++ b/skills/revising-plan-docs/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: revising-plan-docs
+description: >-
+  Revise planning documents based on design review feedback. Reads review
+  docs, critically assesses each finding (agree or disagree with reasoning),
+  then edits the plan docs accordingly or explains why no change is needed.
+  Use when the user asks to revise, update, address feedback, or incorporate
+  review comments into plan docs in the permit0 repository.
+---
+
+# Revising Plan Docs for permit0
+
+## When to Use
+
+Use this skill after plan reviews have been written to
+`docs/plan-reviews/<feature>/`. The input is the review docs. The output is
+direct edits to the plan docs at `docs/plans/<feature>/` -- or an explicit
+explanation of why a finding was rejected.
+
+There is no separate output document. The plan docs themselves are the
+deliverable.
+
+## Workflow
+
+### Phase 1: Read the Reviews
+
+Read every file in `docs/plan-reviews/<feature>/` in order, starting with
+`00-summary.md`. For each finding, note:
+
+- The severity (Critical / Major / Minor / Nit).
+- The specific claim the reviewer disputes.
+- The evidence the reviewer cites (file paths, line numbers).
+- The reviewer's recommendation.
+
+If multiple reviewers submitted reviews (different `Reviewer:` lines), read
+all of them. Note where reviewers agree and where they conflict.
+
+### Phase 2: Critically Assess Each Finding
+
+For every finding, do your own independent analysis. Do NOT blindly accept
+or reject -- verify against the codebase yourself.
+
+For each finding, reach one of three verdicts:
+
+**AGREE** -- The reviewer is correct. The plan has a real problem.
+- State what you verified in the code that confirms the finding.
+- Edit the plan doc to fix it.
+
+**DISAGREE** -- The reviewer is wrong or the finding is not actionable.
+- State what you verified in the code that contradicts the finding.
+- Explain to the user why the plan is correct as-is. Do not edit the plan.
+
+**PARTIALLY AGREE** -- The reviewer identified a real issue but the
+recommendation is wrong or disproportionate.
+- State which part is valid and which is not.
+- Edit the plan doc with your alternative fix.
+
+Rules for critical assessment:
+
+1. **Never agree just because the reviewer said so.** Read the actual code.
+   Reviewers make mistakes -- they may misread a function signature, miss a
+   serde attribute, or confuse two similar types.
+2. **Never disagree just to preserve the plan.** If the reviewer found a
+   real bug (e.g. a wire-format mismatch between two components), the plan
+   must be fixed regardless of how much work it creates.
+3. **Severity matters.** Critical and Major findings must be addressed with
+   code-level verification. Minor and Nit findings can be accepted on face
+   value if they are obviously correct (typos, naming, etc.).
+4. **Conflicting reviewers require a tiebreak.** If reviewer A says the plan
+   is wrong and reviewer B says it is correct, you must verify independently
+   and pick a side with evidence.
+
+### Phase 3: Act on Each Finding
+
+Process findings in severity order (Critical first, Nits last).
+
+For each finding, do one of:
+
+- **Edit the plan doc** -- Make the change directly with StrReplace. Keep
+  edits minimal and targeted. Do not rewrite sections unaffected by the
+  finding. Add a `**Revised:** <date>` line to the metadata header of any
+  doc you modify.
+
+- **Do nothing and explain why** -- Tell the user your verdict, what you
+  checked, and why the plan stands. This is a normal outcome -- not every
+  finding warrants a change.
+
+There is no Phase 4. No revision log, no summary doc. The edits (or lack
+of edits) plus your explanations to the user are the complete output.
+
+## Handling Multiple Reviewers
+
+When multiple review sets exist (e.g. from parallel agents):
+
+1. Read all review sets before making any changes.
+2. Group findings by topic, not by reviewer. Two reviewers may flag the
+   same issue differently.
+3. When reviewers agree on a finding, fix it once.
+4. When reviewers conflict, state both positions, your independent
+   assessment, and which side you took.
+
+## What to Change vs What Not to Change
+
+### DO change the plan when:
+
+- A code snippet does not match the current function signature or type
+  definition in the codebase.
+- The plan claims a file is not modified but evidence shows it must be.
+- The plan omits an error case or failure mode that the reviewer identified
+  with concrete evidence.
+- The plan's JSON schema does not match the actual wire format.
+- A test in the testing doc would not compile or tests the wrong thing.
+
+### DO NOT change the plan when:
+
+- The reviewer suggests an alternative design without evidence that the
+  current design is wrong. Design preferences are not defects.
+- The reviewer flags a future concern that the plan explicitly defers to v2.
+- The reviewer found a purely stylistic nit that does not affect correctness.
+- The reviewer disagrees with a documented decision without showing it causes
+  a concrete problem.

--- a/skills/writing-plan-docs/SKILL.md
+++ b/skills/writing-plan-docs/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: writing-plan-docs
+description: >-
+  Write planning documents for new permit0 features, integrations, or
+  significant changes. Use when the user asks to plan, design, spec, or
+  write a plan for a new integration, pack, feature, or architectural
+  change in the permit0 repository.
+---
+
+# Writing Plan Docs for permit0
+
+## When to Use
+
+Use this skill when the user asks you to plan a new integration (e.g. a new
+agent host like Codex, Cursor, CrewAI), a new pack, a new crate, or any
+multi-step change that benefits from upfront design before code.
+
+## Where to Place Plans
+
+```
+docs/plans/<feature-name>/
+  00-overview.md
+  01-protocol.md          (if wire format / API contract exists)
+  02-implementation.md
+  03-configuration.md     (if user-facing setup is needed)
+  04-testing.md
+  05-limitations.md
+```
+
+- **Path:** Always under `docs/plans/<feature-name>/`.
+- **Numbering:** Prefix with `00-` through `0N-` for reading order.
+- **Naming:** Use lowercase-kebab-case for the feature directory.
+
+## Documents to Write
+
+Not every plan needs all six docs. Pick the ones that apply.
+
+### 00-overview.md (always required)
+
+The entry point. A reader should understand what, why, and how far after
+reading only this file.
+
+Cover:
+
+1. **Goal** -- What this feature does, in one paragraph. If it replicates an
+   existing integration, say so and link to the reference implementation.
+2. **Data flow** -- ASCII or mermaid diagram showing the end-to-end path.
+3. **Comparison table** -- If a similar feature exists (e.g. Claude Code
+   integration), a side-by-side table of what is the same and what differs.
+4. **Scope** -- Bullet list of what is in v1 vs deferred to v2+.
+5. **Crate dependencies** -- Which crates are touched and which are not.
+   permit0's architecture makes most features crate-local; call that out.
+
+Header template:
+
+```markdown
+# 00 -- <Feature>: Overview and Architecture
+
+**Status:** Draft
+**Depends on:** None
+**Blocks:** 01-protocol, 02-implementation
+```
+
+### 01-protocol.md (when there is a wire format)
+
+Exact schemas for any JSON, TOML, HTTP, or stdin/stdout contract.
+
+Cover:
+
+1. **Input schema** -- Every field, type, whether always present or optional.
+2. **Output schema** -- Every possible response shape. Show concrete JSON
+   examples for each verdict/outcome.
+3. **Mapping table** -- How permit0 types (`Permission`, `Tier`, etc.) map
+   to the external system's values.
+4. **Error handling matrix** -- What happens on crash, timeout, malformed
+   output, transport failure. Table format works well.
+5. **Session / identity extraction** -- Where session IDs come from, fallback
+   chain.
+6. **Future extensions** -- Schemas or hooks that exist in the external system
+   but are not used in v1.
+
+### 02-implementation.md (always required)
+
+The code-level plan. A developer should know exactly which files to touch
+and what to add after reading this.
+
+Cover:
+
+1. **Changes** -- Numbered list of specific code changes. Include the file
+   path and a Rust/TS/Python snippet showing the type or function signature.
+2. **Files changed vs not changed** -- Table format. Explicitly listing files
+   NOT changed is important in permit0 because most features are I/O-layer
+   changes with no engine/scoring/pack impact.
+3. **Key decisions** -- If there were architectural choices (new file vs extend
+   existing, new enum variant vs trait impl), state the decision and the
+   reasoning in one sentence.
+4. **Migration path** -- What existing users need to do (usually nothing).
+5. **Risk assessment** -- What breaks if this goes wrong, what the blast
+   radius is.
+
+### 03-configuration.md (when user-facing setup exists)
+
+Step-by-step guide a user follows to enable the feature.
+
+Cover:
+
+1. **Prerequisites** -- What to install, build, or configure first.
+2. **Step-by-step** -- Numbered steps with copy-pasteable config snippets.
+   Show both JSON and TOML if the external system supports both.
+3. **Configuration variants** -- One subsection per mode (local, remote,
+   session-aware, shadow, calibration, project-local, with-profile).
+4. **Environment variable overrides** -- Table of env vars, what they
+   override, and example values.
+5. **Verification** -- How to confirm the integration works end-to-end.
+
+Important: use **absolute paths** in examples. Note when `~` does not expand.
+
+### 04-testing.md (always required)
+
+Cover:
+
+1. **Unit tests** -- List each test by name with a one-line description and
+   a code snippet showing the assertion. Group by concern (parsing, output
+   serialization, session ID, edge cases).
+2. **Regression tests** -- Explicit list of existing tests that must still
+   pass unchanged.
+3. **Integration tests** -- Shell commands that pipe input through the binary
+   and assert stdout/exit code.
+4. **Manual test script** -- A `scripts/test-<feature>.sh` that a developer
+   can run interactively.
+5. **Edge case matrix** -- Table of scenarios and expected behavior (timeout,
+   large input, missing fields, daemon down, etc.).
+
+### 05-limitations.md (when there are known gaps)
+
+Cover:
+
+1. **v1 limitations** -- Each limitation gets its own subsection with:
+   - **Problem**: What does not work.
+   - **v1 workaround**: What the user sees instead.
+   - **Impact**: How bad is it (low/medium/high).
+   - **Risk**: What happens if a developer accidentally hits this.
+2. **Future work** -- Versioned roadmap (v2, v3) with one paragraph per item
+   describing the approach, not just the goal.
+
+## Document Metadata
+
+Every doc should open with:
+
+```markdown
+**Status:** Draft | Review | Approved
+**Depends on:** <list of docs that must be read/written first>
+**Blocks:** <list of docs that depend on this one>
+```
+
+## Dependency Order
+
+Write docs in dependency order. The typical graph:
+
+```
+00-overview (first)
+  +-> 01-protocol
+  +-> 02-implementation (depends on 00 + 01)
+        +-> 03-configuration
+        +-> 04-testing
+  01-protocol +-> 05-limitations
+  02-implementation +-> 05-limitations
+```
+
+Start with `00-overview` and `01-protocol` (can be parallel), then
+`02-implementation`, then `03-configuration` / `04-testing` / `05-limitations`
+(can be parallel).
+
+## Research Before Writing
+
+Before writing any plan doc:
+
+1. **Read the reference implementation** if one exists. For integrations,
+   read `crates/permit0-cli/src/cmd/hook.rs` (the Claude Code hook) end to
+   end. Understand the existing I/O protocol, not just the engine.
+2. **Research the external system's hook/plugin docs.** Use web search. Read
+   the actual schema, not just summaries. Pay attention to what is supported
+   vs "parsed but not implemented."
+3. **Identify the critical difference.** Most integrations share 90% of the
+   flow. Find the 10% that differs and make that the focus of the plan.
+
+## Style
+
+- No emojis in plan docs.
+- Use tables for comparisons and matrices.
+- Use fenced code blocks for JSON/TOML/Rust with the language tag.
+- Keep each doc under 300 lines. If it grows beyond that, split.
+- Link to source files using relative paths from the doc location
+  (e.g. `[hook.rs](../../../crates/permit0-cli/src/cmd/hook.rs)`).
+
+## Reference Example
+
+The Codex CLI integration plan at `docs/plans/codex-integration/` is the
+reference for this skill. Read those files for concrete examples of each
+document type.


### PR DESCRIPTION
## Summary

- Add three agent skills under `skills/` for the plan-docs lifecycle:
  - **writing-plan-docs**: instructions for structuring and writing planning docs to `docs/plans/<feature>/`
  - **reviewing-plan-docs**: instructions for reviewing plans against the codebase and writing review docs to `docs/plan-reviews/<feature>/`
  - **revising-plan-docs**: instructions for critically assessing review feedback and revising plan docs in-place

## Test plan

- [ ] Verify each skill is discoverable via `@skills/<name>/SKILL.md` in Cursor
- [ ] Test writing-plan-docs by asking an agent to plan a new integration
- [ ] Test reviewing-plan-docs by asking an agent to review the Codex integration plan
- [ ] Test revising-plan-docs by asking an agent to revise plans based on review feedback


Made with [Cursor](https://cursor.com)