### PR TITLE
feat(serve): block HITL on dashboard approval; stop caching human verdicts

### DIFF
--- a/crates/permit0-cli/src/cmd/serve.rs
+++ b/crates/permit0-cli/src/cmd/serve.rs
@@ -486,11 +486,17 @@ async fn apply_calibration(
         "[calibrate] human → {:?} (engine had → {:?}) reviewer={} reason={}",
         decision.permission, original_permission, decision.reviewer, decision.reason,
     );
-    // Intentionally do NOT cache the human's verdict. Every fresh decision
-    // must reach a human; subsequent identical calls go through approval
-    // again. The unused norm_hash binding stays for parity with the
-    // advisory flow's signature.
-    let _ = norm_hash;
+
+    // Cache the human's Allow/Deny so subsequent identical calls reflect
+    // it without re-prompting. HITL itself is never cached (matches the
+    // engine's own policy). Session-aware bypass would belong here, but
+    // session chains aren't supported yet — revisit when they are.
+    if decision.permission != Permission::HumanInTheLoop {
+        let _ = state
+            .engine
+            .store()
+            .policy_cache_set(norm_hash, decision.permission);
+    }
 
     let meta = CalibrationMeta {
         engine_permission: Some(original_permission),
@@ -557,6 +563,7 @@ async fn block_for_advisory_approval(
 
     let action_type = result.norm_action.action_type.as_action_str();
     let channel = result.norm_action.channel.clone();
+    let norm_hash = result.norm_action.norm_hash();
     let (approval_id, rx) = manager.create_pending(result.norm_action.clone(), risk_score);
     let timeout = manager.timeout();
 
@@ -585,6 +592,17 @@ async fn block_for_advisory_approval(
         "[approval] {approval_id} → {:?} by {} ({})",
         decision.permission, decision.reviewer, decision.reason,
     );
+
+    // Cache the human's Allow/Deny so subsequent identical calls reflect
+    // it without re-prompting. HITL itself is never cached (matches the
+    // engine's own policy). Session-aware bypass would belong here, but
+    // session chains aren't supported yet — revisit when they are.
+    if decision.permission != Permission::HumanInTheLoop {
+        let _ = state
+            .engine
+            .store()
+            .policy_cache_set(norm_hash, decision.permission);
+    }
 
     Ok(PermissionResult {
         permission: decision.permission,

--- a/crates/permit0-cli/src/cmd/serve.rs
+++ b/crates/permit0-cli/src/cmd/serve.rs
@@ -27,7 +27,8 @@ use permit0_store::audit::{
 };
 use permit0_store::{InMemoryStore, SqliteStore, Store};
 use permit0_types::{
-    ActionType, DecisionRecord, Entities, ExecutionMeta, NormAction, RawToolCall, RiskScore, Tier,
+    ActionType, DecisionRecord, Entities, ExecutionMeta, NormAction, Permission, RawToolCall,
+    RiskScore, Tier,
 };
 use permit0_ui::{AppState, ApprovalManager, TokenStore};
 use tower_http::services::ServeDir;
@@ -144,6 +145,7 @@ async fn check_handler(
     })?;
 
     let (result, meta) = apply_calibration(&state, result).await?;
+    let result = block_for_advisory_approval(&state, result).await?;
 
     let surface_command = tool_call
         .parameters
@@ -384,6 +386,7 @@ async fn check_action_handler(
     })?;
 
     let (result, meta) = apply_calibration(&state, result).await?;
+    let result = block_for_advisory_approval(&state, result).await?;
 
     record_and_respond(
         &state,
@@ -483,13 +486,11 @@ async fn apply_calibration(
         "[calibrate] human → {:?} (engine had → {:?}) reviewer={} reason={}",
         decision.permission, original_permission, decision.reviewer, decision.reason,
     );
-
-    // Persist the human's decision in the cache so future identical calls
-    // reflect the calibrated answer (overwriting the engine's recommendation).
-    let _ = state
-        .engine
-        .store()
-        .policy_cache_set(norm_hash, decision.permission);
+    // Intentionally do NOT cache the human's verdict. Every fresh decision
+    // must reach a human; subsequent identical calls go through approval
+    // again. The unused norm_hash binding stays for parity with the
+    // advisory flow's signature.
+    let _ = norm_hash;
 
     let meta = CalibrationMeta {
         engine_permission: Some(original_permission),
@@ -503,6 +504,94 @@ async fn apply_calibration(
         source: DecisionSource::HumanReviewer,
     };
     Ok((new_result, meta))
+}
+
+/// Block on a human decision for fresh HumanInTheLoop verdicts.
+///
+/// In non-calibration mode, when the engine returns HITL from real risk
+/// scoring (Scorer or AgentReviewer source), park the HTTP request until
+/// a human resolves the approval in the dashboard, then resume with the
+/// human's verdict. No policy-cache writes: every HITL goes through
+/// fresh approval, including identical repeats.
+///
+/// UnknownFallback HITLs ("permit0 has no opinion about this tool") are
+/// deliberately excluded — those should be addressed via a
+/// normalizer/risk-rule pair or by allowlisting the norm_hash, not by
+/// flooding the approval queue with every unrecognized tool call.
+///
+/// Pass-through (no blocking) when:
+/// - The verdict is not HumanInTheLoop (Allow/Deny need no queue entry).
+/// - The decision came from cache/list/prior-human/UnknownFallback path.
+/// - No approval manager is configured (no --ui mode).
+/// - Calibration mode is on (apply_calibration already handled it).
+async fn block_for_advisory_approval(
+    state: &ServerState,
+    result: PermissionResult,
+) -> Result<PermissionResult, (StatusCode, String)> {
+    if state.calibrate || result.permission != Permission::HumanInTheLoop {
+        return Ok(result);
+    }
+    match result.source {
+        DecisionSource::Allowlist
+        | DecisionSource::Denylist
+        | DecisionSource::PolicyCache
+        | DecisionSource::HumanReviewer
+        | DecisionSource::UnknownFallback => return Ok(result),
+        DecisionSource::Scorer | DecisionSource::AgentReviewer => {}
+    }
+
+    let manager = match &state.approval_manager {
+        Some(m) => m.clone(),
+        None => return Ok(result),
+    };
+
+    let risk_score = result.risk_score.clone().unwrap_or_else(|| RiskScore {
+        raw: 0.0,
+        score: 0,
+        tier: Tier::Minimal,
+        blocked: false,
+        flags: Vec::new(),
+        block_reason: None,
+        reason: "no risk score (cache or fast-path)".into(),
+    });
+
+    let action_type = result.norm_action.action_type.as_action_str();
+    let channel = result.norm_action.channel.clone();
+    let (approval_id, rx) = manager.create_pending(result.norm_action.clone(), risk_score);
+    let timeout = manager.timeout();
+
+    eprintln!("[approval] HITL pending for {action_type} ({channel}) — approval_id={approval_id}",);
+
+    let decision = match tokio::time::timeout(timeout, rx).await {
+        Ok(Ok(d)) => d,
+        Ok(Err(_)) => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "approval channel closed unexpectedly".into(),
+            ));
+        }
+        Err(_) => {
+            return Err((
+                StatusCode::REQUEST_TIMEOUT,
+                format!(
+                    "approval timeout after {}s; no human decision",
+                    timeout.as_secs()
+                ),
+            ));
+        }
+    };
+
+    eprintln!(
+        "[approval] {approval_id} → {:?} by {} ({})",
+        decision.permission, decision.reviewer, decision.reason,
+    );
+
+    Ok(PermissionResult {
+        permission: decision.permission,
+        norm_action: result.norm_action,
+        risk_score: result.risk_score,
+        source: DecisionSource::HumanReviewer,
+    })
 }
 
 /// Calibration metadata attached to a decision when a human reviewer


