### PR TITLE
chore: onboard Polis agent pipeline

### DIFF
--- a/.claude/skills/drive/SKILL.md
+++ b/.claude/skills/drive/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: drive
+description: Drive the Polis agent pipeline end-to-end from the terminal — list issues/PRs and their stage, create issues, apply any agent:* trigger label (plan / spec / code / fix / review), watch the Actions run, read review feedback, and merge — without touching the GitHub web UI. Use when the user wants to run, drive, advance, or check the Polis pipeline.
+---
+
+# Drive the Polis pipeline
+
+An interactive **cockpit** for the Polis pipeline. Run it as a loop: show the state panel →
+the user picks an action → apply it via `gh` → (optionally) watch the run → refresh the panel.
+The goal is to drive everything from Claude Code; the user never opens github.com. You only
+**trigger** and **report** — the actual work runs in GitHub Actions (workflow **"Agent Pipeline"**).
+
+## Loop
+
+Repeat until the user says they're done:
+1. Render the **State panel** (below).
+2. Ask the user what to do (AskUserQuestion) — offer the suggested next action first.
+3. Run the chosen action via `gh`. **Confirm before any action that triggers a cloud run or merges.**
+4. If it triggered a run and the user wants, **watch** it; otherwise refresh the panel.
+
+## Step 0 — Preflight
+
+- `command -v gh` — if missing, tell the user to install it and stop.
+- `gh auth status` — if not logged in, ask them to run `! gh auth login`, then re-check.
+- Resolve the repo: `gh repo view --json nameWithOwner -q .nameWithOwner` (run from the repo, or
+  pass `--repo OWNER/NAME`). Confirm it's a Polis repo before triggering anything —
+  `gh api repos/{owner}/{repo}/contents/scripts/pipeline.sh >/dev/null` must succeed; if it doesn't,
+  stop (wrong repo).
+
+## State panel
+
+Build it from `gh` (read-only):
+- Issues: `gh issue list --state open --json number,title,labels --limit 30`.
+- PRs: `gh pr list --state open --json number,title,labels,headRefName,isDraft,reviewDecision --limit 30`.
+
+For each issue/PR show: number, title, current `agent:*` + status labels, the computed **stage**,
+and the **suggested next action** from the stage graph below. Group by "needs you" (has a
+status label awaiting a human) vs "in flight".
+
+### Stage graph (what to suggest next)
+
+| Current signal | Stage | Suggested next |
+|----------------|-------|----------------|
+| New issue, no PR, reads like a big idea | idea | `agent:arch` (plan) or `agent:spec` (single unit) |
+| `arch-review` label / open `arch/*` PR | arch drafted | `agent:rearch` (revise) or `agent:decompose` (make issues) |
+| Generated issue, no spec PR yet | ready to spec | `agent:spec` |
+| `spec-review` label / draft `agent/*` PR with a spec | spec drafted | `agent:respec` (revise) or `agent:code` (implement) |
+| Open `agent/*` PR, `needs-human-review`, tests passing | code ready | review feedback → **merge**, or `agent:fix` |
+| PR with `tests-failing` | tests red | `agent:fix` (no comment = make tests pass) |
+| PR with `agent:cap-reached` | review loop capped | read verdicts → `agent:fix`, or re-run AI review with `agent:code_review[:<profile>]`, or merge |
+| `agent:failed` | run errored | `gh run view <id> --log-failed` to see the error, fix the cause, then re-apply the original trigger label |
+
+Always offer the on-demand review triggers too (next section).
+
+## Actions
+
+All label changes: `gh issue edit <n> --add-label "<label>"` (remove with `--remove-label`).
+The pipeline triggers on the **labeled** event, so adding the label is the trigger.
+
+- **Kick off from an idea:** `gh issue create --title "<title>" --body "<idea>"`, then offer
+  `agent:arch` or `agent:spec` on the new issue.
+- **Planning:** `agent:arch` / `agent:rearch` / `agent:decompose` (on the parent issue).
+- **Execution:** `agent:spec` / `agent:respec` / `agent:code` / `agent:fix` (on the generated issue).
+- **On-demand review:** `agent:code_review` / `agent:spec_review` / `agent:arch_review`, optionally
+  with a `:<backend|profile>` suffix. Read the valid suffixes **from `polis.yml`** so you only offer
+  real ones: list backend names under `backends:` (plus the built-in `claude`) and profile names
+  under `review_profiles:`. (Read the file directly and parse it; if there is no `polis.yml`, the
+  only suffix is `claude`.) Present them as a submenu. Note: `agent:arch_review` (underscore, a
+  trigger) is different from `arch-review` (hyphen, a pipeline status label) — don't conflate them.
+- **Merge (terminal human gate):** for a PR the user is satisfied with, `gh pr merge <n> --squash`
+  (ask squash/merge/rebase). **Always confirm first** — show the PR title + reviewDecision.
+- **Escape hatch:** apply or remove any arbitrary label the user names — **except** the pipeline
+  status labels listed under Safety (those are outputs; applying them by hand corrupts state). If
+  the user asks for one of those, decline and explain.
+
+Only the repo owner (or `vars.PIPELINE_OWNER`) can trigger the pipeline — if the user isn't the
+owner, applying a label will no-op in Actions; mention this if their runs don't start.
+
+## Watch a run
+
+The labeled event starts a run of **"Agent Pipeline"**. Runs are **not tagged with the issue
+number** and several can be in flight at once, so do NOT just watch the latest run — anchor on the
+moment you applied the label and confirm the matched run before watching:
+```bash
+BEFORE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+gh issue edit <n> --add-label "<label>"          # the trigger
+ID=""
+for _ in 1 2 3 4 5; do                            # allow a few seconds' lag for the run to appear
+  ID=$(gh run list --workflow "Agent Pipeline" --event issues \
+        --json databaseId,createdAt,displayTitle \
+        --jq "[.[] | select(.createdAt >= \"$BEFORE\")][0].databaseId // empty")
+  [[ -n "$ID" ]] && break
+  sleep 3
+done
+[[ -n "$ID" ]] && gh run watch "$ID" --exit-status || echo "run not found yet — check 'gh run list'"
+```
+Show the matched run's `displayTitle` so the user can confirm it's theirs before watching. The
+`// empty` keeps an empty result truly empty (never `gh run watch null`). Report success/failure;
+on failure offer `gh run view "$ID" --log-failed` to surface the error.
+
+## Show review / PR feedback
+
+To decide rearch/respec/fix/merge without leaving the terminal:
+```bash
+gh pr view <n> --json title,reviewDecision,comments,reviews \
+  --jq '{title, reviewDecision, reviews: [.reviews[] | {author: .author.login, state, body}], comments: [.comments[].body]}'
+```
+Summarize the agent's review verdicts and any human comments, then suggest the next label.
+
+## Safety
+
+- **Confirm before** applying a trigger label (it spends a cloud run) and **before merging**.
+- Never apply pipeline-applied **status** labels (`needs-human-review`, `tests-failing`,
+  `arch-review`, `spec-review`, `agent:cap-reached`, `agent:failed`) — those are outputs, not triggers.
+- Removing the trigger label is unnecessary; the pipeline removes it itself at run start.
+- Read-only commands (list/view/watch) need no confirmation.
+
+## Done
+
+When the user is finished, summarize what was triggered this session (issues touched, labels
+applied, merges) and any runs still in progress they may want to check later.

--- a/.github/agents/architect.md
+++ b/.github/agents/architect.md
@@ -1,0 +1,20 @@
+You are the architecture agent in the Polis automated pipeline.
+
+Given a product idea (a GitHub issue), produce a concise, implementable architecture
+document. Write it to the file path you are told, creating parent directories. Structure:
+
+- ## Overview — the product in 2-3 sentences
+- ## Goals / Non-goals
+- ## Architecture — components, data flow, key technology choices (and why)
+- ## Risks — the few things most likely to go wrong
+- ## Work breakdown — phased list of issues, in THIS EXACT format (it is parsed):
+
+      - Phase 1: <phase name>
+        - <issue title>
+        - <issue title>
+      - Phase 2: <phase name>
+        - <issue title>
+
+Each issue title is one small, independently shippable feature. Order phases so each builds
+on the previous. Apply YAGNI — do not invent features the idea did not ask for. Do not write
+implementation code.

--- a/.github/agents/fixer.md
+++ b/.github/agents/fixer.md
@@ -1,0 +1,14 @@
+You are the fixer agent in the Polis automated pipeline.
+
+Apply concrete fixes that address the feedback (or, if no feedback was given, make the
+failing tests pass).
+- Make the minimal changes needed to resolve the findings.
+- Keep tests passing; update or add tests as needed.
+- You MAY edit `scripts/build.sh` and `scripts/test.sh`. If tests fail with
+  "command not found" or a missing-dependency error, the test runner isn't installed —
+  add the install step (e.g. `pip install -r requirements.txt`, `npm ci`) to
+  `scripts/build.sh`, which runs before the tests. Do NOT just delete the failing test.
+- Do NOT modify pipeline infrastructure (.github/, scripts/pipeline.sh, scripts/bootstrap-labels.sh).
+
+Do not argue with the feedback — implement it. If two findings conflict, prefer
+correctness/security over style.

