### PR TITLE
docs(codex): default to daemon-backed enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <a href="LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"></a>
 <img alt="Rust 1.85+" src="https://img.shields.io/badge/rust-1.85%2B-orange">
 
-> Permit0 integrates with **Claude Code** and **OpenClaw** — more integrations to come. The pilot `email` taxonomy is ready, with Outlook and Gmail packs. [Open an issue to request the next taxonomy domain or tool pack →](https://github.com/permit0-ai/permit0/issues/new?template=new-pack.md) and ⭐ star the project.
+> Permit0 integrates with **Claude Code**, **Codex**, and **OpenClaw**. The pilot `email` taxonomy is ready, with Outlook and Gmail packs. [Open an issue to request the next taxonomy domain or tool pack →](https://github.com/permit0-ai/permit0/issues/new?template=new-pack.md) and ⭐ star the project.
 
 ---
 
@@ -23,9 +23,9 @@ The vocabulary is published. The first pack is shipped. The rest is the work.
 
 ---
 
-## Try it — Claude Code + Outlook/Gmail in 5 minutes
+## Try it — Claude Code or Codex + Outlook/Gmail in 5 minutes
 
-> **On OpenClaw?** Skip to [`integrations/permit0-openclaw/`](integrations/permit0-openclaw/) — wrap a skill with `permit0Skill(...)` and gate every dispatch through the same daemon. The rest of this section is the Claude Code path.
+> **On OpenClaw?** Skip to [`integrations/permit0-openclaw/`](integrations/permit0-openclaw/) — wrap a skill with `permit0Skill(...)` and gate every dispatch through the same daemon.
 
 ```bash
 # 1. Build
@@ -74,6 +74,22 @@ Restart Claude Code. Ask it: *"list recent emails and archive any newsletters,"*
 
 Shadow mode (`permit0 hook --shadow`) logs decisions without blocking, if you want to observe before enforcing.
 
+For Codex, use the daemon-backed managed-preferences installer:
+
+```bash
+PERMIT0_URL=http://127.0.0.1:9090 bash integrations/permit0-codex/examples/install-managed-prefs.sh
+```
+
+Then add the MCP server to your Codex config:
+
+```toml
+[mcp_servers.permit0-gmail]
+command = "/abs/path/to/permit0-gmail-mcp"
+```
+
+See [`integrations/permit0-codex/`](integrations/permit0-codex/) for the
+full Codex setup, including unattended install and cleanup.
+
 ---
 
 ## What makes it different
@@ -99,7 +115,7 @@ The taxonomy is the canonical, append-only vocabulary for *what agents do* — `
 
 22 domains, 159 verbs are defined today in [`crates/permit0-types/src/taxonomy.rs`](crates/permit0-types/src/taxonomy.rs) and documented at [`docs/taxonomy.md`](docs/taxonomy.md). The engine fails closed on any tool call that doesn't normalize to a covered action — unknown actions queue for human approval, they don't auto-run.
 
-**Today (v0.1):** engine, signed audit, admin UI, CLI, one reference pack (`email`, 16 verbs for Gmail + Outlook), two integrations (Claude Code, OpenClaw).
+**Today (v0.1):** engine, signed audit, admin UI, CLI, one reference pack (`email`, 16 verbs for Gmail + Outlook), three integrations (Claude Code, Codex, OpenClaw).
 
 **Roadmap:** packs for Slack, Notion, Linear, Stripe, Postgres, Bash, GitHub; framework adapters for LangChain, CrewAI, AutoGen, OpenAI Agents; pre-built CLI binaries.
 
@@ -158,7 +174,7 @@ This preserves the determinism guarantee. The LLM is allowed to be fallible in o
 
 **5. Can I run it fully offline / air-gapped?** Yes. Default install uses SQLite and in-memory storage, no external dependencies. The LLM reviewer is optional — disable it in regulated environments where every medium-risk decision must go to a human.
 
-**6. Why is only the email pack shipped?** Phase 1 focus: prove the engine end-to-end on one domain that everyone has (their inbox), with two channels (Outlook + Gmail), through a real agent host (Claude Code). The taxonomy is the moat; the packs are linear work the community can parallelize. Yours next.
+**6. Why is only the email pack shipped?** Phase 1 focus: prove the engine end-to-end on one domain that everyone has (their inbox), with two channels (Outlook + Gmail), through real agent hosts (Claude Code, Codex, and OpenClaw). The taxonomy is the moat; the packs are linear work the community can parallelize. Yours next.
 
 ---
 

--- a/clients/gmail-mcp/README.md
+++ b/clients/gmail-mcp/README.md
@@ -1,21 +1,28 @@
 # permit0-gmail-mcp
 
-MCP server that exposes Gmail tools (Gmail API v1) to Claude Code, **each
-call gated by permit0**. Mirrors `clients/outlook-mcp` — same 13 tools, same
-norm actions, same risk rules.
+MCP server that exposes Gmail tools (Gmail API v1) to agent hosts. With
+Codex and Claude Code, permit0 enforcement happens at the host
+`PreToolUse` hook layer: the host proposes
+`mcp__permit0-gmail__gmail_send`, the permit0 hook sends it to the
+daemon, and the Gmail API call only runs when the hook allows it.
+Mirrors `clients/outlook-mcp` — same 13 tools, same norm actions, same
+risk rules.
 
 ## Architecture
 
+```text
+Agent host ──PreToolUse hook──▶ permit0 hook --client <host> --remote :9090
+   │                                  │
+   │                                  └─▶ permit0 daemon/dashboard
+   │                                        (allow/deny/human)
+   │
+   └─MCP/stdio, only if allowed──────▶ permit0-gmail-mcp
+                                          └─▶ Gmail API
 ```
-Claude Code  ──MCP/stdio──▶  permit0-gmail-mcp
-                               │
-                               ├─▶ @permit0.guard("email.X")
-                               │    └─ POST /api/v1/check_action ──▶ permit0 daemon
-                               │                                       (allow/deny/human)
-                               │
-                               └─▶ Gmail API (gmail.googleapis.com/gmail/v1)
-                                    (only on allow)
-```
+
+For hosts without a hook layer, add an equivalent pre-tool gate before
+starting this MCP server. The server itself is plain MCP and does not
+call permit0 internally.
 
 ## Tools exposed
 
@@ -72,28 +79,76 @@ and silent-refreshes after that.
 python -c "from permit0_gmail_mcp.auth import get_token; print(bool(get_token()))"
 ```
 
-### 4. Wire into Claude Code
+### 4. Wire into Codex or Claude Code
 
-Add to `~/.claude.json` under top-level `mcpServers`:
+Both Codex and Claude Code enforce Gmail tools through a host-level
+`PreToolUse` hook. The MCP server config only exposes the tools; the hook
+is what calls permit0 before Gmail runs.
+
+#### Codex
+
+Start the permit0 daemon and install the Codex hook in remote mode:
+
+```bash
+cd /path/to/permit0
+cargo run -p permit0-cli -- serve --ui --port 9090
+PERMIT0_URL=http://127.0.0.1:9090 bash integrations/permit0-codex/examples/install-managed-prefs.sh
+```
+
+Add the Gmail MCP server to your Codex config:
+
+```toml
+[mcp_servers.permit0-gmail]
+command = "/absolute/path/to/permit0-gmail-mcp"
+```
+
+Restart Codex. The 13 `gmail_*` tools appear, and every Gmail MCP tool
+call is enforced by the daemon-backed Codex hook before the MCP server
+is called.
+
+#### Claude Code
+
+Start the same daemon:
+
+```bash
+cd /path/to/permit0
+cargo run -p permit0-cli -- serve --ui --port 9090
+```
+
+Add the permit0 hook to Claude Code, for example in
+`~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{ "hooks": [{
+      "type": "command",
+      "command": "/absolute/path/to/permit0/target/release/permit0 hook --remote http://127.0.0.1:9090 --unknown defer"
+    }]}]
+  }
+}
+```
+
+If you are using Claude Code, wire the server under top-level
+`mcpServers`:
 
 ```json
 {
   "mcpServers": {
     "permit0-gmail": {
-      "command": "permit0-gmail-mcp",
-      "env": {
-        "PERMIT0_URL": "http://localhost:9090"
-      }
+      "command": "permit0-gmail-mcp"
     }
   }
 }
 ```
 
-Restart Claude Code. The 13 `gmail_*` tools appear.
+Restart Claude Code. The same `gmail_*` tools appear, and the hook gates
+each call before it reaches Gmail.
 
 You can have **both** `permit0-outlook` and `permit0-gmail` configured at
-the same time — both gate through the same permit0 daemon, both lower to
-the same `email.*` norm actions, same risk rules.
+the same time. With the host's permit0 hook configured, both lower to the
+same `email.*` norm actions and are evaluated by the same daemon, using
+the same risk rules.
 
 ## Try it
 
@@ -102,7 +157,8 @@ In Claude Code:
 > Search my Gmail for "newsletter" emails from the past 7 days and archive all results.
 
 Claude Code will call `gmail_search(query="newsletter newer_than:7d")` →
-permit0 evaluates each result's `gmail_archive(message_id=...)`.
+the host hook evaluates each `gmail_archive(message_id=...)` before it
+reaches the MCP server.
 
 > Read that entire thread.
 
@@ -123,12 +179,12 @@ conversationId stitching needed).
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `PERMIT0_URL` | `http://localhost:9090` | permit0 daemon URL |
 | `GMAIL_CREDENTIALS` | `~/.permit0/gmail_credentials.json` | OAuth app credentials |
 
 ## Cross-backend invariant
 
-If you have both Gmail and Outlook MCP servers configured, **both** lower
-to the same `email.*` norm actions. permit0 sees one unified IR. The
-dashboard's audit log shows `channel=gmail` vs `channel=outlook`, but the
-risk rule and the human reviewer's decision applies regardless.
+If you have both Gmail and Outlook MCP servers configured behind a
+permit0 hook, **both** lower to the same `email.*` norm actions. permit0
+sees one unified IR. The dashboard's audit log shows `channel=gmail` vs
+`channel=outlook`, but the risk rule and the human reviewer's decision
+applies regardless.

--- a/clients/outlook-mcp/README.md
+++ b/clients/outlook-mcp/README.md
@@ -1,21 +1,26 @@
 # permit0-outlook-mcp
 
-MCP server that exposes Outlook tools (Microsoft Graph) to Claude Code, **each
-call gated by permit0** so policy is enforced before any email is sent, moved,
-or deleted.
+MCP server that exposes Outlook tools (Microsoft Graph) to agent hosts.
+With Codex and Claude Code, permit0 enforcement happens at the host
+`PreToolUse` hook layer: the host proposes
+`mcp__permit0-outlook__outlook_send`, the permit0 hook sends it to the
+daemon, and the Graph API call only runs when the hook allows it.
 
 ## Architecture
 
+```text
+Agent host ──PreToolUse hook──▶ permit0 hook --client <host> --remote :9090
+   │                                  │
+   │                                  └─▶ permit0 daemon/dashboard
+   │                                        (allow/deny/human)
+   │
+   └─MCP/stdio, only if allowed──────▶ permit0-outlook-mcp
+                                          └─▶ Microsoft Graph API
 ```
-Claude Code  ──MCP/stdio──▶  permit0-outlook-mcp
-                               │
-                               ├─▶ @permit0.guard("email.X")
-                               │    └─ POST /api/v1/check_action ──▶ permit0 daemon
-                               │                                       (allow/deny/human)
-                               │
-                               └─▶ Microsoft Graph API
-                                    (only on allow)
-```
+
+For hosts without a hook layer, add an equivalent pre-tool gate before
+starting this MCP server. The server itself is plain MCP and does not
+call permit0 internally.
 
 ## Tools exposed
 
@@ -61,43 +66,77 @@ Visit the Microsoft device-login URL it prints, sign in with your personal
 Outlook account, approve `Mail.ReadWrite` + `Mail.Send`. Token caches to
 `~/.permit0/outlook_token.json` and is reused by this MCP server.
 
-### 4. Wire into Claude Code
+### 4. Wire into Codex or Claude Code
 
-Add to your Claude Code config (typically `~/.claude.json` or a project-local
-`.mcp.json`):
+Both Codex and Claude Code enforce Outlook tools through a host-level
+`PreToolUse` hook. The MCP server config only exposes the tools; the hook
+is what calls permit0 before Microsoft Graph runs.
+
+#### Codex
+
+Install the daemon-backed Codex hook:
+
+```bash
+PERMIT0_URL=http://127.0.0.1:9090 bash integrations/permit0-codex/examples/install-managed-prefs.sh
+```
+
+For Codex, add the Outlook MCP server to your Codex config:
+
+```toml
+[mcp_servers.permit0-outlook]
+command = "/absolute/path/to/permit0-outlook-mcp"
+```
+
+#### Claude Code
+
+Add the permit0 hook to Claude Code, for example in
+`~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{ "hooks": [{
+      "type": "command",
+      "command": "/absolute/path/to/permit0/target/release/permit0 hook --remote http://127.0.0.1:9090 --unknown defer"
+    }]}]
+  }
+}
+```
+
+For Claude Code, add it to `~/.claude.json` or project-local `.mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "permit0-outlook": {
-      "command": "permit0-outlook-mcp",
-      "env": {
-        "PERMIT0_URL": "http://localhost:9090"
-      }
+      "command": "permit0-outlook-mcp"
     }
   }
 }
 ```
 
-Restart Claude Code. The 9 tools above appear in its tool list.
+Restart the host. The 9 tools above appear in its tool list, and each
+mutating Outlook MCP call is enforced by the daemon-backed host hook
+before the MCP server is called.
 
 ## Try it
 
-In Claude Code:
+In your agent host:
 
 > List the 5 most recent emails in my inbox and archive all promotional emails from last week.
 
-Claude Code will call `outlook_list` (no permit0 check), then for each
-candidate message, call `outlook_archive(message_id=...)`. Each archive call
-hits permit0 — you'll see the decisions live in the dashboard at
-http://localhost:9090/ui/ under the **Audit** tab.
+The host will call `outlook_search` or `outlook_list`, then for each
+candidate message, call `outlook_archive(message_id=...)`. Each archive
+call is evaluated by the hook before it reaches the MCP server; you'll
+see the decisions live in the dashboard at <http://localhost:9090/ui/>.
 
 > Send an email to bob@example.com with subject "test" and body "hi".
 
-Claude Code calls `outlook_send(to=..., subject=..., body=...)`. permit0
-evaluates `email.send` against its risk rule. A clean send → ALLOW. Embedding
-something like `password is hunter2` in the body → DENY (the SDK raises
-`permit0.Denied`, the MCP layer reports the block to Claude Code).
+The host calls `outlook_send(to=..., subject=..., body=...)`. permit0
+evaluates `email.send` against its risk rule. A clean send can run.
+Sensitive content or risky recipients return a deny envelope from the
+hook, so the host blocks the tool call before the MCP layer reaches
+Microsoft Graph.
 
 ## Combining with shadow mode
 
@@ -107,16 +146,14 @@ If you want to **observe** without enforcement while you tune the risk rules:
 export PERMIT0_SHADOW=1   # for `permit0 hook` use
 ```
 
