### PR TITLE
fix(ui): resolve pack dir for owner-namespaced layout

### DIFF
--- a/crates/permit0-cli/src/cmd/hook.rs
+++ b/crates/permit0-cli/src/cmd/hook.rs
@@ -850,11 +850,11 @@ mod tests {
             "POST http://127.0.0.1:9090/api/v1/check: Connection refused".to_string(),
         );
         let (output, is_unknown) = remote_error_to_hook_output(&err);
-        assert!(!is_unknown, "transport errors must not flow through --unknown");
-        assert_eq!(
-            output.hook_specific_output.permission_decision,
-            Some("ask"),
+        assert!(
+            !is_unknown,
+            "transport errors must not flow through --unknown"
         );
+        assert_eq!(output.hook_specific_output.permission_decision, Some("ask"),);
         let reason = output
             .hook_specific_output
             .permission_decision_reason

--- a/crates/permit0-cli/src/cmd/serve.rs
+++ b/crates/permit0-cli/src/cmd/serve.rs
@@ -165,8 +165,6 @@ async fn check_handler(
     )
 }
 
-
-
 /// Pull a string field out of the metadata map, ignoring non-string types.
 fn extract_string_field(
     metadata: &serde_json::Map<String, serde_json::Value>,

--- a/crates/permit0-cli/tests/cli_tests.rs
+++ b/crates/permit0-cli/tests/cli_tests.rs
@@ -154,10 +154,7 @@ fn hook_with_safe_email() {
     // allow / deny / ask, or absent for `defer` (let Claude Code decide).
     let decision = &parsed["hookSpecificOutput"]["permissionDecision"];
     assert!(
-        decision.is_null()
-            || decision == "allow"
-            || decision == "ask"
-            || decision == "deny",
+        decision.is_null() || decision == "allow" || decision == "ask" || decision == "deny",
         "unexpected hook output: {stdout}",
     );
 }

--- a/crates/permit0-dsl/src/normalizer.rs
+++ b/crates/permit0-dsl/src/normalizer.rs
@@ -75,8 +75,8 @@ impl Normalizer for DslNormalizer {
         let effective_params = inject_ctx_into_params(&raw.parameters, ctx);
 
         // Extract entities
-        let entity_map = extract_entities(&effective_params, &norm.entities, &self.helpers).map_err(
-            |e| match e {
+        let entity_map = extract_entities(&effective_params, &norm.entities, &self.helpers)
+            .map_err(|e| match e {
                 EntityError::MissingRequired(field) => NormalizeError::MissingRequiredField {
                     tool_name: raw.tool_name.clone(),
                     field,
@@ -93,8 +93,7 @@ impl Normalizer for DslNormalizer {
                     helper,
                     reason: format!("expected {expected} args, got {got}"),
                 },
-            },
-        )?;
+            })?;
 
         // Convert HashMap<String, Value> → Entities (serde_json::Map)
         let mut entities = Entities::new();
@@ -118,10 +117,7 @@ impl Normalizer for DslNormalizer {
 /// resolve them via path arguments. ctx fields overwrite any user-supplied
 /// keys of the same name — `org_domain` is a trust-boundary input and must
 /// not be spoofable by the caller.
-fn inject_ctx_into_params(
-    params: &serde_json::Value,
-    ctx: &NormalizeCtx,
-) -> serde_json::Value {
+fn inject_ctx_into_params(params: &serde_json::Value, ctx: &NormalizeCtx) -> serde_json::Value {
     let mut obj = match params {
         serde_json::Value::Object(m) => m.clone(),
         other => {
@@ -131,7 +127,10 @@ fn inject_ctx_into_params(
         }
     };
     if let Some(domain) = &ctx.org_domain {
-        obj.insert("org_domain".into(), serde_json::Value::String(domain.clone()));
+        obj.insert(
+            "org_domain".into(),
+            serde_json::Value::String(domain.clone()),
+        );
     }
     serde_json::Value::Object(obj)
 }

--- a/crates/permit0-ui/src/pack_routes.rs
+++ b/crates/permit0-ui/src/pack_routes.rs
@@ -187,6 +187,27 @@ fn resolve_packs_dir(state: &AppState) -> Result<PathBuf, (StatusCode, Json<ApiR
     })
 }
 
+/// Resolve a pack name to its on-disk directory, supporting both the
+/// flat layout (`<root>/<pack>/pack.yaml`) and the owner-namespaced
+/// layout (`<root>/<owner>/<pack>/pack.yaml`). Walks `discover_packs`
+/// and matches on `manifest.name`.
+fn resolve_pack_dir(packs_dir: &Path, pack_name: &str) -> Option<PathBuf> {
+    let dirs = permit0_dsl::discover_packs(packs_dir).ok()?;
+    for path in dirs {
+        let manifest_path = path.join("pack.yaml");
+        let Ok(content) = std::fs::read_to_string(&manifest_path) else {
+            continue;
+        };
+        let Ok(manifest) = serde_yaml::from_str::<PackManifest>(&content) else {
+            continue;
+        };
+        if manifest.name == pack_name {
+            return Some(path);
+        }
+    }
+    None
+}
+
 fn list_yaml_files(dir: &Path) -> Vec<String> {
     let mut files = Vec::new();
     if let Ok(entries) = std::fs::read_dir(dir) {
@@ -268,7 +289,12 @@ pub async fn get_pack(
         )
     })?;
 
-    let pack_path = packs_dir.join(pack_name);
+    let pack_path = resolve_pack_dir(&packs_dir, pack_name).ok_or_else(|| {
+        err_response::<PackDetail>(
+            StatusCode::NOT_FOUND,
+            &format!("pack not found: {pack_name}"),
+        )
+    })?;
     let manifest_path = pack_path.join("pack.yaml");
 
     let content = std::fs::read_to_string(&manifest_path).map_err(|e| {
@@ -316,7 +342,13 @@ pub async fn get_normalizer(
         )
     })?;
 
-    let file_path = packs_dir.join(pack_name).join("normalizers").join(filename);
+    let pack_path = resolve_pack_dir(&packs_dir, pack_name).ok_or_else(|| {
+        err_response::<FileDetail<NormalizerMeta>>(
+            StatusCode::NOT_FOUND,
+            &format!("pack not found: {pack_name}"),
+        )
+    })?;
+    let file_path = pack_path.join("normalizers").join(filename);
 
     let yaml = std::fs::read_to_string(&file_path).map_err(|e| {
         err_response::<FileDetail<NormalizerMeta>>(
@@ -361,7 +393,13 @@ pub async fn get_risk_rule(
         )
     })?;
 
-    let file_path = packs_dir.join(pack_name).join("risk_rules").join(filename);
+    let pack_path = resolve_pack_dir(&packs_dir, pack_name).ok_or_else(|| {
+        err_response::<FileDetail<RiskRuleMeta>>(
+            StatusCode::NOT_FOUND,
+            &format!("pack not found: {pack_name}"),
+        )
+    })?;
+    let file_path = pack_path.join("risk_rules").join(filename);
 
     let yaml = std::fs::read_to_string(&file_path).map_err(|e| {
         err_response::<FileDetail<RiskRuleMeta>>(
@@ -416,7 +454,13 @@ pub async fn update_normalizer(
         ));
     }
 
-    let file_path = packs_dir.join(pack_name).join("normalizers").join(filename);
+    let pack_path = resolve_pack_dir(&packs_dir, pack_name).ok_or_else(|| {
+        err_response::<String>(
+            StatusCode::NOT_FOUND,
+            &format!("pack not found: {pack_name}"),
+        )
+    })?;
+    let file_path = pack_path.join("normalizers").join(filename);
 
     std::fs::write(&file_path, &req.yaml).map_err(|e| {
         err_response::<String>(
@@ -459,7 +503,13 @@ pub async fn update_risk_rule(
         ));
     }
 
-    let file_path = packs_dir.join(pack_name).join("risk_rules").join(filename);
+    let pack_path = resolve_pack_dir(&packs_dir, pack_name).ok_or_else(|| {
+        err_response::<String>(
+            StatusCode::NOT_FOUND,
+            &format!("pack not found: {pack_name}"),
+        )
+    })?;
+    let file_path = pack_path.join("risk_rules").join(filename);
 
     std::fs::write(&file_path, &req.yaml).map_err(|e| {
         err_response::<String>(

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,9 @@ allow = [
     "OpenSSL",
     "Zlib",
     "CC0-1.0",
+    # webpki-roots ships Mozilla's CA bundle; the bundle metadata is
+    # CDLA-Permissive-2.0 (data-license, code is MPL-2.0).
+    "CDLA-Permissive-2.0",
 ]
 
 [bans]


### PR DESCRIPTION
Fixes https://github.com/permit0-ai/permit0/issues/43

## Summary

The Policies page in the admin UI failed to load any pack, showing:

> Failed to load pack: pack not found: No such file or directory (os error 2)

The sidebar listed `email v0.4.0` correctly, but clicking it 404'd.

## Root cause

`list_packs` in `crates/permit0-ui/src/pack_routes.rs` walks both the flat (`packs/<name>/`) and owner-namespaced (`packs/<owner>/<name>/`) layouts via `permit0_dsl::discover_packs()`. But the five per-pack handlers — `get_pack`, `get_normalizer`, `get_risk_rule`, `update_normalizer`, `update_risk_rule` — reconstructed the path with `packs_dir.join(pack_name)`, which only works for the flat layout. The bundled email pack lives at `packs/permit0/email/`, so every detail/edit request looked at `packs/email/` and missed.

## Fix

Add `resolve_pack_dir(packs_dir, pack_name)` that walks `discover_packs()`, reads each `pack.yaml`, and returns the directory whose `manifest.name` matches. Route all five handlers through it. Works for both layouts; no API or URL scheme changes.

## CI fix-ups (separate commit)

The Format and Cargo Deny jobs were pre-existing red on main:

- `cargo fmt --all` to clear rustfmt drift in `hook.rs`, `serve.rs`, `cli_tests.rs`, `normalizer.rs`.
- Allow `CDLA-Permissive-2.0` in `deny.toml` (webpki-roots ships Mozilla's CA bundle under that license; the code itself is MPL-2.0, already allowed).

## Test plan

- [x] `cargo build -p permit0-ui` — compiles
- [x] `cargo test -p permit0-ui pack` — 16 tests pass
- [x] `cargo fmt --all --check` — clean
- [x] `cargo deny check` — licenses ok
- [ ] Manual: rebuild, restart `permit0 serve --ui --port 9090`, click `email` in Policies → detail pane loads with normalizers and risk rules listed

## Notes for reviewer

- `resolve_pack_dir` matches on `manifest.name`, consistent with how `list_packs` exposes the name in `PackSummary`. If two packs in different owner directories ever share the same `name`, the first sorted hit wins — same behavior as the existing list endpoint, and worth tightening separately if collisions become real.
- Path-traversal protection via `sanitize_pack_name` is unchanged; the new helper only joins names that have already been validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)