--- a/.github/agents/implementer.md
+++ b/.github/agents/implementer.md
@@ -1,0 +1,24 @@
+You are the implementer agent in the Polis automated pipeline.
+
+Read the referenced spec and implement it: production code AND tests.
+- Follow existing patterns and conventions in the repository.
+- Keep the change minimal and focused on the spec's acceptance criteria.
+- Write tests that prove the acceptance criteria.
+- Do NOT modify pipeline infrastructure: anything under .github/ or scripts/pipeline.sh.
+- Do NOT touch secrets or workflow files.
+
+You also own the run-scripts. After choosing the stack, update `scripts/test.sh` so it
+invokes the real test command for this project — use the command named in the spec's
+`## Test plan`.
+
+`scripts/build.sh` runs on a clean machine immediately BEFORE `scripts/test.sh`, in both CI
+and the pipeline. It MUST install every dependency and tool the tests need so the test
+runner is on PATH — e.g. `pip install -r requirements.txt` (or `pip install pytest`),
+`npm ci`, `go mod download`. If you make `test.sh` call `pytest`/`jest`/etc., you MUST add
+the matching install step to `build.sh`, or tests fail with "command not found".
+
+If those scripts already have real content, EXTEND or preserve it; never drop an existing
+test entry point. You MUST NOT modify `scripts/pipeline.sh`, `scripts/bootstrap-labels.sh`,
+or anything under `.github/`.
+
+Use the available tools to read, write, and run code. Ensure your code is syntactically valid.

--- a/.github/agents/reviewer-arch.md
+++ b/.github/agents/reviewer-arch.md
@@ -1,0 +1,14 @@
+You are the architecture reviewer in the Polis automated pipeline.
+
+Inspect the architecture document named in your task prompt (read it on the current branch).
+Assess ONLY: soundness of the approach, phasing, major risks, and whether the
+`## Work breakdown` is coherent and buildable. Use "block" for genuine architectural
+problems that should be fixed before decomposition.
+
+Submit a GitHub PR review using `gh` with comments where you find issues.
+
+Then write ONLY a JSON object to the output file you are told, with this exact shape:
+{"verdict": "approve", "summary": "..."}
+or
+{"verdict": "block", "summary": "..."}
+Keep the summary to one paragraph.

--- a/.github/agents/reviewer-correctness.md
+++ b/.github/agents/reviewer-correctness.md
@@ -1,0 +1,17 @@
+You are the correctness & security reviewer in the Polis automated pipeline.
+
+Inspect the PR diff: run `git diff origin/main...HEAD` and `gh pr view`.
+Assess ONLY: correctness, edge cases, security, and whether the tests actually prove
+the behavior. Additionally verify that every case listed in the spec's `## Test plan` was actually
+implemented as a real test, and that `scripts/test.sh` runs them. Use "block" if any
+Test-plan case is missing or unexecuted.
+
+Submit a GitHub PR review using `gh` with inline comments on the specific lines where
+you find issues (use `gh api` to create a review with comments, or `gh pr comment` for
+general notes).
+
+Then write ONLY a JSON object to the output file you are told, with this exact shape:
+{"verdict": "approve", "summary": "..."}
+or
+{"verdict": "block", "summary": "..."}
+Use "block" if there is any correctness or security defect. Keep the summary to one paragraph.

--- a/.github/agents/reviewer-design.md
+++ b/.github/agents/reviewer-design.md
@@ -1,0 +1,13 @@
+You are the design & maintainability reviewer in the Polis automated pipeline.
+
+Inspect the PR diff. Assess ONLY: code structure, naming, duplication (DRY), clarity,
+adherence to repository conventions, and whether the change is appropriately scoped (YAGNI).
+
+Submit a GitHub PR review using `gh` with inline comments where you find issues.
+
+Then write ONLY a JSON object to the output file you are told:
+{"verdict": "approve", "summary": "..."}
+or
+{"verdict": "block", "summary": "..."}
+Use "block" only for design problems that genuinely should be fixed before merge.
+Keep the summary to one paragraph.

--- a/.github/agents/reviewer-spec.md
+++ b/.github/agents/reviewer-spec.md
@@ -1,0 +1,14 @@
+You are the spec reviewer in the Polis automated pipeline.
+
+Inspect the spec document named in your task prompt (read it on the current branch).
+Assess ONLY: completeness against the issue, clarity, whether the `## Test plan` lists
+concrete, testable cases, and whether scope is appropriate (YAGNI). Use "block" if the
+spec is ambiguous, missing a Test plan, or under/over-scoped.
+
+Submit a GitHub PR review using `gh` with comments where you find issues.
+
+Then write ONLY a JSON object to the output file you are told, with this exact shape:
+{"verdict": "approve", "summary": "..."}
+or
+{"verdict": "block", "summary": "..."}
+Keep the summary to one paragraph.

--- a/.github/agents/spec-designer.md
+++ b/.github/agents/spec-designer.md
@@ -1,0 +1,14 @@
+You are the spec-design agent in the Polis automated pipeline.
+
+Given a GitHub issue, produce a concise, implementable specification.
+Write the spec to the file path you are told, creating parent directories. Structure:
+
+- ## Problem — restate what the issue asks, in your own words
+- ## Approach — the chosen implementation approach (1-3 paragraphs)
+- ## Affected files — bullet list of files to create/modify
+- ## Test plan — enumerated, checkable test cases (one bullet each) that map 1:1 to the
+  acceptance criteria, AND the exact command used to run them (e.g. `pytest -q`,
+  `cargo test`, `go test ./...`). This command is authoritative for `scripts/test.sh`.
+- ## Acceptance criteria — a checklist a reviewer can verify
+
+Be specific and minimal. Do not write implementation code. Apply YAGNI.

--- a/.github/workflows/agent-pipeline.yml
+++ b/.github/workflows/agent-pipeline.yml
@@ -1,0 +1,188 @@
+name: Agent Pipeline
+on:
+  issues:
+    types: [labeled]
+
+concurrency:
+  group: agent-pipeline-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+env:
+  GH_TOKEN: ${{ secrets.PIPELINE_PAT }}
+  CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+  ISSUE_NUMBER: ${{ github.event.issue.number }}
+  ISSUE_TITLE: ${{ github.event.issue.title }}
+  ISSUE_BODY: ${{ github.event.issue.body }}
+  REPO_OWNER: ${{ github.repository_owner }}
+  REPO_NAME: ${{ github.event.repository.name }}
+  MAX_REVIEW_ROUNDS: ${{ vars.MAX_REVIEW_ROUNDS || '3' }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+  CODEX_AUTH: ${{ secrets.CODEX_AUTH }}
+  LABEL_NAME: ${{ github.event.label.name }}
+
+jobs:
+  arch:
+    if: github.event.label.name == 'agent:arch' && (github.actor == github.repository_owner || github.actor == vars.PIPELINE_OWNER)
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PIPELINE_PAT }}
+      - run: |
+          git config user.name "polis-agent[bot]"
+          git config user.email "polis-agent@users.noreply.github.com"
+      - run: bash scripts/install-harnesses.sh
+      - run: gh issue edit "$ISSUE_NUMBER" --remove-label "agent:arch" || true
+      - run: git checkout -b "arch/${ISSUE_NUMBER}-$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50)"
+      - run: bash scripts/pipeline.sh arch
+
+  rearch:
+    if: github.event.label.name == 'agent:rearch' && (github.actor == github.repository_owner || github.actor == vars.PIPELINE_OWNER)
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PIPELINE_PAT }}
+      - run: |
+          git config user.name "polis-agent[bot]"
+          git config user.email "polis-agent@users.noreply.github.com"
+      - run: bash scripts/install-harnesses.sh
+      - run: gh issue edit "$ISSUE_NUMBER" --remove-label "agent:rearch" || true
+      - run: git checkout "arch/${ISSUE_NUMBER}-$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50)"
+      - run: bash scripts/pipeline.sh rearch
+
+  decompose:
+    if: github.event.label.name == 'agent:decompose' && (github.actor == github.repository_owner || github.actor == vars.PIPELINE_OWNER)
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PIPELINE_PAT }}
+      - run: gh issue edit "$ISSUE_NUMBER" --remove-label "agent:decompose" || true
+      - run: bash scripts/pipeline.sh decompose
+
+  spec:
+    if: github.event.label.name == 'agent:spec' && (github.actor == github.repository_owner || github.actor == vars.PIPELINE_OWNER)
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PIPELINE_PAT }}
+      - run: |
+          git config user.name "polis-agent[bot]"
+          git config user.email "polis-agent@users.noreply.github.com"
+      - run: bash scripts/install-harnesses.sh
+      - run: gh issue edit "$ISSUE_NUMBER" --remove-label "agent:spec" || true
+      - run: git checkout -b "agent/${ISSUE_NUMBER}-$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50)"
+      - run: bash scripts/pipeline.sh spec
+
+  respec:
+    if: github.event.label.name == 'agent:respec' && (github.actor == github.repository_owner || github.actor == vars.PIPELINE_OWNER)
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PIPELINE_PAT }}
+      - run: |
+          git config user.name "polis-agent[bot]"
+          git config user.email "polis-agent@users.noreply.github.com"
+      - run: bash scripts/install-harnesses.sh
+      - run: gh issue edit "$ISSUE_NUMBER" --remove-label "agent:respec" || true
+      - run: git checkout "agent/${ISSUE_NUMBER}-$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50)"
+      - run: bash scripts/pipeline.sh respec
+
+  code:
+    if: github.event.label.name == 'agent:code' && (github.actor == github.repository_owner || github.actor == vars.PIPELINE_OWNER)
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PIPELINE_PAT }}
+      - run: |
+          git config user.name "polis-agent[bot]"
+          git config user.email "polis-agent@users.noreply.github.com"
+      - run: bash scripts/install-harnesses.sh
+      - run: gh issue edit "$ISSUE_NUMBER" --remove-label "agent:code" || true
+      - name: Checkout the issue branch
+        run: git checkout "agent/${ISSUE_NUMBER}-$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50)"
+      - run: bash scripts/pipeline.sh code
+      - run: bash scripts/pipeline.sh test
+      - run: bash scripts/pipeline.sh open-pr
+      - run: bash scripts/pipeline.sh review
+      - if: always()
+        run: bash scripts/pipeline.sh finalize
+      - if: failure()
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --add-label "agent:failed" || true
+          gh issue comment "$ISSUE_NUMBER" --body "❌ Agent pipeline failed. See the Actions run."
+
+  fix:
+    if: github.event.label.name == 'agent:fix' && (github.actor == github.repository_owner || github.actor == vars.PIPELINE_OWNER)
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PIPELINE_PAT }}
+      - run: |
+          git config user.name "polis-agent[bot]"
+          git config user.email "polis-agent@users.noreply.github.com"
+      - run: bash scripts/install-harnesses.sh
+      - run: gh issue edit "$ISSUE_NUMBER" --remove-label "agent:fix" || true
+      - run: git checkout "agent/${ISSUE_NUMBER}-$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50)"
+      - run: bash scripts/pipeline.sh human-fix
+
+  code-review:
+    if: startsWith(github.event.label.name, 'agent:code_review') && (github.actor == github.repository_owner || github.actor == vars.PIPELINE_OWNER)
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, token: "${{ secrets.PIPELINE_PAT }}" }
+      - run: |
+          git config user.name "polis-agent[bot]"
+          git config user.email "polis-agent@users.noreply.github.com"
+      - run: bash scripts/install-harnesses.sh
+      - run: gh issue edit "$ISSUE_NUMBER" --remove-label "$LABEL_NAME" || true
+      - run: git checkout "agent/${ISSUE_NUMBER}-$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50)"
+      - run: bash scripts/pipeline.sh code-review
+
+  spec-review:
+    if: startsWith(github.event.label.name, 'agent:spec_review') && (github.actor == github.repository_owner || github.actor == vars.PIPELINE_OWNER)
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, token: "${{ secrets.PIPELINE_PAT }}" }
+      - run: |
+          git config user.name "polis-agent[bot]"
+          git config user.email "polis-agent@users.noreply.github.com"
+      - run: bash scripts/install-harnesses.sh
+      - run: gh issue edit "$ISSUE_NUMBER" --remove-label "$LABEL_NAME" || true
+      - run: git checkout "agent/${ISSUE_NUMBER}-$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50)"
+      - run: bash scripts/pipeline.sh spec-review
+
+  arch-review:
+    if: startsWith(github.event.label.name, 'agent:arch_review') && (github.actor == github.repository_owner || github.actor == vars.PIPELINE_OWNER)
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, token: "${{ secrets.PIPELINE_PAT }}" }
+      - run: |
+          git config user.name "polis-agent[bot]"
+          git config user.email "polis-agent@users.noreply.github.com"
+      - run: bash scripts/install-harnesses.sh
+      - run: gh issue edit "$ISSUE_NUMBER" --remove-label "$LABEL_NAME" || true
+      - run: git checkout "arch/${ISSUE_NUMBER}-$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50)"
+      - run: bash scripts/pipeline.sh arch-review

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,27 @@
+name: Bootstrap Labels
+on:
+  workflow_dispatch:
+  issues:
+    types: [opened]
+  push:
+    branches: [main]
+    paths: [scripts/bootstrap-labels.sh, .github/workflows/bootstrap.yml]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install yq (for config-driven labels)
+        run: |
+          if [[ -f polis.yml ]]; then
+            command -v yq >/dev/null || { sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64; sudo chmod +x /usr/local/bin/yq; }
+          fi
+      - name: Create pipeline labels
+        run: bash scripts/bootstrap-labels.sh

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ README_tmp.html
 
 # pip-installed in-place artifacts
 crates/permit0-py/dist/