-Note: this env var is read by the **`permit0 hook`** subcommand
-(Claude Code PreToolUse). The MCP server itself enforces directly via
-`@permit0.guard` — there's no built-in shadow flag yet. If you want shadow
-mode for MCP tools too, ask and we'll add it.
+Note: this env var is read by the **`permit0 hook`** subcommand. The MCP
+server itself is plain MCP, so shadow/enforcement behavior is controlled
+by the host hook command.
 
 ## Configuration
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `PERMIT0_URL` | `http://localhost:9090` | permit0 daemon URL |
 | `MSGRAPH_CLIENT_ID` | Microsoft Graph PowerShell public client | Override with your own Azure App reg |
 
 ## What this is NOT

--- a/clients/outlook-mcp/permit0_outlook_mcp/__init__.py
+++ b/clients/outlook-mcp/permit0_outlook_mcp/__init__.py
@@ -1,3 +1,3 @@
-"""permit0-outlook-mcp: MCP server exposing Outlook tools, each gated by permit0."""
+"""permit0-outlook-mcp: plain MCP server exposing Outlook tools."""
 
 __version__ = "0.1.0"

--- a/clients/outlook-mcp/pyproject.toml
+++ b/clients/outlook-mcp/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "permit0-outlook-mcp"
 version = "0.1.0"