### PR DESCRIPTION
Closes #55.

## Summary

In non-calibration mode (`serve --ui --port 9090`), a fresh `HumanInTheLoop` verdict from real risk scoring now parks the `/check` request, surfaces in the dashboard's Approvals queue with full risk context, and resumes with the human's verdict once they click Allow or Deny. Previously the call returned HITL immediately and the agent's action was simply lost — the Approvals tab stayed empty and there was no path for a human to intervene. See #55 for the full problem statement.

## Type

- [ ] New pack
- [ ] Pack update
- [x] Core feature
- [ ] Bug fix
- [ ] Documentation

## What changed

`crates/permit0-cli/src/cmd/serve.rs`:

- New `block_for_advisory_approval` parks `/check` on fresh HITL verdicts (`Scorer` / `AgentReviewer` source only) until the human resolves the approval, then resumes with the human's verdict. Times out after the existing 5-minute `ApprovalManager` window with 408 — same shape as calibration mode.
- `UnknownFallback` HITLs are deliberately excluded — those mean "permit0 has no opinion about this tool" and should be fixed with a normalizer or allowlist entry rather than flooding the queue.
- Both the advisory path and the calibration path cache the human's Allow/Deny in the policy cache (`engine.store().policy_cache_set`), so subsequent identical calls don't re-prompt. HITL verdicts submitted by the reviewer are not cached, matching the engine's own behavior. Session-aware cache bypass is the right model long-term, but session chains aren't supported yet — revisit then.

## Behavior matrix (non-calibration mode, with `--ui`)

| Engine source | Verdict | Behavior |
|---|---|---|
| `Scorer` / `AgentReviewer` | `Allow` / `Deny` | Returned immediately. Cached (perf). |
| `Scorer` / `AgentReviewer` | `HumanInTheLoop` | **Parks `/check` → Approvals queue → resumes with human verdict.** Cached on Allow/Deny. |
| `UnknownFallback` | `HumanInTheLoop` | Returned immediately (unchanged). Not queued. |
| `PolicyCache` / `Allowlist` / `Denylist` / prior `HumanReviewer` | any | Pass-through. |

`serve --port 9090` without `--ui`: no approval manager → pass-through, same as before.

## Tradeoff to flag for reviewers

`/check` now holds the HTTP connection open up to 5 min waiting on a human (matches the existing `ApprovalManager::DEFAULT_APPROVAL_TIMEOUT`). HTTP clients with shorter default timeouts (most do — 30–60s is common) will give up before the human responds and the call fails on the agent side. Calibration mode has had this property since it shipped, so this is consistent with the existing model. If we want a different default here (60s? configurable per-request?), say so and I'll add it.

## Test plan

- [x] `cargo build -p permit0-cli`
- [x] `cargo clippy -p permit0-cli --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p permit0-cli` (14 + 6 pass)
- [x] `cargo test -p permit0-ui` (77 pass)
- [x] **Manual end-to-end** against a live daemon on port 9091:
  1. `POST /api/v1/check` for `gmail_send` parks.
  2. `GET /api/v1/approvals` returns the entry with MEDIUM tier, score 43, entities `{to, body, subject, domain, recipient_scope}`, flags `[GOVERNANCE, OUTBOUND, PRIVILEGE, EXPOSURE, MUTATION]`.
  3. `POST /api/v1/approvals/decide` with `permission: allow` → original `/check` resumes and returns `{"permission":"allow","source":"HumanReviewer"}`.
  4. Identical second `/check` returns in ~9ms with `source: PolicyCache` — confirms cache write after human approval.
  5. Third `/check` with a different `body` parks again — confirms cache keys on the full normalized action.