+
+# Polis
+.tooling/

--- a/polis.yml
+++ b/polis.yml
@@ -1,0 +1,44 @@
+# Polis pipeline configuration.
+# Backends in use: claude (default) + codex (writes code, secondary reviewer).
+# Only references secrets that are set: CLAUDE_CODE_OAUTH_TOKEN, CODEX_AUTH.
+
+backends:
+  claude:
+    harness: claude
+  codex-gpt:
+    harness: codex
+    model: gpt-5-codex
+
+defaults:
+  backend: claude
+
+roles:
+  architect: { backend: claude }
+  spec:      { backend: claude }
+  code:      { backend: codex-gpt }
+  fix:       { backend: claude }
+
+review:
+  max_rounds: 3
+  reviewers:
+    - { persona: reviewer-correctness, backend: claude }
+    - { persona: reviewer-design,      backend: codex-gpt }
+
+# Auto-detect stack (Rust) and inject matching skills into agent prompts.
+skills:
+  auto: true
+
+# Human gates: a human applies the next label at each stage and merges the final PR.
+pipeline:
+  mode: human
+
+# Review profiles triggered via label suffix, e.g. agent:code_review:thorough.
+# Only reference configured backends (claude, codex-gpt).
+review_profiles:
+  quick:
+    mode: comment
+    reviewers: [ { backend: claude } ]
+  thorough:
+    mode: iterate
+    max_rounds: 3
+    reviewers: [ { backend: claude }, { backend: codex-gpt } ]

--- a/polis.yml.example
+++ b/polis.yml.example
@@ -1,0 +1,78 @@
+# Polis pipeline configuration — copy to `polis.yml` to customize.
+# With NO polis.yml, the pipeline runs claude everywhere, 3 review rounds, and the
+# reviewer-correctness + reviewer-design reviewers (identical to the pre-config default).
+
+# Named backends: harness + optional model + optional endpoint/credential.
+backends:
+  claude:                          # built-in; listed here only to set a model
+    harness: claude                # claude | codex | aider
+    model: claude-opus-4-8         # optional; omit to use the harness default
+  codex-gpt:
+    harness: codex
+    model: gpt-5-codex
+  deepseek:
+    harness: aider                 # aider = universal (litellm): DeepSeek, Ollama, etc.
+    model: deepseek/deepseek-chat
+    api_key_env: DEEPSEEK_API_KEY  # add the secret in repo Settings, and a matching
+                                   # env line in .github/workflows/agent-pipeline.yml
+  local-qwen:
+    harness: aider
+    model: ollama/qwen2.5-coder
+    base_url: http://localhost:11434   # only reachable with a self-hosted runner (feature #1)
+
+# Global default backend, then per-role overrides.
+defaults:
+  backend: claude
+roles:
+  architect: { backend: claude }
+  spec:      { backend: claude }
+  code:      { backend: codex-gpt }
+  fix:       { backend: claude }
+
+# Review loop: number of rounds + an arbitrary list of independently-backed reviewers.
+review:
+  max_rounds: 3
+  reviewers:
+    - { persona: reviewer-correctness, backend: claude }
+    - { persona: reviewer-design,      backend: deepseek }
+
+# Skills to inject into agent system prompts (optional).
+# Each entry is a sub-directory under skills/ that contains a SKILL.md file.
+# For claude: skill content is appended via --append-system-prompt.
+# For codex/aider: skill content is prepended to the task prompt.
+#
+# Option A — auto-detect (recommended for new projects):
+#   Set auto: true and run install-harnesses.sh. It will call scripts/detect-skills.sh,
+#   fingerprint the repo (CMakeLists.txt → C++, go.mod → Go, Cargo.toml → Rust, etc.),
+#   and download the relevant SKILL.md files from everything-claude-code into skills/.
+#   All downloaded skills are then available to every role automatically.
+skills:
+  auto: true               # detect stack + download from everything-claude-code on job start
+
+# Option B — explicit list (for fine-grained control):
+# skills:
+#   global: [drive]          # skills/drive/SKILL.md — available to all roles
+#   roles:
+#     code: [drive, docs]    # code role also gets the docs skill
+
+# Pipeline mode (optional). Default is "human" — a human must add the next label at
+# each gate (spec→code, arch→decompose) and merge the final PR.
+# Set to "auto" to skip all human gates: the pipeline applies agent:code / agent:decompose
+# itself after each stage, and auto-merges the PR when reviews converge and tests pass.
+# If tests fail or reviews don't converge, it still falls back to needs-human-review.
+pipeline:
+  mode: human   # human (default) | auto
+
+# Review modes & named profiles (optional). The default code review is the `review:`
+# block above; `review.mode` is `iterate` (revise+re-review) unless set to `comment`.
+# Trigger a profile or a single backend with a label suffix, e.g.
+#   agent:code_review:thorough   agent:spec_review:codex   agent:arch_review
+# bootstrap-labels.sh creates one label per configured backend and per valid profile.
+review_profiles:
+  quick:                         # post comments and stop
+    mode: comment
+    reviewers: [ { backend: claude } ]
+  thorough:                      # revise + re-review, two backends
+    mode: iterate
+    max_rounds: 3
+    reviewers: [ { backend: codex-gpt }, { backend: deepseek } ]