-description = "MCP server exposing Outlook (Microsoft Graph) tools, each gated by permit0"
+description = "Plain MCP server exposing Outlook (Microsoft Graph) tools for host-level permit0 hooks"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/crates/permit0-ui/src/routes.rs
+++ b/crates/permit0-ui/src/routes.rs
@@ -60,16 +60,20 @@ pub async fn list_audit(
 > {
     if let Some(ref sink) = state.audit_sink {
         let filter = AuditFilter {
-            action_type: q.action_type,
+            action_type: q.action_type.clone(),
             decision: q.decision.as_deref().and_then(parse_permission),
-            session_id: q.session_id,
-            since: q.since,
-            until: q.until,
+            session_id: q.session_id.clone(),
+            since: q.since.clone(),
+            until: q.until.clone(),
             limit: q.limit,
             ..Default::default()
         };
         match sink.query(&filter) {
             Ok(entries) => {
+                if entries.is_empty() {
+                    return list_decision_records(&state, &q);
+                }
+
                 // The frontend's audit table and dashboard "Recent Decisions"
                 // both read flat fields (action_type, permission, tier,
                 // risk_raw, ...) shaped like DecisionRecord. AuditEntry has a
@@ -86,27 +90,7 @@ pub async fn list_audit(
             )),
         }
     } else {
-        // Fall back to simple decision records from store
-        let filter = DecisionFilter {
-            action_type: q.action_type,
-            permission: q.decision.as_deref().and_then(parse_permission),
-            since: q.since,
-            limit: q.limit,
-            ..Default::default()
-        };
-        match state.store.query_decisions(&filter) {
-            Ok(records) => {
-                let json_records: Vec<serde_json::Value> = records
-                    .iter()
-                    .filter_map(|r| serde_json::to_value(r).ok())
-                    .collect();
-                Ok(ok_response(json_records))
-            }
-            Err(e) => Err(err_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("decision query failed: {e}"),
-            )),
-        }
+        list_decision_records(&state, &q)
     }
 }
 
