### PR TITLE
fix(deps): bump pyo3 0.24→0.29 to patch RUSTSEC-2026-0176/0177

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,15 +1241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,15 +1406,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -2196,37 +2178,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2234,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2246,13 +2223,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -3440,12 +3416,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/crates/permit0-py/Cargo.toml
+++ b/crates/permit0-py/Cargo.toml
@@ -12,7 +12,7 @@ name = "permit0"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 

--- a/crates/permit0-py/src/lib.rs
+++ b/crates/permit0-py/src/lib.rs
@@ -15,7 +15,7 @@ use permit0_types::{Permission, RiskScore, Tier};
 // ── Python wrapper types ──
 
 /// Permission decision: "allow", "human", or "deny".
-#[pyclass(name = "Permission", eq)]
+#[pyclass(name = "Permission", eq, from_py_object)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum PyPermission {
     Allow,
@@ -53,7 +53,7 @@ impl From<Permission> for PyPermission {
 }
 
 /// Risk tier: Minimal, Low, Medium, High, Critical.
-#[pyclass(name = "Tier", eq)]
+#[pyclass(name = "Tier", eq, from_py_object)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum PyTier {
     Minimal,
@@ -99,7 +99,7 @@ impl From<Tier> for PyTier {
 }
 
 /// Risk score output from the scoring pipeline.
-#[pyclass(name = "RiskScore")]
+#[pyclass(name = "RiskScore", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyRiskScore {
     /// Raw score 0.0–1.0.
@@ -150,7 +150,7 @@ impl From<&RiskScore> for PyRiskScore {
 }
 
 /// Normalized action — the tool-agnostic representation.
-#[pyclass(name = "NormAction")]
+#[pyclass(name = "NormAction", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyNormAction {
     /// Action type string, e.g. "payment.charge".
@@ -185,7 +185,7 @@ impl PyNormAction {
 }
 
 /// Decision result from the engine.
-#[pyclass(name = "DecisionResult")]
+#[pyclass(name = "DecisionResult", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyDecisionResult {
     /// The permission decision.
@@ -438,7 +438,7 @@ impl PyEngineBuilder {
     /// It will be called by the Rust reviewer pipeline when a MEDIUM-tier
     /// action needs LLM review. The callback should call an LLM and return
     /// the raw text response.
-    fn with_reviewer(&mut self, callback: PyObject) -> PyResult<()> {
+    fn with_reviewer(&mut self, callback: Py<PyAny>) -> PyResult<()> {
         let builder = self
             .inner
             .take()
@@ -447,7 +447,7 @@ impl PyEngineBuilder {
         // Wrap the Python callable in a Rust closure.
         // PyO3 handles re-entrant GIL acquisition on the same thread.
         let client = CallbackLlmClient::new(move |prompt: &str| {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let result = callback
                     .call1(py, (prompt,))
                     .map_err(|e| LlmError::RequestFailed(format!("Python callback error: {e}")))?;
@@ -667,7 +667,7 @@ fn json_value_to_pydict<'py>(
     let json_mod = py.import("json")?;
     let result = json_mod.call_method1("loads", (json_str,))?;
     result
-        .downcast::<PyDict>()
+        .cast::<PyDict>()
         .cloned()
         .map_err(|e| PyRuntimeError::new_err(format!("expected dict: {e}")))
 }


### PR DESCRIPTION
## What

Bumps `pyo3` from 0.24 to 0.29 in `permit0-py` to patch two advisories published 2026-06-22:

| Advisory | Issue | Fixed in |
|---|---|---|
| [RUSTSEC-2026-0176](https://rustsec.org/advisories/RUSTSEC-2026-0176) | Out-of-bounds read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators | pyo3 0.29.0 |
| [RUSTSEC-2026-0177](https://rustsec.org/advisories/RUSTSEC-2026-0177) | Missing `Sync` bound on `PyCFunction::new_closure` closures | pyo3 0.29.0 |

These started failing **Cargo Deny** and **Security Audit** on `main` once the advisories landed (the advisory DB is pulled live, so unchanged code began failing).

## Why

Both advisories affect `pyo3 >=0.24.0, <0.29.0`. `permit0-py` was pinned to 0.24, putting it in range. 0.29.0 is the first patched release.

## Changes

- `crates/permit0-py/Cargo.toml`: `pyo3` 0.24 → 0.29
- `Cargo.lock`: regenerated (pyo3 0.29.0)
- `crates/permit0-py/src/lib.rs`: adapt to the 0.29 API —
  - `Python::with_gil` → `Python::attach`
  - `Bound::downcast` → `Bound::cast`
  - `PyObject` → `Py<PyAny>`
  - opt into the now-opt-in `FromPyObject` derive via `#[pyclass(from_py_object)]` (preserves existing behavior; avoids `-D warnings` failure)

**No public Python API changes.**

## Test plan

- [x] `cargo build -p permit0-py` — clean, 0 warnings
- [x] `cargo check -p permit0-py` with `-D warnings` — passes (mirrors CI Check job)
- [x] `cargo clippy -p permit0-py --all-targets -- -D warnings` — clean
- [ ] CI: Cargo Deny + Security Audit green
- [ ] CI: Check (all OS) / Clippy / Test green

> Note: `RUSTSEC-2023-0071` (rsa) is intentionally left in the `deny.toml` ignore list — `rsa` is still in the lockfile and that ignore is a deliberate prior decision (commit c213e05).