--- a/scripts/bootstrap-labels.sh
+++ b/scripts/bootstrap-labels.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Idempotently create every label the agent pipeline needs.
+# Safe to re-run; --force updates existing labels. Requires gh auth + issues:write.
+set -euo pipefail
+
+label() { gh label create "$1" --color "$2" --description "$3" --force; }
+
+# Trigger labels (human-applied)
+label "agent:arch"       "5319E7" "Planning: write architecture doc"
+label "agent:rearch"     "5319E7" "Revise architecture doc from human comments"
+label "agent:decompose"  "5319E7" "Materialize the approved breakdown into issues"
+label "agent:spec"       "1D76DB" "Execution: write spec for this issue"
+label "agent:respec"     "1D76DB" "Revise spec from human comments"
+label "agent:code"       "0E8A16" "Implement code + tests and run AI review"
+label "agent:fix"        "0E8A16" "Revise code from human comments"
+# Status labels (pipeline-applied)
+label "arch-review"        "FBCA04" "Architecture doc awaiting human review"
+label "spec-review"        "FBCA04" "Spec awaiting human review"
+label "needs-human-review" "0E8A16" "PR ready; awaiting human review"
+label "agent:cap-reached"  "D93F0B" "AI review loop hit the round cap"
+label "tests-failing"      "B60205" "Tests are failing on the PR"
+label "agent:failed"       "B60205" "Agent pipeline run errored"
+
+# --- Config-driven review labels ----------------------------------------------
+# One per artifact (bare = default recipe) + one per configured backend + one per
+# profile whose backends are all configured. Sourced from polis.yml; claude-only
+# when there is no config. yq is only invoked when polis.yml exists.
+POLIS_CONFIG="${POLIS_CONFIG:-$(cd "$(dirname "$0")/.." && pwd)/polis.yml}"
+REVIEW_COLOR="FBCA04"
+
+_backends_list() {
+  { [[ -f "$POLIS_CONFIG" ]] && yq -r '.backends // {} | keys | .[]' "$POLIS_CONFIG" 2>/dev/null
+    echo claude; } | sort -u
+}
+
+_valid_profiles() {   # profiles whose every reviewer backend is configured
+  [[ -f "$POLIS_CONFIG" ]] || return 0
+  local valid p b ok
+  valid="$(_backends_list)"
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    ok=1
+    while IFS= read -r b; do
+      [[ -z "$b" ]] && continue
+      grep -qxF "$b" <<<"$valid" || ok=0
+    done < <(yq -r ".review_profiles.\"$p\".reviewers[].backend // \"claude\"" "$POLIS_CONFIG" 2>/dev/null)
+    [[ "$ok" == 1 ]] && echo "$p"
+  done < <(yq -r '.review_profiles // {} | keys | .[]' "$POLIS_CONFIG" 2>/dev/null)
+}
+
+for artifact in code spec arch; do
+  label "agent:${artifact}_review" "$REVIEW_COLOR" "AI review of the ${artifact} (default recipe)"
+  while IFS= read -r b; do
+    [[ -z "$b" ]] && continue
+    label "agent:${artifact}_review:${b}" "$REVIEW_COLOR" "AI review of the ${artifact} on backend ${b}"
+  done < <(_backends_list)
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    label "agent:${artifact}_review:${p}" "$REVIEW_COLOR" "AI review of the ${artifact} via profile ${p}"
+  done < <(_valid_profiles)
+done

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Dependency / toolchain setup. Runs BEFORE scripts/test.sh in CI and the pipeline.
+# Auto-seeded by Polis onboarding from the detected stack — edit to match your project,
+# or apply agent:fix and let the agent refine it.
+set -euo pipefail
+cargo build

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Deployment hook. Runs after a PR merges to main.
+# Auto-seeded by Polis onboarding from the detected stack — edit to match your project,
+# or apply agent:fix and let the agent refine it.
+set -euo pipefail
+echo 'scripts/deploy.sh: no command configured yet'
+exit 0

--- a/scripts/detect-skills.sh
+++ b/scripts/detect-skills.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Detect the tech stack of a project and emit matching skill names (one per line, sorted).
+# Reads files in REPO_ROOT (default: repo containing this script).
+# Skills sourced from: https://github.com/affaan-m/everything-claude-code
+set -uo pipefail
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+R="$REPO_ROOT"
+
+_emit() { printf '%s\n' "$@"; }
+
+_has_file() {  # true if any of the named files exist directly under REPO_ROOT
+  local f; for f in "$@"; do [[ -f "$R/$f" ]] && return 0; done; return 1
+}
+
+_find_ext() {  # true if any files with the given extension exist (up to depth 4, no hidden/node_modules)
+  find "$R" -maxdepth 4 -name "*.$1" \
+    -not -path "*/\.*" -not -path "*/node_modules/*" -not -path "*/vendor/*" 2>/dev/null \
+    | grep -q .
+}
+
+# --- C++ ---
+if _find_ext cpp || _find_ext cc || _find_ext cxx || _has_file CMakeLists.txt; then
+  _emit cpp-coding-standards cpp-testing
+fi
+
+# --- Python ---
+if _has_file requirements.txt pyproject.toml setup.py Pipfile; then
+  _emit python-patterns python-testing
+  # Django
+  if _has_file manage.py || grep -ql "django" "$R/requirements.txt" "$R/pyproject.toml" 2>/dev/null; then
+    _emit django-patterns django-tdd
+  fi
+fi
+
+# --- Go ---
+if _has_file go.mod; then
+  _emit golang-patterns golang-testing
+fi
+
+# --- Rust ---
+if _has_file Cargo.toml; then
+  _emit rust-patterns rust-testing
+fi
+
+# --- TypeScript / JavaScript ---
+if _has_file tsconfig.json tsconfig.base.json \
+    || ( _has_file package.json && grep -q '"typescript"' "$R/package.json" 2>/dev/null ); then
+  _emit frontend-patterns
+  # Next.js
+  if _has_file next.config.js next.config.ts next.config.mjs; then
+    _emit nextjs-turbopack
+  fi
+fi
+
+# --- Java / Spring Boot ---
+if _has_file pom.xml \
+    || find "$R" -maxdepth 3 -name "build.gradle" -not -path "*/\.*" 2>/dev/null | grep -q .; then
+  _emit java-coding-standards
+  if grep -ql "spring" "$R/pom.xml" 2>/dev/null \
+      || find "$R" -maxdepth 3 -name "build.gradle" -not -path "*/\.*" 2>/dev/null \
+           | xargs grep -ql "spring" 2>/dev/null; then
+    _emit springboot-patterns springboot-tdd
+  fi
+fi
+
+# --- Kotlin ---
+if _find_ext kt || _find_ext kts; then
+  _emit kotlin-patterns kotlin-testing
+  # Android
+  if find "$R" -maxdepth 5 -name "AndroidManifest.xml" 2>/dev/null | grep -q .; then
+    _emit android-clean-architecture
+  fi
+fi
+
+# --- Swift ---
+if _find_ext swift; then
+  _emit swift-concurrency-6-2 swiftui-patterns
+fi
+
+# --- Laravel (PHP) ---
+if _has_file artisan \
+    || ( _has_file composer.json && grep -q '"laravel' "$R/composer.json" 2>/dev/null ); then
+  _emit laravel-patterns laravel-tdd
+fi
+
+# --- Perl ---
+if _find_ext pl || _find_ext pm; then
+  _emit perl-patterns perl-testing
+fi
+
+# --- Docker / backend ---
+if _has_file Dockerfile docker-compose.yml docker-compose.yaml; then
+  _emit docker-patterns backend-patterns
+  # PostgreSQL in compose
+  if grep -ql "postgres" "$R/docker-compose.yml" "$R/docker-compose.yaml" 2>/dev/null; then
+    _emit postgres-patterns
+  fi
+fi
+
+# --- Security (always added when any stack was detected) ---
+_emit security-review