@@ -231,6 +215,35 @@ fn parse_permission(s: &str) -> Option<Permission> {
         "deny" => Some(Permission::Deny),
         "human" | "humanintheloop" => Some(Permission::HumanInTheLoop),
         _ => None,
+    }
+}
+
+fn list_decision_records(
+    state: &AppState,
+    q: &AuditQuery,
+) -> Result<
+    Json<ApiResponse<Vec<serde_json::Value>>>,
+    (StatusCode, Json<ApiResponse<Vec<serde_json::Value>>>),
+> {
+    let filter = DecisionFilter {
+        action_type: q.action_type.clone(),
+        permission: q.decision.as_deref().and_then(parse_permission),
+        since: q.since.clone(),
+        limit: q.limit,
+        ..Default::default()
+    };
+    match state.store.query_decisions(&filter) {
+        Ok(records) => {
+            let json_records: Vec<serde_json::Value> = records
+                .iter()
+                .filter_map(|r| serde_json::to_value(r).ok())
+                .collect();
+            Ok(ok_response(json_records))
+        }
+        Err(e) => Err(err_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("decision query failed: {e}"),
+        )),
     }
 }
 

--- a/crates/permit0-ui/src/server.rs
+++ b/crates/permit0-ui/src/server.rs
@@ -243,9 +243,10 @@ pub fn create_app_state(config: &ServerConfig) -> AppState {
 mod tests {
     use super::*;
     use crate::auth::Role;
-    use axum::body::Body;
+    use axum::body::{Body, to_bytes};
     use axum::http::Request;
-    use permit0_store::InMemoryStore;
+    use permit0_store::{InMemoryAuditSink, InMemoryStore};
+    use permit0_types::{DecisionRecord, Permission, Tier};
     use tower::ServiceExt;
 
     fn test_state() -> AppState {
@@ -289,6 +290,57 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn audit_endpoint_falls_back_to_decision_store_when_sink_empty() {
+        let store = InMemoryStore::new();
+        store
+            .save_decision(DecisionRecord {
+                id: "decision-1".into(),
+                norm_hash: [0u8; 32],
+                action_type: "email.send".into(),
+                channel: "gmail".into(),
+                permission: Permission::HumanInTheLoop,
+                source: "Scorer".into(),
+                tier: Some(Tier::Medium),
+                risk_raw: Some(0.426),
+                blocked: false,
+                flags: vec!["OUTBOUND".into()],
+                timestamp: "2026-05-11T17:50:54Z".into(),
+                surface_tool: "gmail_send".into(),
+                surface_command: "gmail_send".into(),
+                engine_permission: None,
+                reviewer: None,
+                reason: None,
+            })
+            .unwrap();
+
+        let app = build_router(AppState {
+            store: Arc::new(store),
+            audit_sink: Some(Arc::new(InMemoryAuditSink::new())),
+            token_store: Arc::new(TokenStore::new()),
+            approval_manager: Arc::new(ApprovalManager::new()),
+            packs_dir: None,
+            profiles_dir: None,
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/audit?limit=20")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let rows = json["data"].as_array().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["action_type"], "email.send");
+        assert_eq!(rows[0]["channel"], "gmail");
     }
 
     #[tokio::test]

--- a/integrations/permit0-codex/README.md
+++ b/integrations/permit0-codex/README.md
@@ -15,8 +15,9 @@ Model proposes a tool call (Bash, apply_patch, mcp__<server>__<tool>)
    ↓
 Codex fires PreToolUse hook → spawns `permit0 hook --client codex`
    ↓
-permit0 normalizes the tool call through packs, scores it, returns
-either empty stdout (no objection) or a deny envelope
+permit0 forwards the tool call to the daemon, which normalizes it
+through packs, scores it, records the decision for the dashboard, and
+returns either empty stdout (no objection) or a deny envelope
    ↓
 Codex either runs the tool or blocks it with permit0's reason
 ```
@@ -34,9 +35,20 @@ Codex either runs the tool or blocks it with permit0's reason
   # produces ./target/release/permit0
   ```
 
-## Setup (production-ish)
+## Setup (dashboard-visible enforcement)
 
-Add the hook to your Codex config and trust it once via the TUI.
+Start the permit0 daemon, then add the hook to your Codex config and
+trust it once via the TUI. Remote daemon mode is the recommended setup:
+it gives one enforcement point, one approval flow, and one dashboard
+record for every Codex tool decision.
+
+0. Start the daemon:
+
+   ```bash
+   cargo run -p permit0-cli -- serve --ui --port 9090
+   ```
+
+   Open <http://127.0.0.1:9090/ui/> to watch decisions and approvals.
 
 1. Append this block to `~/.codex/config.toml`:
 
@@ -49,7 +61,7 @@ Add the hook to your Codex config and trust it once via the TUI.
 
    [[hooks.PreToolUse.hooks]]
    type = "command"
-   command = "/absolute/path/to/permit0/target/release/permit0 hook --client codex --packs-dir /absolute/path/to/permit0/packs --unknown defer"
+   command = "/absolute/path/to/permit0/target/release/permit0 hook --client codex --remote http://127.0.0.1:9090 --unknown deny"
    timeout = 30
    statusMessage = "permit0 safety check"
    ```
@@ -70,8 +82,14 @@ Add the hook to your Codex config and trust it once via the TUI.
    Exit Codex.
 
 3. From now on every `codex` and `codex exec` session fires permit0 on
-   every tool call. Re-trust is required if you edit the hook command
+   every tool call. If the daemon is down, remote mode fails closed and
+   blocks the tool. Re-trust is required if you edit the hook command
    (Codex tracks a content hash).
+
+Local hook mode (`--packs-dir ...`) still exists for offline development
+and synthetic smoke tests, but it evaluates in the hook process and does
+not write decisions to the daemon dashboard. Do not use local mode when
+you expect dashboard-visible enforcement.
 
 ## Setup (unattended — macOS auto-trust)
 
@@ -80,14 +98,17 @@ via macOS managed preferences. Codex treats these as MDM-sourced =
 always trusted, no review needed.
 
 ```bash
+cargo run -p permit0-cli -- serve --ui --port 9090
 bash integrations/permit0-codex/examples/install-managed-prefs.sh
 ```
 
 The script reads the same TOML config layered into macOS user defaults
-under `com.openai.codex/requirements_toml_base64`. To uninstall:
+under `com.openai.codex/requirements_toml_base64`. By default it installs
+remote daemon mode against `http://127.0.0.1:9090`; override with
+`PERMIT0_URL=http://host:port` if your daemon runs elsewhere. To uninstall:
 
 ```bash
-defaults delete com.openai.codex requirements_toml_base64
+bash integrations/permit0-codex/examples/install-managed-prefs.sh --uninstall
 ```
 
 This is the path the live-demo launcher in `dev-test-rig/codex-demo`
@@ -114,8 +135,8 @@ enforcement boundary." permit0 inherits them.
 |---|---|---|
 | `Allow` / `Defer` | Zero stdout bytes | Tool runs |
 | `Deny` | `permissionDecision: "deny"` envelope with reason | Tool blocked, model sees the reason |
-| `HumanInTheLoop` (Medium/High tier) | `permissionDecision: "deny"` envelope with `" — requires human review"` marker appended to the reason | Tool blocked; the marker tells users this was a HITL action under Claude Code, not a hard Critical block |
-| Internal error in permit0 | `permissionDecision: "deny"` envelope with `"permit0 internal error: <msg>"` | Tool blocked (fail-closed) |
+| `HumanInTheLoop` (Medium/High tier) | `permissionDecision: "deny"` envelope with `" — requires human review"` marker appended to the reason | Tool blocked; the marker tells users this was a HITL action, not a hard Critical block |
+| Daemon unavailable / internal error | `permissionDecision: "deny"` envelope with the failure reason | Tool blocked (fail-closed) |
 
 Codex `PreToolUse` does **not** support `permissionDecision: "allow"` or
 `"ask"`; both are explicitly rejected. permit0 never emits either.

--- a/integrations/permit0-codex/examples/config.toml.example
+++ b/integrations/permit0-codex/examples/config.toml.example
@@ -9,6 +9,10 @@
 #
 # Replace `/abs/path/to/permit0` with the actual checkout path (the
 # `command` field does not expand `~` or shell vars).
+# Start the daemon first so decisions are enforced and visible in the
+# dashboard:
+#
+#   cargo run -p permit0-cli -- serve --ui --port 9090
 
 [features]
 hooks = true
@@ -18,7 +22,7 @@ matcher = ".*"
 
 [[hooks.PreToolUse.hooks]]
 type = "command"
-command = "/abs/path/to/permit0/target/release/permit0 hook --client codex --packs-dir /abs/path/to/permit0/packs --unknown defer"
+command = "/abs/path/to/permit0/target/release/permit0 hook --client codex --remote http://127.0.0.1:9090 --unknown deny"
 timeout = 30
 statusMessage = "permit0 safety check"
 
@@ -32,18 +36,15 @@ statusMessage = "permit0 safety check"
 #   matcher = "^mcp__.*"                        # all MCP tools
 #   matcher = "^mcp__permit0-gmail__.*"         # one specific MCP server
 
-# Remote mode — point the hook at a running daemon instead of
-# evaluating in-process. Useful for centralized dashboards / audit:
+# Local dev mode — evaluate in-process without the dashboard daemon.
+# Useful for offline smoke tests, but decisions will not appear in the
+# daemon dashboard:
 #
-#   command = "/abs/path/to/permit0 hook --client codex --remote http://127.0.0.1:9090 --unknown defer"
-#
-# Then in a separate process:
-#
-#   cargo run --release -p permit0-cli -- serve --ui --port 9090
+#   command = "/abs/path/to/permit0/target/release/permit0 hook --client codex --packs-dir /abs/path/to/permit0/packs --unknown defer"
 
 # Shadow mode — observe without blocking. permit0 logs the verdict to
 # stderr but never returns a deny envelope. Append --shadow:
 #
-#   command = "/abs/path/to/permit0 hook --client codex --shadow --unknown defer"
+#   command = "/abs/path/to/permit0/target/release/permit0 hook --client codex --remote http://127.0.0.1:9090 --unknown deny --shadow"
 #
 # Equivalently, set PERMIT0_SHADOW=1 in the environment that runs codex.

--- a/integrations/permit0-codex/examples/hooks.json.example
+++ b/integrations/permit0-codex/examples/hooks.json.example
@@ -1,5 +1,5 @@
 {
-  "_comment": "permit0 hook for Codex — alternative to inline [hooks] in config.toml. Save as ~/.codex/hooks.json. Replace /abs/path/to/permit0 with your actual checkout. After saving, launch codex once interactively and /hooks to mark it trusted.",
+  "_comment": "permit0 hook for Codex — alternative to inline [hooks] in config.toml. Save as ~/.codex/hooks.json. Replace /abs/path/to/permit0 with your actual checkout. Start permit0 serve --ui --port 9090 before Codex. After saving, launch codex once interactively and /hooks to mark it trusted.",
 
   "hooks": {
     "PreToolUse": [
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/abs/path/to/permit0/target/release/permit0 hook --client codex --packs-dir /abs/path/to/permit0/packs --unknown defer",
+            "command": "/abs/path/to/permit0/target/release/permit0 hook --client codex --remote http://127.0.0.1:9090 --unknown deny",
             "timeout": 30,
             "statusMessage": "permit0 safety check"
           }

--- a/integrations/permit0-codex/examples/install-managed-prefs.sh
+++ b/integrations/permit0-codex/examples/install-managed-prefs.sh
@@ -10,9 +10,9 @@
 # Codex's TUI first.
 #
 # Usage:
-#   install-managed-prefs.sh [--force]       install (refuses if an
-#                                            unstamped value is already
-#                                            present)
+#   install-managed-prefs.sh [--force]       install a daemon-backed hook
+#                                            (refuses if an unstamped value
+#                                            is already present)
 #   install-managed-prefs.sh --uninstall     remove permit0's value; if a
 #                                            backup exists, restore the
 #                                            most recent one
@@ -44,7 +44,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 PERMIT0_BIN="$REPO_ROOT/target/release/permit0"
-PACKS_DIR="$REPO_ROOT/packs"
+PERMIT0_URL="${PERMIT0_URL:-http://127.0.0.1:9090}"
 
 DEFAULTS_DOMAIN="com.openai.codex"
 DEFAULTS_KEY="requirements_toml_base64"
@@ -57,11 +57,18 @@ print_help() {
 install-managed-prefs.sh — install the permit0+Codex managed-prefs hook.
 
 USAGE:
-  install-managed-prefs.sh                    # install (refuses if unstamped)
+  install-managed-prefs.sh                    # install daemon-backed hook
   install-managed-prefs.sh --force            # overwrite (backs up first)
   install-managed-prefs.sh --uninstall        # remove permit0 value; restore last backup
   install-managed-prefs.sh --uninstall --force  # remove any value (no stamp check)
   install-managed-prefs.sh --help             # this message
+
+CONFIG:
+  PERMIT0_URL=http://127.0.0.1:9090           # daemon used by the hook
+
+  The installed hook uses remote daemon mode so enforcement decisions land
+  in the same permit0 server and dashboard. Start it with:
+    cargo run -p permit0-cli -- serve --ui --port 9090
 
 SAFETY:
   This script writes to macOS user defaults at
@@ -137,7 +144,7 @@ matcher = ".*"
 
 [[hooks.PreToolUse.hooks]]
 type = "command"
-command = "$PERMIT0_BIN hook --client codex --packs-dir $PACKS_DIR --unknown defer"
+command = "$PERMIT0_BIN hook --client codex --remote $PERMIT0_URL --unknown deny"
 timeout = 30
 statusMessage = "permit0 safety check"
 EOF
@@ -148,10 +155,6 @@ do_install() {
     if [[ ! -x "$PERMIT0_BIN" ]]; then
         echo "error: $PERMIT0_BIN not found or not executable" >&2
         echo "       run: cd $REPO_ROOT && cargo build --release" >&2
-        exit 2
-    fi
-    if [[ ! -d "$PACKS_DIR" ]]; then
-        echo "error: $PACKS_DIR missing" >&2
         exit 2
     fi
 
@@ -184,10 +187,14 @@ do_install() {
     defaults write "$DEFAULTS_DOMAIN" "$DEFAULTS_KEY" -string "$(printf '%s' "$body" | base64)"
 
     echo "✓ permit0 managed-prefs installed."
+    echo "  daemon URL: $PERMIT0_URL"
     echo
     cat <<EOF
 Verify:
   defaults read $DEFAULTS_DOMAIN $DEFAULTS_KEY | base64 -d
+
+Run the daemon before starting Codex:
+  cd $REPO_ROOT && cargo run -p permit0-cli -- serve --ui --port 9090
 
 Uninstall (and restore the most recent backup if any):
   $0 --uninstall


### PR DESCRIPTION
## Summary
- make Codex managed-preferences installer default to remote daemon mode with fail-closed unknown handling
- update Codex config examples and README to recommend dashboard-visible enforcement through `permit0 serve --ui`
- keep Claude Code, Codex, and OpenClaw positioned as supported integrations in the top-level README
- make Gmail and Outlook MCP READMEs explicitly document both Codex and Claude Code hook setup
- clarify that Gmail and Outlook MCP servers are plain MCP and enforcement happens at the host hook layer
- fix dashboard audit listing fallback so persisted decisions show after the in-memory audit sink is empty or reset

## Tests
- `bash -n integrations/permit0-codex/examples/install-managed-prefs.sh scripts/test-managed-prefs-roundtrip.sh scripts/test-codex-hook.sh`
- `python3 -m json.tool integrations/permit0-codex/examples/hooks.json.example >/dev/null`
- `PERMIT0=./target/debug/permit0 scripts/test-codex-hook.sh`
- `cargo test -p permit0-cli codex`
- `scripts/test-managed-prefs-roundtrip.sh`
- `cargo test -p permit0-ui`