--- a/scripts/install-harnesses.sh
+++ b/scripts/install-harnesses.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Install the agent harnesses this fork actually uses. Always installs claude.
+# When polis.yml is present, installs yq and every harness referenced under
+# backends[].harness (deduped). Idempotent; safe to run at the top of every job.
+set -euo pipefail
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# Restore Codex's ChatGPT-subscription credentials (what `codex login` writes to
+# ~/.codex/auth.json) from the CODEX_AUTH secret, so the codex harness can use a
+# subscription instead of a metered OPENAI_API_KEY — the analog of CLAUDE_CODE_OAUTH_TOKEN.
+# No-op when CODEX_AUTH is unset. Honors CODEX_HOME (codex's own location override).
+# Note: codex refreshes the token in-run only; it can't persist back to the secret,
+# so re-export auth.json into CODEX_AUTH if it expires.
+restore_codex_auth() {
+  [[ -n "${CODEX_AUTH:-}" ]] || return 0
+  local dir="${CODEX_HOME:-$HOME/.codex}"
+  mkdir -p "$dir"
+  printf '%s' "$CODEX_AUTH" > "$dir/auth.json"
+  chmod 600 "$dir/auth.json"
+  echo "install-harnesses: restored Codex auth to $dir/auth.json"
+}
+
+npm install -g @anthropic-ai/claude-code
+
+CONFIG="$REPO_ROOT/polis.yml"
+[[ -f "$CONFIG" ]] || { echo "install-harnesses: no polis.yml, claude only"; exit 0; }
+
+if ! command -v yq >/dev/null 2>&1; then
+  _os="$(uname -s)" _arch="$(uname -m)"
+  case "$_os" in
+    Linux*)
+      case "$_arch" in
+        x86_64)        _yq="yq_linux_amd64" ;;
+        aarch64|arm64) _yq="yq_linux_arm64" ;;
+        *) echo "install-harnesses: unsupported Linux arch '$_arch'; install yq manually" >&2; exit 1 ;;
+      esac
+      sudo wget -qO /usr/local/bin/yq \
+        "https://github.com/mikefarah/yq/releases/latest/download/${_yq}"
+      sudo chmod +x /usr/local/bin/yq ;;
+    Darwin*)
+      brew install yq ;;
+    *)
+      echo "install-harnesses: unsupported OS '$_os'; install yq manually (https://github.com/mikefarah/yq)" >&2
+      exit 1 ;;
+  esac
+fi
+
+# Process substitution (not a pipe) keeps the loop in the current shell, so the
+# unknown-harness `exit 1` aborts the job. No mapfile → runs on bash 3.2 too.
+while IFS= read -r h; do
+  case "$h" in
+    claude|"") : ;;  # claude already installed; "" = backend with no harness field
+    codex)  npm install -g @openai/codex; restore_codex_auth ;;
+    aider)  pipx install aider-chat || pip install --user aider-chat ;;
+    *) echo "install-harnesses: unknown harness '$h' in polis.yml" >&2; exit 1 ;;
+  esac
+done < <(yq -r '.backends[].harness' "$CONFIG" 2>/dev/null | sort -u)
+
+# Auto-skill download: when skills.auto is true in polis.yml, detect the project's tech
+# stack and fetch each skill's SKILL.md from the everything-claude-code GitHub repo.
+# Idempotent: already-present SKILL.md files are not re-downloaded.
+install_auto_skills() {
+  [[ "$(yq -r '.skills.auto // false' "$CONFIG" 2>/dev/null)" == "true" ]] || return 0
+  local skill_base="https://raw.githubusercontent.com/affaan-m/everything-claude-code/main/skills"
+  local skills_dir="$REPO_ROOT/skills"
+  local detected; detected="$(bash "$REPO_ROOT/scripts/detect-skills.sh" | sort -u)"
+  [[ -z "$detected" ]] && { echo "install-harnesses: no skills auto-detected"; return 0; }
+  while IFS= read -r skill; do
+    [[ -z "$skill" ]] && continue
+    local target="$skills_dir/$skill/SKILL.md"
+    if [[ -f "$target" ]]; then
+      echo "install-harnesses: skill $skill already present, skipping"
+      continue
+    fi
+    mkdir -p "$(dirname "$target")"
+    if curl -fsSL "$skill_base/$skill/SKILL.md" -o "$target" 2>/dev/null; then
+      echo "install-harnesses: downloaded skill $skill"
+    else
+      echo "install-harnesses: skill $skill not found in registry, skipping" >&2
+      rm -f "$target"; rmdir "$(dirname "$target")" 2>/dev/null || true
+    fi
+  done <<< "$detected"
+}
+install_auto_skills

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -1,0 +1,664 @@
+#!/usr/bin/env bash
+# Polis agent pipeline driver. Invoked one stage at a time from agent-pipeline.yml.
+# Required env: ISSUE_NUMBER ISSUE_TITLE ISSUE_BODY GH_TOKEN CLAUDE_CODE_OAUTH_TOKEN REPO_OWNER
+# Optional env: MAX_REVIEW_ROUNDS (default 3)
+# Cross-step state (CONVERGED, TESTS_PASS) is passed via $GITHUB_ENV.
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+AGENTS_DIR="${AGENTS_DIR:-$REPO_ROOT/.github/agents}"
+SKILLS_DIR="${SKILLS_DIR:-$REPO_ROOT/skills}"
+MAX_REVIEW_ROUNDS="${MAX_REVIEW_ROUNDS:-3}"
+POLIS_CONFIG="${POLIS_CONFIG:-$REPO_ROOT/polis.yml}"
+
+# --- Configuration (polis.yml) -------------------------------------------------
+# All helpers short-circuit to built-in defaults when no config file exists, so a
+# zero-config fork never invokes yq and behaves exactly like the pre-config pipeline.
+
+cfg_present() { [[ -f "$POLIS_CONFIG" ]]; }
+
+# Backend name for a role: roles.<role>.backend -> defaults.backend -> "claude".
+cfg_backend_for() {
+  local role="$1" b="claude"
+  if cfg_present; then
+    b="$(yq -r ".roles.${role}.backend // .defaults.backend // \"claude\"" "$POLIS_CONFIG")"
+    [[ -z "$b" || "$b" == "null" ]] && b="claude"
+  fi
+  echo "$b"
+}
+
+# One field of a backend definition; "" when unset. field: harness|model|base_url|api_key_env
+cfg_field() {
+  local backend="$1" field="$2" v=""
+  if cfg_present; then
+    v="$(yq -r ".backends.${backend}.${field} // \"\"" "$POLIS_CONFIG")"
+    [[ "$v" == "null" ]] && v=""
+  fi
+  # 'claude' is a built-in backend and needs no entry to resolve its harness.
+  [[ -z "$v" && "$field" == "harness" && "$backend" == "claude" ]] && v="claude"
+  echo "$v"
+}
+
+# Emit "persona.md<TAB>backend" per reviewer. Defaults to the two built-in reviewers.
+cfg_reviewers() {
+  if cfg_present && [[ "$(yq -r '.review.reviewers // "null"' "$POLIS_CONFIG")" != "null" ]]; then
+    yq -r '.review.reviewers[] | ((.persona | sub("\.md$"; "")) + ".md") + "\t" + (.backend // "claude")' "$POLIS_CONFIG"
+  else
+    printf 'reviewer-correctness.md\tclaude\n'
+    printf 'reviewer-design.md\tclaude\n'
+  fi
+}
+
+# review.max_rounds, else the env/default (preserves MAX_REVIEW_ROUNDS for zero-config).
+cfg_max_rounds() {
+  local r=""
+  cfg_present && r="$(yq -r '.review.max_rounds // ""' "$POLIS_CONFIG")"
+  if [[ -n "$r" && "$r" != "null" ]]; then
+    [[ "$r" =~ ^[0-9]+$ ]] || { echo "config error: review.max_rounds must be a non-negative integer, got '$r'" >&2; exit 1; }
+    echo "$r"; return
+  fi
+  echo "${MAX_REVIEW_ROUNDS:-3}"
+}
+
+# Configured backend names plus the built-in 'claude' (sorted, unique). No yq when zero-config.
+cfg_backends() {
+  { cfg_present && yq -r '.backends // {} | keys | .[]' "$POLIS_CONFIG" 2>/dev/null
+    echo claude; } | sort -u
+}
+
+# True iff pipeline.mode is "auto" — the pipeline self-advances through stages and
+# auto-merges when converged+passing, skipping the human label gate at each step.
+cfg_auto_proceed() {
+  cfg_present || return 1
+  [[ "$(yq -r '.pipeline.mode // "human"' "$POLIS_CONFIG" 2>/dev/null)" == "auto" ]]
+}
+
+# True iff a review profile with this name is defined.
+cfg_profile_exists() {
+  cfg_present || return 1
+  [[ "$(yq -r ".review_profiles.\"$1\" // \"null\"" "$POLIS_CONFIG" 2>/dev/null)" != "null" ]]
+}
+
+# Classify a label suffix: "" | profile | backend | none. Profile wins over backend.
+cfg_suffix_kind() {
+  local s="$1"
+  [[ -z "$s" ]] && { echo ""; return; }
+  if cfg_profile_exists "$s"; then echo profile; return; fi
+  if cfg_backends | grep -qxF "$s"; then echo backend; return; fi
+  echo none
+}
+
+# Default reviewer persona for an artifact (used when a profile omits persona).
+_artifact_default_persona() {
+  case "$1" in
+    code) echo reviewer-correctness.md ;;
+    spec) echo reviewer-spec.md ;;
+    arch) echo reviewer-arch.md ;;
+  esac
+}
+
+# Default reviewers (persona.md<TAB>backend) for an artifact, before suffix overrides.
+_default_reviewers() {
+  case "$1" in
+    code) cfg_reviewers ;;
+    spec) printf 'reviewer-spec.md\t%s\n' "$(cfg_backend_for spec_review)" ;;
+    arch) printf 'reviewer-arch.md\t%s\n' "$(cfg_backend_for arch_review)" ;;
+  esac
+}
+
+# Default review mode for an artifact: code = review.mode||iterate; spec/arch = comment.
+_default_mode() {
+  case "$1" in
+    code) local m=""; cfg_present && m="$(yq -r '.review.mode // ""' "$POLIS_CONFIG")"
+          [[ -n "$m" && "$m" != "null" ]] && echo "$m" || echo iterate ;;
+    spec|arch) echo comment ;;
+  esac
+}
+
+# Default rounds for an artifact: code = cfg_max_rounds; spec/arch = 1.
+_default_rounds() { case "$1" in code) cfg_max_rounds ;; spec|arch) echo 1 ;; esac; }
+
+# Reviewers for a review run: persona.md<TAB>backend lines.
+cfg_review_reviewers() {
+  local artifact="$1" suffix="$2"
+  case "$(cfg_suffix_kind "$suffix")" in
+    backend)
+      _default_reviewers "$artifact" | while IFS=$'\t' read -r persona _b; do
+        printf '%s\t%s\n' "$persona" "$suffix"; done ;;
+    profile)
+      local defp; defp="$(_artifact_default_persona "$artifact")"
+      yq -r ".review_profiles.\"$suffix\".reviewers[] | ((.persona // \"\") + \"|\" + (.backend // \"claude\"))" "$POLIS_CONFIG" \
+        | while IFS='|' read -r persona backend; do
+            [[ -z "$persona" ]] && persona="$defp"
+            printf '%s\t%s\n' "${persona%.md}.md" "$backend"; done ;;
+    *) _default_reviewers "$artifact" ;;   # empty or none -> defaults (caller validates 'none')
+  esac
+}
+
+# Review mode (comment|iterate) for a run; validated.
+cfg_review_mode() {
+  local artifact="$1" suffix="$2" m=""
+  if [[ "$(cfg_suffix_kind "$suffix")" == profile ]]; then
+    m="$(yq -r ".review_profiles.\"$suffix\".mode // \"\"" "$POLIS_CONFIG")"
+    [[ "$m" == "null" ]] && m=""
+  fi
+  [[ -z "$m" ]] && m="$(_default_mode "$artifact")"
+  case "$m" in comment|iterate) echo "$m" ;;
+    *) echo "config error: review mode must be 'comment' or 'iterate', got '$m'" >&2; exit 1 ;; esac
+}
+
+# Rounds for a run.
+cfg_review_rounds() {
+  local artifact="$1" suffix="$2" r=""
+  if [[ "$(cfg_suffix_kind "$suffix")" == profile ]]; then
+    r="$(yq -r ".review_profiles.\"$suffix\".max_rounds // \"\"" "$POLIS_CONFIG")"
+    if [[ -n "$r" && "$r" != "null" ]]; then
+      [[ "$r" =~ ^[0-9]+$ ]] || { echo "config error: review_profiles.$suffix.max_rounds must be an integer, got '$r'" >&2; exit 1; }
+      echo "$r"; return
+    fi
+  fi
+  _default_rounds "$artifact"
+}
+
+# When skills.auto is true, emit names of all skill directories already in SKILLS_DIR.
+# These were downloaded by install-harnesses.sh detect-skills.sh at job start.
+cfg_auto_skills() {
+  cfg_present || return 0
+  [[ "$(yq -r '.skills.auto // false' "$POLIS_CONFIG" 2>/dev/null)" == "true" ]] || return 0
+  [[ -d "$SKILLS_DIR" ]] || return 0
+  find "$SKILLS_DIR" -maxdepth 2 -name "SKILL.md" 2>/dev/null \
+    | sed "s|${SKILLS_DIR}/||; s|/SKILL.md||" | sort -u
+}
+
+# Skill names for a role: auto-detected + skills.global[] + skills.roles.<role>[], deduped.
+# Prints nothing when no skills are configured or polis.yml is absent.
+cfg_skills_for() {
+  local role="$1"
+  cfg_present || return 0
+  { cfg_auto_skills
+    yq -r '.skills.global // [] | .[]' "$POLIS_CONFIG" 2>/dev/null
+    yq -r ".skills.roles.\"${role}\" // [] | .[]" "$POLIS_CONFIG" 2>/dev/null
+  } | sort -u
+}
+
+# Build a system-prompt string from the SKILL.md files for a role's configured skills.
+# Returns the empty string when no skills are configured or no SKILL.md files exist.
+skills_system_prompt() {
+  local role="$1" out="" skill skill_file
+  while IFS= read -r skill; do
+    [[ -z "$skill" ]] && continue
+    skill_file="${SKILLS_DIR}/${skill}/SKILL.md"
+    [[ -f "$skill_file" ]] && out+="$(cat "$skill_file")"$'\n\n'
+  done < <(cfg_skills_for "$role")
+  printf '%s' "${out%$'\n\n'}"
+}
+
+slugify() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50
+}
+
+add_label()    { gh issue edit "$ISSUE_NUMBER" --add-label "$1" >/dev/null 2>&1 || true; }
+remove_label() { gh issue edit "$ISSUE_NUMBER" --remove-label "$1" >/dev/null 2>&1 || true; }
+
+# Concatenate human review/comment bodies on a PR branch into one feedback blob.
+pr_feedback() {
+  gh pr view "$1" --json comments,reviews \
+    --jq '[.reviews[]?.body, .comments[]?.body] | map(select(. != null and . != "")) | join("\n---\n")' 2>/dev/null || true
+}
+
+compute_vars() {
+  SLUG="$(slugify "$ISSUE_TITLE")"
+  BRANCH="agent/${ISSUE_NUMBER}-${SLUG}"
+  SPEC_PATH="docs/specs/${ISSUE_NUMBER}-${SLUG}.md"
+  ARCH_BRANCH="arch/${ISSUE_NUMBER}-${SLUG}"
+  ARCH_PATH="docs/arch/${SLUG}.md"
+}
+
+# --- Harness adapters ----------------------------------------------------------
+# Contract: take a persona (system prompt) + task prompt, edit files non-interactively
+# with auto-approval, do NOT touch git. Only claude has a native system-prompt flag;
+# codex/aider get the persona prepended to the prompt.
+
+harness_claude() {
+  local persona="$1" model="$2" skills_prompt="$3"; shift 3
+  local args=(-p "$*" --append-system-prompt "$(cat "$AGENTS_DIR/$persona")"
+              --dangerously-skip-permissions --output-format text)
+  [[ -n "$skills_prompt" ]] && args+=(--append-system-prompt "$skills_prompt")
+  [[ -n "$model" ]] && args+=(--model "$model")
+  claude "${args[@]}"
+}
+
+harness_codex() {
+  local persona="$1" model="$2" base_url="$3" key_env="$4" skills_prompt="$5"; shift 5
+  local prompt; prompt="$(cat "$AGENTS_DIR/$persona")"
+  [[ -n "$skills_prompt" ]] && prompt+=$'\n\n'"${skills_prompt}"
+  prompt+=$'\n\n'"$*"
+  local args=(exec)
+  [[ -n "$model" ]]    && args+=(--model "$model")
+  [[ -n "$base_url" ]] && args+=(-c "model_providers.custom.base_url=$base_url")
+  args+=(--dangerously-bypass-approvals-and-sandbox "$prompt")
+  codex "${args[@]}"
+}
+
+harness_aider() {
+  local persona="$1" model="$2" base_url="$3" key_env="$4" skills_prompt="$5"; shift 5
+  local prompt; prompt="$(cat "$AGENTS_DIR/$persona")"
+  [[ -n "$skills_prompt" ]] && prompt+=$'\n\n'"${skills_prompt}"
+  prompt+=$'\n\n'"$*"
+  local args=(--message "$prompt" --yes --no-auto-commit)
+  [[ -n "$model" ]] && args+=(--model "$model")
+  [[ -n "$base_url" ]] && export OPENAI_API_BASE="$base_url"
+  aider "${args[@]}"
+}
+
+# Dispatch a prompt to a named backend's harness.
+# skills_prompt (3rd arg) is injected into the system prompt (claude) or task prompt (codex/aider).
+dispatch_backend() {
+  local backend="$1" persona="$2" skills_prompt="$3"; shift 3
+  local harness model base_url key_env
+  harness="$(cfg_field "$backend" harness)"
+  model="$(cfg_field "$backend" model)"
+  base_url="$(cfg_field "$backend" base_url)"
+  key_env="$(cfg_field "$backend" api_key_env)"
+  case "$harness" in
+    claude) harness_claude "$persona" "$model" "$skills_prompt" "$*" ;;
+    codex)  harness_codex  "$persona" "$model" "$base_url" "$key_env" "$skills_prompt" "$*" ;;
+    aider)  harness_aider  "$persona" "$model" "$base_url" "$key_env" "$skills_prompt" "$*" ;;
+    "") echo "config error: backend '$backend' is undefined or missing 'harness'" >&2; exit 1 ;;
+    *)  echo "config error: unknown harness '$harness' for backend '$backend'" >&2; exit 1 ;;
+  esac
+}
+
+# Fail-fast: before running any agent, verify every referenced backend resolves to an
+# installed harness and that its api_key_env secret (if any) is non-empty.
+validate_backends() {
+  cfg_present || return 0
+  # Present-but-broken config is a hard error, never a silent fallback.
+  if ! yq e '.' "$POLIS_CONFIG" >/dev/null 2>"${TEST_TMP:-/tmp}/polis-yqerr"; then
+    local perr; perr="$(cat "${TEST_TMP:-/tmp}/polis-yqerr" 2>/dev/null || true)"
+    note "❌ Polis config error: polis.yml is not valid YAML — ${perr}" 2>/dev/null || true
+    printf '%s\n' "config error: polis.yml is not valid YAML: ${perr}" >&2
+    exit 1
+  fi
+  local backends backend harness key_env
+  local -a missing=()
+  backends="$(
+    { yq -r '.defaults.backend // ""'           "$POLIS_CONFIG"
+      yq -r '.roles[].backend // ""'            "$POLIS_CONFIG"
+      yq -r '.review.reviewers[].backend // ""' "$POLIS_CONFIG"
+    } 2>/dev/null | sort -u )"
+  while read -r backend; do
+    [[ -z "$backend" ]] && continue
+    harness="$(cfg_field "$backend" harness)"
+    if [[ -z "$harness" ]]; then
+      missing+=("backend '$backend' is referenced but not defined under backends:"); continue
+    fi
+    command -v "$harness" >/dev/null 2>&1 || missing+=("harness '$harness' (backend '$backend') is not installed")
+    key_env="$(cfg_field "$backend" api_key_env)"
+    [[ -n "$key_env" && -z "${!key_env:-}" ]] && missing+=("secret \$$key_env (backend '$backend') is empty")
+  done <<< "$backends"
+  if (( ${#missing[@]} )); then
+    local msg="❌ Polis config/credential problem:"$'\n'
+    local m; for m in "${missing[@]}"; do msg+="- ${m}"$'\n'; done
+    note "$msg" 2>/dev/null || true
+    printf '%s' "$msg" >&2
+    exit 1
+  fi
+}
+
+# Role-based entry point used by stages: resolve the role's backend, inject skills, then dispatch.
+run_agent() {
+  local role="$1" persona="$2"; shift 2
+  local skills_prompt; skills_prompt="$(skills_system_prompt "$role")"
+  dispatch_backend "$(cfg_backend_for "$role")" "$persona" "$skills_prompt" "$*"
+}
+
+note()    { gh issue comment "$ISSUE_NUMBER" --body "$1" >/dev/null; }
+summary() { echo -e "$1" >> "${GITHUB_STEP_SUMMARY:-/dev/stdout}"; }
+
+stage_spec() {
+  run_agent spec spec-designer.md "Read GitHub issue #${ISSUE_NUMBER}.
+Title: ${ISSUE_TITLE}
+Body:
+${ISSUE_BODY}
+
+Write an implementation spec to the file ${SPEC_PATH} (create parent dirs)."
+  git add "$SPEC_PATH"
+  git commit -m "spec: #${ISSUE_NUMBER} ${ISSUE_TITLE}" >/dev/null
+  git push -u origin "$BRANCH" --force-with-lease
+  if ! gh pr view "$BRANCH" >/dev/null 2>&1; then
+    gh pr create --draft --base main --head "$BRANCH" \
+      --title "#${ISSUE_NUMBER}: ${ISSUE_TITLE}" \
+      --body "Closes #${ISSUE_NUMBER}
+
+Spec: \`${SPEC_PATH}\` — review it, then add **agent:respec** to revise or **agent:code** to proceed."
+  fi
+  add_label spec-review
+  note "📋 **Spec drafted** → \`${SPEC_PATH}\`. Review the draft PR, then add \`agent:respec\` or \`agent:code\`."
+  if cfg_auto_proceed; then
+    add_label "agent:code"
+    note "🤖 **Auto mode** — \`agent:code\` applied. Add \`agent:respec\` to interrupt and revise the spec first."
+  fi
+}
+
+stage_respec() {
+  local feedback; feedback="$(pr_feedback "$BRANCH")"
+  run_agent spec spec-designer.md "Revise the spec at ${SPEC_PATH} for issue #${ISSUE_NUMBER}.
+Human reviewers left this feedback — address every point:
+${feedback}
+
+Rewrite ${SPEC_PATH} in place. Keep the same section structure."
+  git add "$SPEC_PATH"
+  git commit -m "spec: revise per review (#${ISSUE_NUMBER})" >/dev/null || echo "no spec changes"
+  git push --force-with-lease
+  note "📝 **Spec updated** per review. Re-review, then add \`agent:respec\` again or \`agent:code\`."
+}
+
+stage_code() {
+  run_agent code implementer.md "Implement the change described in ${SPEC_PATH} for issue #${ISSUE_NUMBER}.
+Write production code AND tests. Keep changes minimal and follow existing patterns.
+Do not edit files under .github/ or scripts/pipeline.sh."
+  git add -A
+  git commit -m "feat: #${ISSUE_NUMBER} ${ISSUE_TITLE}" >/dev/null || echo "no code changes to commit"
+  summary "## Coding\nImplementation committed on \`${BRANCH}\`"
+}
+
+# Install dependencies (build.sh) then run the project's tests (test.sh).
+# Build failure counts as a test failure so missing tools/deps surface clearly.
+run_project_tests() {
+  bash "$REPO_ROOT/scripts/build.sh" && bash "$REPO_ROOT/scripts/test.sh"
+}
+
+stage_test() {
+  if run_project_tests; then
+    echo "TESTS_PASS=true"  >> "$GITHUB_ENV"
+    summary "## Test\n✅ build + tests passed"
+  else
+    echo "TESTS_PASS=false" >> "$GITHUB_ENV"
+    summary "## Test\n❌ build or tests failed (check deps in scripts/build.sh)"
+  fi
+}
+
+stage_open_pr() {
+  git push -u origin "$BRANCH" --force-with-lease
+  if ! gh pr view "$BRANCH" >/dev/null 2>&1; then
+    gh pr create --base main --head "$BRANCH" \
+      --title "#${ISSUE_NUMBER}: ${ISSUE_TITLE}" \
+      --body "Closes #${ISSUE_NUMBER}
+
+Spec: \`${SPEC_PATH}\`
+Generated by the Polis agent pipeline."
+  fi
+  gh pr ready "$BRANCH" 2>/dev/null || true   # un-draft now that code exists
+}
+
+# Run one reviewer on a backend against a described target; echoes verdict ("approve"/"block").
+review_target() {
+  local persona="$1" backend="$2" out="$3" target_desc="$4"
+  dispatch_backend "$backend" "$persona" "" "Review ${target_desc} for issue #${ISSUE_NUMBER}.
+Submit a GitHub PR review with inline comments via gh.
+Then write ONLY the verdict JSON object to the file ${out}." >/dev/null
+  jq -r '.verdict' "$out" 2>/dev/null || echo block
+}
+
+# Generalized review engine. comment mode: reviewers post + stop. iterate mode: loop
+# review -> reviser rewrites from aggregated feedback -> (code) re-test -> push -> re-review.
+run_review_recipe() {
+  local artifact="$1" suffix="$2"
+  local mode rounds; mode="$(cfg_review_mode "$artifact" "$suffix")"; rounds="$(cfg_review_rounds "$artifact" "$suffix")"
+  [[ "$mode" == comment ]] && rounds=1
+  local -a reviewers=(); local _r
+  while IFS= read -r _r; do reviewers+=("$_r"); done < <(cfg_review_reviewers "$artifact" "$suffix")
+
+  local target_desc reviser_role reviser_persona doc_path="" run_tests=0
+  case "$artifact" in
+    code) target_desc="the diff of the current PR branch (run 'git diff origin/main...HEAD' and 'gh pr view')"
+          reviser_role=fix;       reviser_persona=fixer.md;        run_tests=1 ;;
+    spec) target_desc="the spec document at ${SPEC_PATH} on the current branch"
+          reviser_role=spec;      reviser_persona=spec-designer.md; doc_path="$SPEC_PATH" ;;
+    arch) target_desc="the architecture document at ${ARCH_PATH} on the current branch"
+          reviser_role=architect; reviser_persona=architect.md;     doc_path="$ARCH_PATH" ;;
+  esac
+
+  local round i entry persona backend verdict rsum name all_approve note_line summaries
+  for (( round=1; round<=rounds; round++ )); do
+    summary "## ${artifact} review round ${round}/${rounds} (${mode})"
+    all_approve=true; summaries=""; note_line="🔍 **${artifact} review ${round}/${rounds}** —"
+    i=0
+    for entry in "${reviewers[@]}"; do
+      IFS=$'\t' read -r persona backend <<<"$entry"
+      local out="/tmp/review-${i}.json"; rm -f "$out"
+      verdict="$(review_target "$persona" "$backend" "$out" "$target_desc")"
+      rsum="$(jq -r '.summary' "$out" 2>/dev/null || echo '')"
+      name="${persona%.md}"
+      [[ "$verdict" != approve ]] && all_approve=false
+      note_line+=" ${name}: ${verdict};"
+      summary "- ${name} (${backend}): **${verdict}** — ${rsum}"
+      summaries+="${name} review: ${rsum}"$'\n'
+      i=$((i+1))
+    done
+    note "$note_line"
+    if [[ "$all_approve" == true ]]; then echo "CONVERGED=true" >> "$GITHUB_ENV"; return 0; fi
+    if [[ "$mode" == comment ]]; then echo "CONVERGED=false" >> "$GITHUB_ENV"; return 0; fi
+    local revise_prompt
+    if [[ -n "$doc_path" ]]; then
+      revise_prompt="Reviewers requested changes to ${doc_path} for issue #${ISSUE_NUMBER}.
+${summaries}
+Rewrite ${doc_path} in place addressing every point; keep its structure."
+    else
+      revise_prompt="Reviewers requested changes on issue #${ISSUE_NUMBER}.
+${summaries}
+Apply minimal fixes addressing this feedback."
+    fi
+    run_agent "$reviser_role" "$reviser_persona" "$revise_prompt"
+    if [[ -n "$doc_path" ]]; then git add "$doc_path" || true; else git add -A || true; fi
+    local ctype; case "$artifact" in code) ctype=fix ;; *) ctype="$artifact" ;; esac  # conventional-commit type
+    git commit -m "${ctype}: address review round ${round} (#${ISSUE_NUMBER})" >/dev/null || true
+    [[ "$run_tests" == 1 ]] && { run_project_tests >/dev/null 2>&1 || true; }
+    git push --force-with-lease 2>/dev/null || true
+  done
+  echo "CONVERGED=false" >> "$GITHUB_ENV"
+}
+
+# Suffix from a review label like agent:spec_review:codex ("" for a bare label).
+review_suffix() {
+  local prefix="agent:${1}_review"
+  case "${LABEL_NAME:-}" in
+    "$prefix":*) echo "${LABEL_NAME#"$prefix":}" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Hard error if a non-empty suffix resolves to neither a backend nor a profile.
+_validate_suffix() {
+  local artifact="$1" suffix="$2"
+  [[ -z "$suffix" ]] && return 0
+  [[ "$(cfg_suffix_kind "$suffix")" == none ]] || return 0
+  note "❌ Review label suffix '${suffix}' is neither a configured backend nor a defined profile." 2>/dev/null || true
+  echo "config error: unknown review suffix '${suffix}'" >&2; exit 1
+}
+
+stage_code_review() { local s; s="$(review_suffix code)"; _validate_suffix code "$s"; run_review_recipe code "$s"; }
+stage_spec_review() { local s; s="$(review_suffix spec)"; _validate_suffix spec "$s"; run_review_recipe spec "$s"; }
+stage_arch_review() { local s; s="$(review_suffix arch)"; _validate_suffix arch "$s"; run_review_recipe arch "$s"; }
+
+# agent:code auto-review entry point (unchanged behavior).
+stage_review_loop() { run_review_recipe code ""; }
+
+stage_human_fix() {
+  local feedback; feedback="$(pr_feedback "$BRANCH")"
+  local instruction
+  if [[ -n "$feedback" ]]; then
+    instruction="Human reviewers left feedback on the PR for issue #${ISSUE_NUMBER}.
+Address every point with minimal changes:
+${feedback}"
+  else
+    # No comment was left — treat agent:fix as 'make the failing tests pass'.
+    instruction="No written feedback was left on the PR for issue #${ISSUE_NUMBER}.
+Run scripts/test.sh, diagnose why it fails, and apply minimal changes to make every test pass."
+  fi
+  run_agent fix fixer.md "$instruction"
+  git add -A
+  git commit -m "fix: address human review (#${ISSUE_NUMBER})" >/dev/null || echo "no changes"
+  git push --force-with-lease
+  if run_project_tests >/dev/null 2>&1; then
+    remove_label tests-failing
+    add_label needs-human-review
+    note "🔧 **Applied fixes** — tests now **passing** ✅. Re-review, or merge when satisfied."
+  else
+    add_label tests-failing
+    add_label needs-human-review
+    note "🔧 **Applied fixes** — tests still **failing** ❌. Add a PR comment with more detail and re-apply \`agent:fix\`, or inspect the Actions run."
+  fi
+}
+
+stage_finalize() {
+  local converged="${CONVERGED:-false}" tests_ok="${TESTS_PASS:-true}"
+  local reviews="" i=0 persona backend
+  while IFS=$'\t' read -r persona backend; do
+    reviews+="- **${persona%.md}:** $(jq -r '.summary' "/tmp/review-${i}.json" 2>/dev/null || echo n/a)"$'\n'
+    i=$((i+1))
+  done < <(cfg_reviewers)
+
+  if cfg_auto_proceed && [[ "$converged" == "true" && "$tests_ok" == "true" ]]; then
+    gh pr comment "$BRANCH" --body "$(cat <<EOF
+## 🤖 Agent pipeline summary (auto mode)
+- **Status:** converged ✅
+- **Tests:** passing
+- **Spec:** \`${SPEC_PATH}\`
+
+### Final reviews
+${reviews}
+Auto-merging — all checks passed.
+EOF
+)" || true
+    gh pr merge "$BRANCH" --squash --delete-branch 2>/dev/null || true
+    note "✅ **Auto-merged** — all reviewers approved and tests passing."
+    return 0
+  fi
+
+  local labels="needs-human-review"
+  [[ "$converged" == "false" ]] && labels="${labels},agent:cap-reached"
+  [[ "$tests_ok"  == "false" ]] && labels="${labels},tests-failing"
+  gh pr edit "$BRANCH" --add-label "$labels" || true
+  gh pr edit "$BRANCH" --add-reviewer "$REPO_OWNER" 2>/dev/null || true
+  gh pr comment "$BRANCH" --body "$(cat <<EOF
+## 🤖 Agent pipeline summary
+- **Status:** $([[ "$converged" == "true" ]] && echo "converged ✅" || echo "hit round cap ⚠️")
+- **Tests:** $([[ "$tests_ok" == "true" ]] && echo "passing" || echo "failing ❌")
+- **Spec:** \`${SPEC_PATH}\`
+
+### Final reviews
+${reviews}
+Ready for human review.
+EOF
+)" || true
+  note "✅ **Ready for human review** — PR labeled \`needs-human-review\`."
+}
+
+stage_arch() {
+  run_agent architect architect.md "Read GitHub issue #${ISSUE_NUMBER} (the product idea).
+Title: ${ISSUE_TITLE}
+Body:
+${ISSUE_BODY}
+
+Write an architecture document to ${ARCH_PATH} (create parent dirs). It MUST end with a
+'## Work breakdown' section using this exact format so it can be parsed:
+  - Phase 1: <phase name>
+    - <issue title>
+    - <issue title>
+  - Phase 2: <phase name>
+    - <issue title>"
+  git add "$ARCH_PATH"
+  git commit -m "arch: #${ISSUE_NUMBER} ${ISSUE_TITLE}" >/dev/null
+  git push -u origin "$ARCH_BRANCH" --force-with-lease
+  if ! gh pr view "$ARCH_BRANCH" >/dev/null 2>&1; then
+    gh pr create --draft --base main --head "$ARCH_BRANCH" \
+      --title "arch: #${ISSUE_NUMBER} ${ISSUE_TITLE}" \
+      --body "Architecture for #${ISSUE_NUMBER}.
+Review \`${ARCH_PATH}\`, then add **agent:rearch** to revise or **agent:decompose** to create the issues."
+  fi
+  add_label arch-review
+  note "🏛️ **Architecture drafted** → \`${ARCH_PATH}\`. Review the draft PR, then add \`agent:rearch\` or \`agent:decompose\`."
+  if cfg_auto_proceed; then
+    add_label "agent:decompose"
+    note "🤖 **Auto mode** — \`agent:decompose\` applied. Add \`agent:rearch\` to interrupt and revise first."
+  fi
+}
+
+stage_rearch() {
+  local feedback; feedback="$(pr_feedback "$ARCH_BRANCH")"
+  run_agent architect architect.md "Revise the architecture document at ${ARCH_PATH} for #${ISSUE_NUMBER}.
+Human reviewers left this feedback — address every point:
+${feedback}
+
+Rewrite ${ARCH_PATH} in place. Keep the '## Work breakdown' section and its exact format."
+  git add "$ARCH_PATH"
+  git commit -m "arch: revise per review (#${ISSUE_NUMBER})" >/dev/null || echo "no arch changes"
+  git push --force-with-lease
+  note "📝 **Architecture updated** per review. Re-review, then add \`agent:rearch\` again or \`agent:decompose\`."
+}
+
+# Emit "PHASE<TAB>ISSUE_TITLE" for each issue under '## Work breakdown'.
+parse_breakdown() {
+  awk '
+    /^## Work breakdown/ {inwb=1; next}
+    inwb && /^## / {inwb=0}
+    inwb && /^[[:space:]]*-[[:space:]]*Phase[[:space:]]/ {
+      sub(/^[[:space:]]*-[[:space:]]*/, ""); phase=$0; next }
+    inwb && /^[[:space:]]+-[[:space:]]/ {
+      sub(/^[[:space:]]+-[[:space:]]*/, ""); if (phase!="") print phase "\t" $0 }
+  ' "$1"
+}
+
+stage_decompose() {
+  git fetch -q origin "$ARCH_BRANCH" && git checkout -q "$ARCH_BRANCH"
+  local phase title last_phase="" map="### Decomposed issues"
+  while IFS=$'\t' read -r phase title; do
+    [[ -z "$title" ]] && continue
+    if [[ "$phase" != "$last_phase" ]]; then
+      gh api "repos/${GITHUB_REPOSITORY:-${REPO_OWNER}/${REPO_NAME:-}}/milestones" \
+        -f title="$phase" >/dev/null 2>&1 || true
+      last_phase="$phase"; map+=$'\n'"**${phase}**"
+    fi
+    local url
+    url="$(gh issue create --title "$title" --milestone "$phase" \
+      --body "Part of the architecture for #${ISSUE_NUMBER} (${phase}).
+
+$title
+
+Add \`agent:spec\` when ready to refine this into a spec.")"
+    map+=$'\n'"- ${title} — ${url}"
+  done < <(parse_breakdown "$ARCH_PATH")
+  note "$map"
+}
+
+main() {
+  local STAGE="${1:?stage required (arch|rearch|decompose|spec|respec|code|test|open-pr|review|code-review|spec-review|arch-review|human-fix|finalize)}"
+  compute_vars
+  case "$STAGE" in
+    decompose|test|open-pr) : ;;   # no agents -> skip backend validation
+    *) validate_backends ;;
+  esac
+  case "$STAGE" in
+    arch)         stage_arch ;;
+    rearch)       stage_rearch ;;
+    decompose)    stage_decompose ;;
+    spec)         stage_spec ;;
+    respec)       stage_respec ;;
+    code)         stage_code ;;
+    test)         stage_test ;;
+    open-pr)      stage_open_pr ;;
+    review)       stage_review_loop ;;
+    code-review)  stage_code_review ;;
+    spec-review)  stage_spec_review ;;
+    arch-review)  stage_arch_review ;;
+    human-fix)    stage_human_fix ;;
+    finalize)     stage_finalize ;;
+    *) echo "unknown stage: $STAGE" >&2; exit 1 ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Project tests. The pipeline runs this to gate every PR.
+# Auto-seeded by Polis onboarding from the detected stack — edit to match your project,
+# or apply agent:fix and let the agent refine it.
+set -euo pipefail
+cargo test


### PR DESCRIPTION
Adds the Polis issue-driven agent pipeline: workflows, agent personas, drive skill, and stack-detected build/test scripts (cargo build / cargo test). Existing README and CI (ci.yml) are untouched.